### PR TITLE
feat: add collaborator endpoints

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2310,16 +2310,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.11.11",
-        "@swc/core-darwin-x64": "1.11.11",
-        "@swc/core-linux-arm-gnueabihf": "1.11.11",
-        "@swc/core-linux-arm64-gnu": "1.11.11",
-        "@swc/core-linux-arm64-musl": "1.11.11",
-        "@swc/core-linux-x64-gnu": "1.11.11",
-        "@swc/core-linux-x64-musl": "1.11.11",
-        "@swc/core-win32-arm64-msvc": "1.11.11",
-        "@swc/core-win32-ia32-msvc": "1.11.11",
-        "@swc/core-win32-x64-msvc": "1.11.11"
+        "@swc/core-darwin-arm64": "1.11.13",
+        "@swc/core-darwin-x64": "1.11.13",
+        "@swc/core-linux-arm-gnueabihf": "1.11.13",
+        "@swc/core-linux-arm64-gnu": "1.11.13",
+        "@swc/core-linux-arm64-musl": "1.11.13",
+        "@swc/core-linux-x64-gnu": "1.11.13",
+        "@swc/core-linux-x64-musl": "1.11.13",
+        "@swc/core-win32-arm64-msvc": "1.11.13",
+        "@swc/core-win32-ia32-msvc": "1.11.13",
+        "@swc/core-win32-x64-msvc": "1.11.13"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -15614,7 +15614,7 @@
       "license": "MIT",
       "dependencies": {
         "prettier-linter-helpers": "^1.0.0",
-        "synckit": "^0.9.1"
+        "synckit": "^0.10.2"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -19976,8 +19976,8 @@
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.1.0",
-        "tslib": "^2.6.2"
+        "@pkgr/core": "^0.2.0",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -20322,6 +20322,7 @@
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
         "semver": "^7.7.1",
+        "type-fest": "^4.37.0",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -20354,6 +20355,19 @@
         "esbuild": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ts-jest/node_modules/type-fest": {
+      "version": "4.38.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
+      "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ts-loader": {

--- a/src/collaborator/collaborators.controller.spec.ts
+++ b/src/collaborator/collaborators.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from "@nestjs/testing";
+import { CollaboratorsController } from "./collaborators.controller";
+import { CollaboratorsService } from "./collaborators.service";
+
+describe("CollaboratorsController", () => {
+  let controller: CollaboratorsController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CollaboratorsController],
+      providers: [CollaboratorsService],
+    }).compile();
+
+    controller = module.get<CollaboratorsController>(CollaboratorsController);
+  });
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/collaborator/collaborators.controller.ts
+++ b/src/collaborator/collaborators.controller.ts
@@ -1,0 +1,58 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Put,
+  Param,
+  Delete,
+  UseGuards,
+} from "@nestjs/common";
+import { CollaboratorsService } from "./collaborators.service";
+import { CreateCollaboratorDto } from "./dto/create-collaborator.dto";
+import { JwtAuthGuard } from "../../security/guards/jwt-auth.guard";
+import { RolesGuard } from "../../security/guards/rolesGuard/roles.guard";
+import { RoleDecorator } from "../../security/decorators/roles.decorator";
+import { UserRole } from "../common/enums/users-roles.enum";
+
+@Controller("collaborators")
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class CollaboratorsController {
+  constructor(private readonly collaboratorsService: CollaboratorsService) {}
+
+  @Post()
+  @RoleDecorator(UserRole.Admin)
+  create(@Body() createCollaboratorDto: CreateCollaboratorDto) {
+    return this.collaboratorsService.create(createCollaboratorDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.collaboratorsService.findAll();
+  }
+
+  @Get(":id")
+  findOne(@Param("id") id: string) {
+    return this.collaboratorsService.findOne(id);
+  }
+
+  @Get("event/:eventId")
+  findByEvent(@Param("eventId") eventId: string) {
+    return this.collaboratorsService.findByEvent(eventId);
+  }
+
+  @Put(":id")
+  @RoleDecorator(UserRole.Admin)
+  update(
+    @Param("id") id: string,
+    @Body() updateCollaboratorDto: Partial<CreateCollaboratorDto>,
+  ) {
+    return this.collaboratorsService.update(id, updateCollaboratorDto);
+  }
+
+  @Delete(":id")
+  @RoleDecorator(UserRole.Admin)
+  remove(@Param("id") id: string) {
+    return this.collaboratorsService.remove(id);
+  }
+}

--- a/src/collaborator/collaborators.controller.ts
+++ b/src/collaborator/collaborators.controller.ts
@@ -7,51 +7,146 @@ import {
   Param,
   Delete,
   UseGuards,
+  UseInterceptors,
+  HttpStatus,
+  UploadedFile,
+  ParseUUIDPipe,
 } from "@nestjs/common";
 import { CollaboratorsService } from "./collaborators.service";
 import { CreateCollaboratorDto } from "./dto/create-collaborator.dto";
 import { JwtAuthGuard } from "../../security/guards/jwt-auth.guard";
 import { RolesGuard } from "../../security/guards/rolesGuard/roles.guard";
-import { RoleDecorator } from "../../security/decorators/roles.decorator";
-import { UserRole } from "../common/enums/users-roles.enum";
+import { FileInterceptor } from "@nestjs/platform-express";
+import type { Express } from "express"
+import {
+  ApiBody,
+  ApiConsumes,
+  ApiOperation,
+  ApiResponse,
+  ApiTags,
+} from "@nestjs/swagger";
 
+@ApiTags("collaborators")
 @Controller("collaborators")
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class CollaboratorsController {
   constructor(private readonly collaboratorsService: CollaboratorsService) {}
 
   @Post()
-  @RoleDecorator(UserRole.Admin)
-  create(@Body() createCollaboratorDto: CreateCollaboratorDto) {
-    return this.collaboratorsService.create(createCollaboratorDto);
+  @UseInterceptors(FileInterceptor("image"))
+  @ApiOperation({ summary: "Upload a new event Collaborator" })
+  @ApiConsumes("multipart/form-data")
+  @ApiBody({
+    schema: {
+      type: "object",
+      properties: {
+        image: {
+          type: "string",
+          format: "binary",
+        },
+        name: {
+          type: "string",
+        },
+        email: {
+          type: "string",
+        },
+        eventId: {
+          type: "string",
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.CREATED,
+    description: "Collaborator created successfully",
+  })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "Invalid input" })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: "Unauthorized" })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: "Forbidden" })
+  async create(
+    @UploadedFile() file: Express.Multer.File,
+    @Body() createCollaboratorDto: CreateCollaboratorDto,
+  ) {
+    return this.collaboratorsService.create(file, createCollaboratorDto);
   }
 
   @Get()
-  findAll() {
+  @ApiOperation({ summary: "Retrieve all collaborators" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Retrieved all collaborator",
+  })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: "Unauthorized" })
+  async findAll() {
     return this.collaboratorsService.findAll();
   }
 
   @Get(":id")
-  findOne(@Param("id") id: string) {
+  @ApiOperation({ summary: "Retrieve collaborator by ID" })
+  @ApiResponse({ status: HttpStatus.OK, description: "Retrieved collaborator" })
+  @ApiResponse({
+    status: HttpStatus.NOT_FOUND,
+    description: "collaborator not found",
+  })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: "Unauthorized" })
+  async findOne(@Param("id", new ParseUUIDPipe()) id: string) {
     return this.collaboratorsService.findOne(id);
   }
 
   @Get("event/:eventId")
-  findByEvent(@Param("eventId") eventId: string) {
+  @ApiOperation({ summary: "Retrieve all collaborator for a specific event" })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: "Retrieved collaborator for event",
+  })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: "Unauthorized" })
+  async findByEvent(@Param("eventId", new ParseUUIDPipe()) eventId: string) {
     return this.collaboratorsService.findByEvent(eventId);
   }
 
   @Put(":id")
-  @RoleDecorator(UserRole.Admin)
-  update(
-    @Param("id") id: string,
+  @UseInterceptors(FileInterceptor("image"))
+  @ApiOperation({ summary: "Update a collaborator" })
+  @ApiConsumes("multipart/form-data")
+  @ApiBody({
+    schema: {
+      type: "object",
+      properties: {
+        image: {
+          type: "string",
+          format: "binary",
+        },
+        name: {
+          type: "string",
+        },
+        email: {
+          type: "string",
+        },
+        eventId: {
+          type: "string",
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: HttpStatus.OK, description: "collaborator updated successfully" })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: "Invalid input" })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: "Collaborator not found" })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: "Unauthorized" })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: "Forbidden" })
+  async update(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @UploadedFile() file: Express.Multer.File,
     @Body() updateCollaboratorDto: Partial<CreateCollaboratorDto>,
   ) {
-    return this.collaboratorsService.update(id, updateCollaboratorDto);
+    return this.collaboratorsService.update(id, file, updateCollaboratorDto);
   }
 
   @Delete(":id")
-  @RoleDecorator(UserRole.Admin)
+  @ApiOperation({ summary: 'Delete a collaborator' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'collaborator deleted successfully' })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Collaborator not found' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden' })
   remove(@Param("id") id: string) {
     return this.collaboratorsService.remove(id);
   }

--- a/src/collaborator/collaborators.module.ts
+++ b/src/collaborator/collaborators.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { CollaboratorsController } from "./collaborators.controller";
+import { CollaboratorsService } from "./collaborators.service";
+import { Collaborator } from "./entities/collaborator.entity";
+import { JwtAuthGuard } from "../../security/guards/jwt-auth.guard";
+import { RolesGuard } from "../../security/guards/rolesGuard/roles.guard";
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Collaborator])],
+  controllers: [CollaboratorsController],
+  providers: [CollaboratorsService, JwtAuthGuard, RolesGuard],
+  exports: [CollaboratorsService],
+})
+export class CollaboratorsModule {}

--- a/src/collaborator/collaborators.module.ts
+++ b/src/collaborator/collaborators.module.ts
@@ -5,9 +5,25 @@ import { CollaboratorsService } from "./collaborators.service";
 import { Collaborator } from "./entities/collaborator.entity";
 import { JwtAuthGuard } from "../../security/guards/jwt-auth.guard";
 import { RolesGuard } from "../../security/guards/rolesGuard/roles.guard";
+import { MulterModule } from "@nestjs/platform-express";
+import { diskStorage } from "multer";
+import { v4 as uuidv4 } from "uuid";
+import { extname } from "path";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Collaborator])],
+  imports: [
+    TypeOrmModule.forFeature([Collaborator]),
+    MulterModule.register({
+      storage: diskStorage({
+        destination: "./uploads/collaborators",
+        filename: (req, file, callback) => {
+          const uniqueName = uuidv4();
+          const extension = extname(file.originalname);
+          callback(null, `${uniqueName}${extension}`);
+        },
+      }),
+    }),
+  ],
   controllers: [CollaboratorsController],
   providers: [CollaboratorsService, JwtAuthGuard, RolesGuard],
   exports: [CollaboratorsService],

--- a/src/collaborator/collaborators.service.ts
+++ b/src/collaborator/collaborators.service.ts
@@ -7,32 +7,43 @@ import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { Collaborator } from "./entities/collaborator.entity";
 import { CreateCollaboratorDto } from "./dto/create-collaborator.dto";
+import * as fs from "fs";
 
 @Injectable()
 export class CollaboratorsService {
   constructor(
     @InjectRepository(Collaborator)
-    private readonly collaboratorRepository: Repository<Collaborator>,
+    private collaboratorRepository: Repository<Collaborator>,
   ) {}
 
   async create(
+    file: Express.Multer.File,
     createCollaboratorDto: CreateCollaboratorDto,
   ): Promise<Collaborator> {
-    // Check collaborator limit
-    const count = await this.collaboratorRepository.count({
-      where: { eventId: createCollaboratorDto.eventId },
-    });
-
-    if (count >= 5) {
-      throw new BadRequestException(
-        "Maximum number of collaborators (5) reached for this event",
-      );
+    if (!file) {
+      throw new BadRequestException("Collaborator image is required");
     }
 
-    const collaborator = this.collaboratorRepository.create(
-      createCollaboratorDto,
-    );
-    return this.collaboratorRepository.save(collaborator);
+    try {
+      const collaborator = new Collaborator();
+      collaborator.imageUrl = file.path;
+      collaborator.name = createCollaboratorDto.name;
+      collaborator.email = createCollaboratorDto.email;
+      collaborator.eventId = createCollaboratorDto.eventId;
+      // Check collaborator limit
+      const count = await this.collaboratorRepository.count({
+        where: { eventId: createCollaboratorDto.eventId },
+      });
+
+      if (count >= 5) {
+        throw new BadRequestException(
+          "Maximum number of collaborators (5) reached for this event",
+        );
+      }
+      return this.collaboratorRepository.save(collaborator);
+    } catch (error) {
+      throw new BadRequestException("Failed to create collaborator");
+    }
   }
 
   async findAll(): Promise<Collaborator[]> {
@@ -55,17 +66,59 @@ export class CollaboratorsService {
 
   async update(
     id: string,
+    file: Express.Multer.File,
     updateCollaboratorDto: Partial<CreateCollaboratorDto>,
   ): Promise<Collaborator> {
     const collaborator = await this.findOne(id);
-    Object.assign(collaborator, updateCollaboratorDto);
-    return this.collaboratorRepository.save(collaborator);
+    try {
+      if (collaborator.eventId !== updateCollaboratorDto.eventId) {
+        // Check collaborator limit
+        const count = await this.collaboratorRepository.count({
+          where: { eventId: updateCollaboratorDto.eventId },
+        });
+
+        if (count >= 5) {
+          throw new BadRequestException(
+            "Maximum number of collaborators (5) reached for this event",
+          );
+        }
+      } else {
+        collaborator.eventId = updateCollaboratorDto.eventId;
+      }
+
+      if (updateCollaboratorDto.name) {
+        collaborator.name = updateCollaboratorDto.name;
+      }
+
+      if (updateCollaboratorDto.email) {
+        collaborator.email = updateCollaboratorDto.email;
+      }
+
+      if (file) {
+        // update image if new image is provided
+        if (collaborator.imageUrl && fs.existsSync(collaborator.imageUrl)) {
+          fs.unlinkSync(collaborator.imageUrl);
+        }
+        collaborator.imageUrl = file.path;
+      }
+      return this.collaboratorRepository.save(collaborator);
+    } catch (error) {
+      throw new BadRequestException("Failed to update collaborator");
+    }
   }
 
   async remove(id: string): Promise<void> {
-    const result = await this.collaboratorRepository.delete(id);
-    if (!result.affected) {
-      throw new NotFoundException("Collaborator not found");
+    const collaborator = await this.findOne(id);
+    try {
+      if (collaborator.imageUrl && fs.existsSync(collaborator.imageUrl)) {
+        fs.unlinkSync(collaborator.imageUrl);
+        const result = await this.collaboratorRepository.delete(id);
+        if (!result.affected) {
+          throw new NotFoundException("Collaborator not found");
+        }
+      }
+    } catch (error) {
+      throw new BadRequestException("Failed to delete collaborator");
     }
   }
 }

--- a/src/collaborator/collaborators.service.ts
+++ b/src/collaborator/collaborators.service.ts
@@ -1,0 +1,71 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from "@nestjs/common";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import { Collaborator } from "./entities/collaborator.entity";
+import { CreateCollaboratorDto } from "./dto/create-collaborator.dto";
+
+@Injectable()
+export class CollaboratorsService {
+  constructor(
+    @InjectRepository(Collaborator)
+    private readonly collaboratorRepository: Repository<Collaborator>,
+  ) {}
+
+  async create(
+    createCollaboratorDto: CreateCollaboratorDto,
+  ): Promise<Collaborator> {
+    // Check collaborator limit
+    const count = await this.collaboratorRepository.count({
+      where: { eventId: createCollaboratorDto.eventId },
+    });
+
+    if (count >= 5) {
+      throw new BadRequestException(
+        "Maximum number of collaborators (5) reached for this event",
+      );
+    }
+
+    const collaborator = this.collaboratorRepository.create(
+      createCollaboratorDto,
+    );
+    return this.collaboratorRepository.save(collaborator);
+  }
+
+  async findAll(): Promise<Collaborator[]> {
+    return this.collaboratorRepository.find();
+  }
+
+  async findOne(id: string): Promise<Collaborator> {
+    const collaborator = await this.collaboratorRepository.findOne({
+      where: { id },
+    });
+    if (!collaborator) {
+      throw new NotFoundException("Collaborator not found");
+    }
+    return collaborator;
+  }
+
+  async findByEvent(eventId: string): Promise<Collaborator[]> {
+    return this.collaboratorRepository.find({ where: { eventId } });
+  }
+
+  async update(
+    id: string,
+    updateCollaboratorDto: Partial<CreateCollaboratorDto>,
+  ): Promise<Collaborator> {
+    const collaborator = await this.findOne(id);
+    Object.assign(collaborator, updateCollaboratorDto);
+    return this.collaboratorRepository.save(collaborator);
+  }
+
+  async remove(id: string): Promise<void> {
+    const result = await this.collaboratorRepository.delete(id);
+    if (!result.affected) {
+      throw new NotFoundException("Collaborator not found");
+    }
+  }
+}

--- a/src/collaborator/dto/create-collaborator.dto.ts
+++ b/src/collaborator/dto/create-collaborator.dto.ts
@@ -1,0 +1,16 @@
+import { IsString, IsEmail, IsUUID, IsOptional } from 'class-validator';
+
+export class CreateCollaboratorDto {
+  @IsString()
+  name: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsOptional()
+  @IsString()
+  imageUrl?: string;
+
+  @IsUUID()
+  eventId: string;
+}

--- a/src/collaborator/dto/create-collaborator.dto.ts
+++ b/src/collaborator/dto/create-collaborator.dto.ts
@@ -1,16 +1,19 @@
-import { IsString, IsEmail, IsUUID, IsOptional } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsEmail, IsUUID, IsNotEmpty } from 'class-validator';
 
 export class CreateCollaboratorDto {
+  @ApiProperty({ description: 'Name of the collaborator' })
+  @IsNotEmpty()
   @IsString()
   name: string;
 
+  @ApiProperty({ description: 'Email of the collaborator' })
+  @IsNotEmpty()
   @IsEmail()
   email: string;
 
-  @IsOptional()
-  @IsString()
-  imageUrl?: string;
-
+  @ApiProperty({ description: 'Event ID associated with the collaborator' })
+  @IsNotEmpty()
   @IsUUID()
   eventId: string;
 }

--- a/src/collaborator/entities/collaborator.entity.ts
+++ b/src/collaborator/entities/collaborator.entity.ts
@@ -1,4 +1,11 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from "typeorm";
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from "typeorm";
 import { Event } from "../../events/entities/event.entity";
 
 @Entity()
@@ -12,7 +19,7 @@ export class Collaborator {
   @Column()
   email: string;
 
-  @Column({ nullable: true })
+  @Column()
   imageUrl: string;
 
   @ManyToOne(() => Event, (event) => event.collaborators)
@@ -20,4 +27,10 @@ export class Collaborator {
 
   @Column()
   eventId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/src/collaborator/entities/collaborator.entity.ts
+++ b/src/collaborator/entities/collaborator.entity.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from "typeorm";
+import { Event } from "../../events/entities/event.entity";
+
+@Entity()
+export class Collaborator {
+  @PrimaryGeneratedColumn("uuid")
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column()
+  email: string;
+
+  @Column({ nullable: true })
+  imageUrl: string;
+
+  @ManyToOne(() => Event, (event) => event.collaborators)
+  event: Event;
+
+  @Column()
+  eventId: string;
+}

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -8,8 +8,9 @@ import {
 } from "typeorm";
 import { Ticket } from "../../tickets/entities/ticket.entity";
 import { SpecialGuest } from "../../special-guests/entities/special-guest.entity";
-import { Sponsor } from "src/sponsors/sponsor.entity";
-import { Poster } from "src/posters/entities/poster.entity";
+import { Sponsor } from "../../sponsors/sponsor.entity";
+import { Poster } from "../../posters/entities/poster.entity";
+import { Collaborator } from "../../collaborator/entities/collaborator.entity";
 
 @Entity()
 export class Event {
@@ -88,15 +89,15 @@ export class Event {
   })
   specialGuests: SpecialGuest[] | null;
 
+  @OneToMany(() => Collaborator, (collaborator) => collaborator.event)
+  collaborators: Collaborator[];
+
   @Column({ default: false })
   isArchived: boolean;
 
   @DeleteDateColumn()
   deletedAt?: Date;
 
-  @OneToMany(
-    () => Poster,
-    (poster) => poster.event,
-  )
-  posters: Poster[]
+  @OneToMany(() => Poster, (poster) => poster.event)
+  posters: Poster[];
 }


### PR DESCRIPTION
## Description
Implement endpoints to manage event collaborators.

## Summary
This PR introduces a set of RESTful APIs for managing event collaborators. It allows collaborators to be added to an event while ensuring security through role-based access control.

## Related Issues
closes #33 

## Changes Made
 - Implemented CRUD endpoints for event collaborators.
-  Added input validation using DTOs.
-  Enforced authentication and role-based authorization.
- I applied proper HTTP status codes and handled errors.
- Enforce that no more than five collaborators are added to a single event.

## How to Test

- Upload a Poster: Send a POST request to `/collaborators`  with an image, name, email, and event ID.
- Retrieve Posters:
`GET /collaborators` → Returns all event collaborators.
`GET /collaborators/{id}` → Returns a single event collaborator.
`GET /collaborators/events/{eventId}` → Returns collaborators for a specific event.
`Update a Collaborator: Send a PUT request to /collaborators/{id}` with updated details.
`Delete a collaborator: Send a DELETE request to /collaborators/{id}` as an authorized user.
- Ensures only authenticated and authorized users can perform these operations.

## Screenshots (if applicable)

<!-- Upload screenshots for UI-related changes. -->

## Checklist

- [x] My code follows the project's coding style.
- [x] I have tested these changes locally.
- [x] Documentation has been updated where necessary.
