### PR TITLE
Implement Admin Campaign APIs - Issue #10

### DIFF
--- a/admin-campaign-api-test.http
+++ b/admin-campaign-api-test.http
@@ -1,0 +1,65 @@
+### Admin Login to Get JWT Token
+# @name adminLogin
+POST http://localhost:3000/api/v1/admin/auth/login
+Content-Type: application/json
+
+{
+  "email": "admin@veritix.com",
+  "password": "AdminPass123!"
+}
+
+### Save Admin JWT Token from Login Response
+@adminToken={{adminLogin.response.body.access_token}}
+
+### Fetch App Analytics
+GET http://localhost:3000/admin/dashboard
+Authorization: Bearer {{adminToken}}
+
+### Resolve Ticket Issue
+POST http://localhost:3000/admin/tickets/resolve
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+  "ticketId": "6789abcd-1234-abcd-5678-1234abcd5678",
+  "resolution": "Issue resolved by admin",
+  "notes": "Ticket was for a duplicate purchase"
+}
+
+### Create Campaign Email
+POST http://localhost:3000/admin/create/campaign-emails
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+  "subject": "Special Summer Event Promotion",
+  "content": "Join us for our special summer events! Book your tickets now and get a 15% discount!",
+  "targetAudience": "All Users",
+  "scheduledDate": "2025-06-01T12:00:00Z"
+}
+
+### Retrieve All Campaign Emails
+GET http://localhost:3000/admin/retrieve/campaign-emails
+Authorization: Bearer {{adminToken}}
+
+### Retrieve Single Campaign Email
+# Replace the ID with a valid campaign email ID from the previous response
+GET http://localhost:3000/admin/retrieve/campaign-emails/CAMPAIGN_ID_HERE
+Authorization: Bearer {{adminToken}}
+
+### Update Campaign Email
+# Replace the ID with a valid campaign email ID
+PUT http://localhost:3000/admin/update/campaign-emails/CAMPAIGN_ID_HERE
+Authorization: Bearer {{adminToken}}
+Content-Type: application/json
+
+{
+  "subject": "Updated: Summer Event Promotion",
+  "content": "Don't miss our special summer events! Book now for a 20% early bird discount!",
+  "isSent": false
+}
+
+### Delete Campaign Email
+# Replace the ID with a valid campaign email ID
+DELETE http://localhost:3000/admin/delete/campaign-emails/CAMPAIGN_ID_HERE
+Authorization: Bearer {{adminToken}} 

--- a/src/admin/admin-campaign.controller.ts
+++ b/src/admin/admin-campaign.controller.ts
@@ -1,0 +1,190 @@
+import {
+    Controller,
+    Get,
+    Post,
+    Put,
+    Delete,
+    Body,
+    Param,
+    UseGuards,
+    HttpStatus,
+    UseFilters,
+  } from '@nestjs/common';
+  import {
+    ApiTags,
+    ApiOperation,
+    ApiResponse,
+    ApiBearerAuth,
+    ApiParam,
+    ApiBody,
+  } from '@nestjs/swagger';
+  import { JwtAuthGuard } from 'security/guards/jwt-auth.guard';
+  import { RolesGuard } from 'security/guards/rolesGuard/roles.guard';
+  import { UserRole } from 'src/common/enums/users-roles.enum';
+  import { RoleDecorator } from 'security/decorators/roles.decorator';
+  import { AllExceptionsFilter } from 'src/common/filters';
+  import { CampaignService } from './providers/campaign.service';
+  import { DashboardService } from './providers/dashboard.service';
+  import { TicketService } from './providers/ticket.service';
+  import { CreateCampaignEmailDto } from './dto/create-campaign-email.dto';
+  import { UpdateCampaignEmailDto } from './dto/update-campaign-email.dto';
+  import { ResolveTicketDto } from './dto/resolve-ticket.dto';
+  import { AnalyticsResponseDto } from './dto/analytics-response.dto';
+  import { Logger } from '@nestjs/common';
+  
+  @ApiTags('Admin Campaign')
+  @ApiBearerAuth()
+  @Controller('admin')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @RoleDecorator(UserRole.Admin)
+  @UseFilters(AllExceptionsFilter)
+  export class AdminCampaignController {
+    private readonly logger = new Logger(AdminCampaignController.name);
+  
+    constructor(
+      private readonly campaignService: CampaignService,
+      private readonly dashboardService: DashboardService,
+      private readonly ticketService: TicketService,
+    ) {}
+  
+    @Get('dashboard')
+    @ApiOperation({ summary: 'Fetch app analytics' })
+    @ApiResponse({
+      status: HttpStatus.OK,
+      description: 'Analytics data retrieved successfully',
+      type: AnalyticsResponseDto,
+    })
+    @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+    @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden resource' })
+    async getAnalytics(): Promise<AnalyticsResponseDto> {
+      try {
+        this.logger.log('GET /admin/dashboard - Retrieving analytics');
+        return await this.dashboardService.getAnalytics();
+      } catch (error) {
+        this.logger.error(`Error retrieving analytics: ${error.message}`, error.stack);
+        throw error;
+      }
+    }
+  
+    @Post('tickets/resolve')
+    @ApiOperation({ summary: 'Resolve ticket issues' })
+    @ApiBody({ type: ResolveTicketDto })
+    @ApiResponse({
+      status: HttpStatus.OK,
+      description: 'Ticket resolved successfully',
+    })
+    @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Ticket not found' })
+    @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+    @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden resource' })
+    async resolveTicket(@Body() resolveTicketDto: ResolveTicketDto) {
+      try {
+        this.logger.log(`POST /admin/tickets/resolve - Resolving ticket: ${resolveTicketDto.ticketId}`);
+        return await this.ticketService.resolveTicket(resolveTicketDto);
+      } catch (error) {
+        this.logger.error(`Error resolving ticket: ${error.message}`, error.stack);
+        throw error;
+      }
+    }
+  
+    @Post('create/campaign-emails')
+    @ApiOperation({ summary: 'Create campaign email' })
+    @ApiBody({ type: CreateCampaignEmailDto })
+    @ApiResponse({
+      status: HttpStatus.CREATED,
+      description: 'Campaign email created successfully',
+    })
+    @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+    @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden resource' })
+    async createCampaignEmail(@Body() createCampaignEmailDto: CreateCampaignEmailDto) {
+      try {
+        this.logger.log('POST /admin/create/campaign-emails - Creating campaign email');
+        return await this.campaignService.createCampaignEmail(createCampaignEmailDto);
+      } catch (error) {
+        this.logger.error(`Error creating campaign email: ${error.message}`, error.stack);
+        throw error;
+      }
+    }
+  
+    @Get('retrieve/campaign-emails')
+    @ApiOperation({ summary: 'Retrieve all campaign emails' })
+    @ApiResponse({
+      status: HttpStatus.OK,
+      description: 'Campaign emails retrieved successfully',
+    })
+    @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+    @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden resource' })
+    async getAllCampaignEmails() {
+      try {
+        this.logger.log('GET /admin/retrieve/campaign-emails - Retrieving all campaign emails');
+        return await this.campaignService.getAllCampaignEmails();
+      } catch (error) {
+        this.logger.error(`Error retrieving campaign emails: ${error.message}`, error.stack);
+        throw error;
+      }
+    }
+  
+    @Get('retrieve/campaign-emails/:id')
+    @ApiOperation({ summary: 'Retrieve a single campaign email' })
+    @ApiParam({ name: 'id', description: 'Campaign email ID' })
+    @ApiResponse({
+      status: HttpStatus.OK,
+      description: 'Campaign email retrieved successfully',
+    })
+    @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Campaign email not found' })
+    @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+    @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden resource' })
+    async getCampaignEmailById(@Param('id') id: string) {
+      try {
+        this.logger.log(`GET /admin/retrieve/campaign-emails/${id} - Retrieving campaign email`);
+        return await this.campaignService.getCampaignEmailById(id);
+      } catch (error) {
+        this.logger.error(`Error retrieving campaign email: ${error.message}`, error.stack);
+        throw error;
+      }
+    }
+  
+    @Put('update/campaign-emails/:id')
+    @ApiOperation({ summary: 'Update campaign email' })
+    @ApiParam({ name: 'id', description: 'Campaign email ID' })
+    @ApiBody({ type: UpdateCampaignEmailDto })
+    @ApiResponse({
+      status: HttpStatus.OK,
+      description: 'Campaign email updated successfully',
+    })
+    @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Campaign email not found' })
+    @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+    @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden resource' })
+    async updateCampaignEmail(
+      @Param('id') id: string,
+      @Body() updateCampaignEmailDto: UpdateCampaignEmailDto,
+    ) {
+      try {
+        this.logger.log(`PUT /admin/update/campaign-emails/${id} - Updating campaign email`);
+        return await this.campaignService.updateCampaignEmail(id, updateCampaignEmailDto);
+      } catch (error) {
+        this.logger.error(`Error updating campaign email: ${error.message}`, error.stack);
+        throw error;
+      }
+    }
+  
+    @Delete('delete/campaign-emails/:id')
+    @ApiOperation({ summary: 'Delete campaign email' })
+    @ApiParam({ name: 'id', description: 'Campaign email ID' })
+    @ApiResponse({
+      status: HttpStatus.OK,
+      description: 'Campaign email deleted successfully',
+    })
+    @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Campaign email not found' })
+    @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+    @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden resource' })
+    async deleteCampaignEmail(@Param('id') id: string) {
+      try {
+        this.logger.log(`DELETE /admin/delete/campaign-emails/${id} - Deleting campaign email`);
+        await this.campaignService.deleteCampaignEmail(id);
+        return { message: 'Campaign email deleted successfully' };
+      } catch (error) {
+        this.logger.error(`Error deleting campaign email: ${error.message}`, error.stack);
+        throw error;
+      }
+    }
+  } 

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -16,9 +16,18 @@ import { AdminController } from "./admin.controller";
 import { UsersModule } from "src/users/users.module";
 import { User } from "src/users/entities/user.entity";
 
+// New imports for campaign functionality
+import { CampaignEmail } from "./entities/campaign-email.entity";
+import { CampaignService } from "./providers/campaign.service";
+import { DashboardService } from "./providers/dashboard.service";
+import { TicketService } from "./providers/ticket.service";
+import { AdminCampaignController } from "./admin-campaign.controller";
+import { Event } from "src/events/entities/event.entity";
+import { Ticket } from "src/tickets/entities/ticket.entity";
+
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Admin, User]),
+    TypeOrmModule.forFeature([Admin, User, CampaignEmail, Event, Ticket]),
     forwardRef(() => UsersModule),
     PassportModule.register({ defaultStrategy: "admin-jwt" }),
     JwtModule.registerAsync({
@@ -32,17 +41,20 @@ import { User } from "src/users/entities/user.entity";
       inject: [ConfigService],
     }),
   ],
-  controllers: [AdminController, AdminAuthController],
+  controllers: [AdminController, AdminAuthController, AdminCampaignController],
   providers: [
     AdminService,
     AdminAuthService,
     AdminJwtStrategy,
     AdminLocalStrategy,
+    CampaignService,
+    DashboardService,
+    TicketService,
     {
       provide: HashingProvider,
       useClass: BcryptProvider,
     },
   ],
-  exports: [AdminService, AdminAuthService, HashingProvider],
+  exports: [AdminService, AdminAuthService, HashingProvider, CampaignService, DashboardService, TicketService],
 })
 export class AdminModule {}

--- a/src/admin/dto/analytics-response.dto.ts
+++ b/src/admin/dto/analytics-response.dto.ts
@@ -1,0 +1,40 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AnalyticsResponseDto {
+  @ApiProperty({ description: 'Total number of users' })
+  totalUsers: number;
+
+  @ApiProperty({ description: 'Total number of active users' })
+  activeUsers: number;
+
+  @ApiProperty({ description: 'Total number of events' })
+  totalEvents: number;
+
+  @ApiProperty({ description: 'Total number of tickets sold' })
+  totalTicketsSold: number;
+
+  @ApiProperty({ description: 'Total revenue' })
+  totalRevenue: number;
+
+  @ApiProperty({ description: 'Total number of unresolved tickets' })
+  unresolvedTickets: number;
+
+  @ApiProperty({ 
+    description: 'Recent campaign statistics',
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      totalCampaigns: { type: 'number' },
+      sentCampaigns: { type: 'number' },
+      scheduledCampaigns: { type: 'number' }
+    }
+  })
+  campaignStats: {
+    totalCampaigns: number;
+    sentCampaigns: number;
+    scheduledCampaigns: number;
+  };
+
+  @ApiProperty({ description: 'Timestamp when analytics were generated' })
+  generatedAt: Date;
+} 

--- a/src/admin/dto/create-campaign-email.dto.ts
+++ b/src/admin/dto/create-campaign-email.dto.ts
@@ -1,0 +1,29 @@
+import { IsString, IsNotEmpty, IsOptional, IsBoolean, IsDateString } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class CreateCampaignEmailDto {
+  @ApiProperty({ description: 'Email subject' })
+  @IsString()
+  @IsNotEmpty()
+  subject: string;
+
+  @ApiProperty({ description: 'Email content' })
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @ApiPropertyOptional({ description: 'Target audience for the email' })
+  @IsString()
+  @IsOptional()
+  targetAudience?: string;
+
+  @ApiPropertyOptional({ description: 'Whether the email has been sent', default: false })
+  @IsBoolean()
+  @IsOptional()
+  isSent?: boolean;
+
+  @ApiPropertyOptional({ description: 'Scheduled date for sending the email' })
+  @IsDateString()
+  @IsOptional()
+  scheduledDate?: Date;
+} 

--- a/src/admin/dto/resolve-ticket.dto.ts
+++ b/src/admin/dto/resolve-ticket.dto.ts
@@ -1,0 +1,18 @@
+import { IsString, IsNotEmpty, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class ResolveTicketDto {
+  @ApiProperty({ description: 'Ticket ID' })
+  @IsUUID()
+  @IsNotEmpty()
+  ticketId: string;
+
+  @ApiProperty({ description: 'Resolution details' })
+  @IsString()
+  @IsNotEmpty()
+  resolution: string;
+
+  @ApiPropertyOptional({ description: 'Additional notes' })
+  @IsString()
+  notes?: string;
+} 

--- a/src/admin/dto/update-campaign-email.dto.ts
+++ b/src/admin/dto/update-campaign-email.dto.ts
@@ -1,0 +1,11 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCampaignEmailDto } from './create-campaign-email.dto';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsUUID, IsOptional } from 'class-validator';
+
+export class UpdateCampaignEmailDto extends PartialType(CreateCampaignEmailDto) {
+  @ApiPropertyOptional({ description: 'Campaign email ID' })
+  @IsUUID()
+  @IsOptional()
+  id?: string;
+} 

--- a/src/admin/entities/campaign-email.entity.ts
+++ b/src/admin/entities/campaign-email.entity.ts
@@ -1,0 +1,41 @@
+import {
+    Entity,
+    PrimaryGeneratedColumn,
+    Column,
+    CreateDateColumn,
+    UpdateDateColumn,
+    DeleteDateColumn,
+  } from "typeorm";
+  
+  @Entity()
+  export class CampaignEmail {
+    @PrimaryGeneratedColumn("uuid")
+    id: string;
+  
+    @Column()
+    subject: string;
+  
+    @Column("text")
+    content: string;
+  
+    @Column({ nullable: true })
+    targetAudience: string;
+  
+    @Column({ default: false })
+    isSent: boolean;
+  
+    @Column({ nullable: true, type: "timestamp" })
+    scheduledDate: Date;
+  
+    @Column({ default: false })
+    isArchived: boolean;
+  
+    @CreateDateColumn()
+    createdAt: Date;
+  
+    @UpdateDateColumn()
+    updatedAt: Date;
+  
+    @DeleteDateColumn()
+    deletedAt?: Date;
+  } 

--- a/src/admin/providers/campaign.service.ts
+++ b/src/admin/providers/campaign.service.ts
@@ -1,0 +1,121 @@
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, Not, IsNull } from 'typeorm';
+import { CampaignEmail } from '../entities/campaign-email.entity';
+import { CreateCampaignEmailDto } from '../dto/create-campaign-email.dto';
+import { UpdateCampaignEmailDto } from '../dto/update-campaign-email.dto';
+
+@Injectable()
+export class CampaignService {
+  private readonly logger = new Logger(CampaignService.name);
+
+  constructor(
+    @InjectRepository(CampaignEmail)
+    private campaignEmailRepository: Repository<CampaignEmail>,
+  ) {}
+
+  async createCampaignEmail(createDto: CreateCampaignEmailDto): Promise<CampaignEmail> {
+    try {
+      this.logger.log('Creating new campaign email');
+      const campaignEmail = this.campaignEmailRepository.create(createDto);
+      return await this.campaignEmailRepository.save(campaignEmail);
+    } catch (error) {
+      this.logger.error(`Failed to create campaign email: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async getAllCampaignEmails(): Promise<CampaignEmail[]> {
+    try {
+      this.logger.log('Retrieving all campaign emails');
+      return await this.campaignEmailRepository.find({
+        where: { isArchived: false },
+        order: { createdAt: 'DESC' },
+      });
+    } catch (error) {
+      this.logger.error(`Failed to retrieve campaign emails: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async getCampaignEmailById(id: string): Promise<CampaignEmail> {
+    try {
+      this.logger.log(`Retrieving campaign email with ID: ${id}`);
+      const campaignEmail = await this.campaignEmailRepository.findOne({
+        where: { id, isArchived: false },
+      });
+
+      if (!campaignEmail) {
+        throw new NotFoundException(`Campaign email with ID ${id} not found`);
+      }
+
+      return campaignEmail;
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error(`Failed to retrieve campaign email: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async updateCampaignEmail(id: string, updateDto: UpdateCampaignEmailDto): Promise<CampaignEmail> {
+    try {
+      this.logger.log(`Updating campaign email with ID: ${id}`);
+      const campaignEmail = await this.getCampaignEmailById(id);
+      
+      Object.assign(campaignEmail, updateDto);
+      return await this.campaignEmailRepository.save(campaignEmail);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error(`Failed to update campaign email: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async deleteCampaignEmail(id: string): Promise<void> {
+    try {
+      this.logger.log(`Deleting campaign email with ID: ${id}`);
+      const campaignEmail = await this.getCampaignEmailById(id);
+      
+      // Soft delete
+      await this.campaignEmailRepository.softDelete(id);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error(`Failed to delete campaign email: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+
+  async getCampaignStatistics(): Promise<{
+    totalCampaigns: number;
+    sentCampaigns: number;
+    scheduledCampaigns: number;
+  }> {
+    try {
+      this.logger.log('Retrieving campaign statistics');
+      const totalCampaigns = await this.campaignEmailRepository.count({ where: { isArchived: false } });
+      const sentCampaigns = await this.campaignEmailRepository.count({ where: { isArchived: false, isSent: true } });
+      const scheduledCampaigns = await this.campaignEmailRepository.count({ 
+        where: { 
+          isArchived: false, 
+          isSent: false,
+          scheduledDate: Not(IsNull()) 
+        } 
+      });
+
+      return {
+        totalCampaigns,
+        sentCampaigns,
+        scheduledCampaigns,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to retrieve campaign statistics: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+} 

--- a/src/admin/providers/dashboard.service.ts
+++ b/src/admin/providers/dashboard.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from 'src/users/entities/user.entity';
+import { Event } from 'src/events/entities/event.entity';
+import { Ticket } from 'src/tickets/entities/ticket.entity';
+import { CampaignService } from './campaign.service';
+import { AnalyticsResponseDto } from '../dto/analytics-response.dto';
+
+@Injectable()
+export class DashboardService {
+  private readonly logger = new Logger(DashboardService.name);
+
+  constructor(
+    @InjectRepository(User)
+    private usersRepository: Repository<User>,
+    
+    @InjectRepository(Event)
+    private eventsRepository: Repository<Event>,
+    
+    @InjectRepository(Ticket)
+    private ticketsRepository: Repository<Ticket>,
+    
+    private campaignService: CampaignService
+  ) {}
+
+  async getAnalytics(): Promise<AnalyticsResponseDto> {
+    try {
+      this.logger.log('Retrieving dashboard analytics');
+      
+      // Get user statistics
+      const totalUsers = await this.usersRepository.count();
+      const activeUsers = await this.usersRepository.count({ where: { isActive: true } });
+      
+      // Get event statistics
+      const totalEvents = await this.eventsRepository.count({ where: { isArchived: false } });
+      
+      // Get ticket statistics
+      const tickets = await this.ticketsRepository.find();
+      const totalTicketsSold = tickets.length;
+      
+      // Calculate total revenue
+      const totalRevenue = tickets.reduce((sum, ticket) => sum + Number(ticket.price), 0);
+      
+      // Get unresolved tickets (assuming a ticket is unresolved if it's reserved but has no transactionId)
+      const unresolvedTickets = await this.ticketsRepository.count({
+        where: {
+          isReserved: true,
+          transactionId: null
+        }
+      });
+      
+      // Get campaign statistics
+      const campaignStats = await this.campaignService.getCampaignStatistics();
+      
+      // Return analytics data
+      return {
+        totalUsers,
+        activeUsers,
+        totalEvents,
+        totalTicketsSold,
+        totalRevenue,
+        unresolvedTickets,
+        campaignStats,
+        generatedAt: new Date()
+      };
+    } catch (error) {
+      this.logger.error(`Failed to retrieve analytics: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+} 

--- a/src/admin/providers/ticket.service.ts
+++ b/src/admin/providers/ticket.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Ticket } from 'src/tickets/entities/ticket.entity';
+import { ResolveTicketDto } from '../dto/resolve-ticket.dto';
+
+@Injectable()
+export class TicketService {
+  private readonly logger = new Logger(TicketService.name);
+
+  constructor(
+    @InjectRepository(Ticket)
+    private ticketsRepository: Repository<Ticket>,
+  ) {}
+
+  async resolveTicket(resolveTicketDto: ResolveTicketDto): Promise<Ticket> {
+    try {
+      this.logger.log(`Resolving ticket with ID: ${resolveTicketDto.ticketId}`);
+      
+      // Find the ticket
+      const ticket = await this.ticketsRepository.findOne({
+        where: { id: resolveTicketDto.ticketId }
+      });
+      
+      if (!ticket) {
+        throw new NotFoundException(`Ticket with ID ${resolveTicketDto.ticketId} not found`);
+      }
+      
+      // Process the ticket resolution
+      // For this implementation, we'll add a transactionId to mark it as resolved
+      // In a real app, this would likely involve more complex logic
+      ticket.transactionId = `RESOLVED-${Date.now()}`;
+      
+      // Add notes if provided (this would require extending the Ticket entity with a notes field)
+      // For now, we'll just use the existing fields
+      
+      // Save the updated ticket
+      return await this.ticketsRepository.save(ticket);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw error;
+      }
+      this.logger.error(`Failed to resolve ticket: ${error.message}`, error.stack);
+      throw error;
+    }
+  }
+} 


### PR DESCRIPTION
## Description

This PR implements the Admin Campaign APIs as requested in issue #10. The implementation includes endpoints for managing application analytics, ticket resolutions, and campaign emails.

## Related Issues

Closes #10

## Changes Made

- [x] Created CampaignEmail entity with necessary fields and TypeORM decorators
- [x] Implemented DTOs for campaign email operations with validation decorators
- [x] Created CampaignService for CRUD operations on campaign emails
- [x] Implemented DashboardService for analytics data retrieval
- [x] Added TicketService for ticket issue resolution
- [x] Created AdminCampaignController with all required endpoints:
  - GET /admin/dashboard
  - POST /admin/tickets/resolve
  - POST /admin/create/campaign-emails
  - GET /admin/retrieve/campaign-emails
  - GET /admin/retrieve/campaign-emails/:id
  - PUT /admin/update/campaign-emails/:id
  - DELETE /admin/delete/campaign-emails/:id
- [x] Updated AdminModule to include the new controllers, services, and repositories
- [x] Added HTTP test file for testing the new endpoints

## How to Test

1. Start the application with `npm run start:dev`
2. Use the admin-campaign-api-test.http file to test the endpoints:
   - Login as admin to get JWT token
   - Test each endpoint with appropriate data
   - Verify CRUD operations on campaign emails
   - Check analytics data retrieval
   - Test ticket resolution functionality

## Checklist

- [x] My code follows the project's coding style.
- [x] I have tested these changes locally.
- [x] Documentation has been updated with Swagger annotations.
- [x] Proper authentication and authorization is implemented.
- [x] Input validation is implemented using class-validator.