### PR TITLE
Feature: Event Sponsor Management APIs with CRUD & Role-based Access

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,10 @@
 import { Module } from "@nestjs/common";
 import { AppController } from "./app.controller";
 import { AppService } from "./app.service";
+import { SponsorsModule } from "./sponsors/sponsors.module";
 
 @Module({
-  imports: [],
+  imports: [SponsorsModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -1,6 +1,7 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from "typeorm";
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany } from "typeorm";
 import { Ticket } from "../../tickets/entities/ticket.entity";
 import { SpecialGuest } from "../../special-guests/entities/special-guest.entity";
+import { Sponsor } from "src/sponsors/sponsor.entity";
 
 @Entity()
 export class Event {
@@ -66,6 +67,9 @@ export class Event {
 
   @Column({ nullable: true })
   instagram: string;
+
+  @ManyToMany(() => Sponsor, (sponsor) => sponsor.events)
+  sponsors: Sponsor[];
 
   // Relations - Make them optional
   @OneToMany(() => Ticket, (ticket) => ticket.event, { nullable: true })

--- a/src/sponsors/dtos/create-sponsor.dto.ts
+++ b/src/sponsors/dtos/create-sponsor.dto.ts
@@ -1,0 +1,24 @@
+import { IsNotEmpty, IsObject, IsString, IsUrl } from 'class-validator';
+
+export class CreateSponsorDto {
+  @IsString()
+  @IsNotEmpty()
+  brandImage: string;
+
+  @IsString()
+  @IsNotEmpty()
+  brandName: string;
+
+  @IsUrl()
+  brandWebsite: string;
+
+  @IsObject()
+  socialMediaLinks: {
+    facebook: string;
+    twitter: string;
+    instagram: string;
+  };
+
+  @IsNotEmpty()
+  eventId: number;
+}

--- a/src/sponsors/dtos/update-sponsor.dto.ts
+++ b/src/sponsors/dtos/update-sponsor.dto.ts
@@ -1,0 +1,14 @@
+import { IsInt, IsNotEmpty } from 'class-validator';
+import { CreateSponsorDto } from './create-sponsor.dto';
+
+/**
+ * using the patch to edit part of the data, the partialtype makes everything optional
+ */
+export class UpdateSponsorDto extends CreateSponsorDto {
+  /**
+   * a unique id of number used to edit create user dto
+   */
+  @IsInt()
+  @IsNotEmpty()
+  id: number;
+}

--- a/src/sponsors/providers/create-sponsors-provider.ts
+++ b/src/sponsors/providers/create-sponsors-provider.ts
@@ -1,0 +1,36 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Sponsor } from '../sponsor.entity';
+import { Repository } from 'typeorm';
+import { CreateSponsorDto } from '../dtos/create-sponsor.dto';
+
+/**
+ * Service provider for updating sponsors.
+ */
+@Injectable()
+export class CreateSponsorsProvider {
+  constructor(
+    @InjectRepository(Sponsor)
+    private sponsorsRepository: Repository<Sponsor>,
+  ) {}
+
+  /**
+   * Updates a sponsor by ID.
+   * 
+   * @param {number} id - The ID of the sponsor to update.
+   * @param {UpdateSponsorDto} updateSponsorDto - DTO containing updated sponsor details.
+   * @returns {Promise<Sponsor>} The updated sponsor entity.
+   * @throws {NotFoundException} If the sponsor with the given ID is not found.
+   * @throws {InternalServerErrorException} If an error occurs while updating the sponsor.
+   */
+  public async createSponsor(
+    createSponsorDto: CreateSponsorDto,
+  ): Promise<Sponsor> {
+    try {
+      const sponsor = this.sponsorsRepository.create(createSponsorDto);
+      return await this.sponsorsRepository.save(sponsor);
+    } catch (error) {
+      throw new InternalServerErrorException('Error creating sponsor');
+    }
+  }
+}

--- a/src/sponsors/providers/find-all-sponsors-provider.ts
+++ b/src/sponsors/providers/find-all-sponsors-provider.ts
@@ -1,0 +1,29 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { Sponsor } from '../sponsor.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+/**
+ * Service provider for retrieving all sponsors.
+ */
+@Injectable()
+export class FindAllSponsorsProvider {
+  constructor(
+    @InjectRepository(Sponsor)
+    private sponsorsRepository: Repository<Sponsor>,
+  ) {}
+
+  /**
+   * Retrieves all sponsors from the database.
+   * 
+   * @returns {Promise<Sponsor[]>} A list of all sponsors.
+   * @throws {InternalServerErrorException} If an error occurs while fetching sponsors.
+   */
+  async findAllSponsors(): Promise<Sponsor[]> {
+    try {
+      return await this.sponsorsRepository.find();
+    } catch (error) {
+      throw new InternalServerErrorException('Error fetching sponsors');
+    }
+  }
+}

--- a/src/sponsors/providers/find-one-sponsor-provider.ts
+++ b/src/sponsors/providers/find-one-sponsor-provider.ts
@@ -1,0 +1,36 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Sponsor } from '../sponsor.entity';
+import { Repository } from 'typeorm';
+
+/**
+ * Service provider for retrieving one sponsor.
+ */
+@Injectable()
+export class FindOneSponsorProvider {
+  constructor(
+    @InjectRepository(Sponsor)
+    private sponsorsRepository: Repository<Sponsor>,
+  ) {}
+
+  /**
+   * Retrieves one sponsor from the database.
+   * 
+   * @returns {Promise<Sponsor>} A single sponsors.
+   * @throws {InternalServerErrorException} If an error occurs while fetching sponsors.
+   */
+  async findOneSponsor(id: number): Promise<Sponsor> {
+    try {
+      const sponsor = await this.sponsorsRepository.findOne({ where: { id } });
+      if (!sponsor)
+        throw new NotFoundException(`Sponsor with ID ${id} not found`);
+      return sponsor;
+    } catch (error) {
+      throw new InternalServerErrorException('Error retrieving sponsor');
+    }
+  }
+}

--- a/src/sponsors/providers/find-sponsors-by-event-provider.ts
+++ b/src/sponsors/providers/find-sponsors-by-event-provider.ts
@@ -1,0 +1,37 @@
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Sponsor } from '../sponsor.entity';
+import { Event } from 'src/events/entities/event.entity';
+
+/**
+ * Service provider for geting sponsors by event.
+ */
+@Injectable()
+export class FindSponsorsByEventProvider {
+  constructor(
+    @InjectRepository(Sponsor)
+    private sponsorsRepository: Repository<Sponsor>,
+    @InjectRepository(Event)
+    private eventRepository: Repository<Event>,
+  ) {}
+
+  /**
+   * Retrieves sponsors based on events from the database.
+   * 
+   * @returns {Promise<Sponsor[]>} A list of sponsors for a particular event.
+   * @throws {InternalServerErrorException} If an error occurs while fetching sponsors.
+   */
+  async findByEvent(eventId: number): Promise<Sponsor[]> {
+    try {
+      return await this.sponsorsRepository
+        .createQueryBuilder('sponsor')
+        .innerJoin('sponsor.events', 'event')
+        .where('event.id = :eventId', { eventId })
+        .getMany();
+    } catch (error) {
+      throw new InternalServerErrorException('Error retrieving sponsors for event');
+    }
+  }
+  
+}

--- a/src/sponsors/providers/remove-sponsors-provider.ts
+++ b/src/sponsors/providers/remove-sponsors-provider.ts
@@ -1,0 +1,35 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Sponsor } from '../sponsor.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class RemoveSponsorsProvider {
+  constructor(
+    @InjectRepository(Sponsor)
+    private sponsorsRepository: Repository<Sponsor>,
+  ) {}
+
+  /**
+   * deletes a sponsor from the database.
+   * 
+   * @returns {Promise<Sponsor>}
+   * @throws {NotFoundException} If an error occurs while geting id of sponsor.
+   * @throws {InternalServerErrorException} If an error occurs while deleting a sponsor.
+   */
+  async removeSponsor(id: number): Promise<void> {
+    try {
+      const sponsor = await this.sponsorsRepository.findOne({ where: { id } });
+      if (!sponsor)
+        throw new NotFoundException(`Sponsor with ID ${id} not found`);
+
+      await this.sponsorsRepository.remove(sponsor);
+    } catch (error) {
+      throw new InternalServerErrorException('Error deleting sponsor');
+    }
+  }
+}

--- a/src/sponsors/providers/sponsors.service.ts
+++ b/src/sponsors/providers/sponsors.service.ts
@@ -1,0 +1,61 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { Sponsor } from '../sponsor.entity';
+import { CreateSponsorDto } from '../dtos/create-sponsor.dto';
+import { UpdateSponsorDto } from '../dtos/update-sponsor.dto';
+import { CreateSponsorsProvider } from './create-sponsors-provider';
+import { FindAllSponsorsProvider } from './find-all-sponsors-provider';
+import { FindOneSponsorProvider } from './find-one-sponsor-provider';
+import { FindSponsorsByEventProvider } from './find-sponsors-by-event-provider';
+import { UpdateSponsorsProvider } from './update-sponsors-provider';
+import { RemoveSponsorsProvider } from './remove-sponsors-provider';
+
+/**
+ * Seneral Service for all sponsors business logic.
+ */
+@Injectable()
+export class SponsorsService {
+  constructor(
+    private readonly createSponsorsProvider: CreateSponsorsProvider,
+
+    private readonly findAllSponsorsProvider: FindAllSponsorsProvider,
+
+    private readonly findOneSponsorProvider: FindOneSponsorProvider,
+
+    private readonly findSponsorsByEventProvider: FindSponsorsByEventProvider,
+    
+    private readonly updateSponsorsProvider: UpdateSponsorsProvider,
+
+    private readonly removeSponsorsProvider: RemoveSponsorsProvider,
+  ) {}
+
+  public async createSponsors(createSponsorDto: CreateSponsorDto) {
+    this.createSponsorsProvider.createSponsor(createSponsorDto);
+  }
+
+  public async findAllSponsors() {
+    this.findAllSponsorsProvider.findAllSponsors();
+  }
+
+  async findOneSponsor(id: number) {
+    this.findOneSponsorProvider.findOneSponsor(id);
+  }
+
+  async findSponsorsByEvent(eventId: number): Promise<Sponsor[]> {
+    return this.findSponsorsByEventProvider.findByEvent(eventId);
+  }
+
+  async updateSponsor(
+    id: number,
+    updateSponsorDto: UpdateSponsorDto,
+  ): Promise<Sponsor> {
+    return this.updateSponsorsProvider.updateSponsor(id, updateSponsorDto)
+  }
+
+  async removeSponsor(id: number): Promise<void> {
+    return this.removeSponsorsProvider.removeSponsor(id)
+  }
+}

--- a/src/sponsors/providers/update-sponsors-provider.ts
+++ b/src/sponsors/providers/update-sponsors-provider.ts
@@ -1,0 +1,49 @@
+import {
+  Injectable,
+  InternalServerErrorException,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Sponsor } from '../sponsor.entity';
+import { Repository } from 'typeorm';
+import { UpdateSponsorDto } from '../dtos/update-sponsor.dto';
+
+/**
+ * Service provider for updating sponsors info.
+ */
+@Injectable()
+export class UpdateSponsorsProvider {
+  constructor(
+    @InjectRepository(Sponsor)
+    private sponsorsRepository: Repository<Sponsor>,
+  ) {}
+
+  /**
+   * Updates sponsors info in the database.
+   *
+   * @returns {Promise<Sponsor>}
+   * @throws {NotFoundException} If an error occurs while geting id of sponsor.
+   * @throws {InternalServerErrorException} If an error occurs while fetching sponsors.
+   */
+  async updateSponsor(
+    id: number,
+    updateSponsorDto: UpdateSponsorDto,
+  ): Promise<Sponsor> {
+    try {
+      const sponsor = await this.sponsorsRepository.findOneBy({ id });
+      if (!sponsor)
+        throw new NotFoundException(`Sponsor with ID ${id} not found`);
+
+      sponsor.brandImage = updateSponsorDto.brandImage ?? sponsor.brandImage;
+      sponsor.brandName = updateSponsorDto.brandName ?? sponsor.brandName;
+      sponsor.brandWebsite =
+        updateSponsorDto.brandWebsite ?? sponsor.brandWebsite;
+      sponsor.socialMediaLinks =
+        updateSponsorDto.socialMediaLinks ?? sponsor.socialMediaLinks;
+
+      return await this.sponsorsRepository.save(sponsor);
+    } catch (error) {
+      throw new InternalServerErrorException('Error updating sponsor');
+    }
+  }
+}

--- a/src/sponsors/sponsor.entity.ts
+++ b/src/sponsors/sponsor.entity.ts
@@ -1,0 +1,28 @@
+import { Event } from 'src/events/entities/event.entity';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany, JoinTable } from 'typeorm';
+
+@Entity()
+export class Sponsor {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  brandImage: string;
+
+  @Column()
+  brandName: string;
+
+  @Column()
+  brandWebsite: string;
+
+  @Column('json')
+  socialMediaLinks: {
+    facebook: string;
+    twitter: string;
+    instagram: string;
+  };
+
+  @ManyToMany(() => Event, (event) => event.sponsors)
+  @JoinTable() // Defines this side as the owning side of the relation
+  events: Event[];
+}

--- a/src/sponsors/sponsors.controller.ts
+++ b/src/sponsors/sponsors.controller.ts
@@ -1,0 +1,49 @@
+import { Body, Controller, Delete, Get, Param, Post, Put, UseGuards } from '@nestjs/common';
+import { SponsorsService } from './providers/sponsors.service';
+import { CreateSponsorDto } from './dtos/create-sponsor.dto';
+import { UpdateSponsorDto } from './dtos/update-sponsor.dto';
+import { UserRole } from 'src/common/enums/users-roles.enum';
+import { RoleDecorator } from 'security/decorators/roles.decorator';
+import { JwtAuthGuard } from 'security/guards/jwt-auth.guard';
+import { RolesGuard } from 'security/guards/rolesGuard/roles.guard';
+
+@Controller('sponsors')
+export class SponsorsController {
+    constructor(private readonly sponsorsService: SponsorsService) {}
+
+  @Post()
+  @RoleDecorator(UserRole.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  async createSponsors(@Body() createSponsorDto: CreateSponsorDto) {
+    return this.sponsorsService.createSponsors(createSponsorDto)
+  }
+
+  @Get()
+  async findAllSponsors() {
+    return this.sponsorsService.findAllSponsors();
+  }
+
+  @Get(':id')
+  async findOneSponsor(@Param('id') id: number) {
+    return this.sponsorsService.findOneSponsor(id);
+  }
+
+  @Get('/events/:eventId')
+  async findSponsorsByEvent(@Param('eventId') eventId: number) {
+    return this.sponsorsService.findSponsorsByEvent(eventId);
+  }
+
+  @Put(':id')
+  @RoleDecorator(UserRole.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  async update(@Param('id') id: number, @Body() updateSponsorDto: UpdateSponsorDto) {
+    return this.sponsorsService.updateSponsor(id, updateSponsorDto);
+  }
+
+  @Delete(':id')
+  @RoleDecorator(UserRole.Admin)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  async remove(@Param('id') id: number) {
+    return this.sponsorsService.removeSponsor(id);
+  }
+}

--- a/src/sponsors/sponsors.module.ts
+++ b/src/sponsors/sponsors.module.ts
@@ -1,0 +1,27 @@
+import { Module } from '@nestjs/common';
+import { SponsorsController } from './sponsors.controller';
+import { SponsorsService } from './providers/sponsors.service';
+import { Sponsor } from './sponsor.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { CreateSponsorsProvider } from './providers/create-sponsors-provider';
+import { FindAllSponsorsProvider } from './providers/find-all-sponsors-provider';
+import { FindOneSponsorProvider } from './providers/find-one-sponsor-provider';
+import { FindSponsorsByEventProvider } from './providers/find-sponsors-by-event-provider';
+import { Event } from 'src/events/entities/event.entity';
+import { UpdateSponsorsProvider } from './providers/update-sponsors-provider';
+import { RemoveSponsorsProvider } from './providers/remove-sponsors-provider';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Sponsor, Event])],
+  controllers: [SponsorsController],
+  providers: [
+    SponsorsService,
+    CreateSponsorsProvider,
+    FindAllSponsorsProvider,
+    FindOneSponsorProvider,
+    FindSponsorsByEventProvider,
+    UpdateSponsorsProvider,
+    RemoveSponsorsProvider,
+  ],
+})
+export class SponsorsModule {}


### PR DESCRIPTION
This PR introduces a complete CRUD API for managing event sponsors, ensuring secure and efficient sponsor handling.
closes issue #20 

Features Implemented:
Create Sponsors – Allows admins to add sponsors with details (Brand Name, Image, Website, Social Links)

Api endpoints:
POST   /sponsors                             # Add a new sponsor  
GET    /sponsors                               # Get all sponsors  
GET    /sponsors/:id                          # Get a sponsor by ID  
GET    /sponsors/events/:eventId     # Get sponsors for an event  
PUT    /sponsors/:id                         # Update a sponsor  
DELETE /sponsors/:id                      # Delete a sponsor  
