### PR TITLE
add retrieve all conference api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5230,6 +5230,7 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
       "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/babel-jest": {
@@ -5368,6 +5369,7 @@
       "version": "2.5.4",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
       "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true
     },
@@ -18085,6 +18087,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
       "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -18553,6 +18556,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -18893,6 +18897,7 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -20180,6 +20185,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -22721,6 +22727,7 @@
       "version": "2.22.0",
       "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
       "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
@@ -23102,6 +23109,7 @@
       "version": "3.1.7",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
       "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
@@ -23344,6 +23352,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
       "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "b4a": "^1.6.4"
@@ -23999,6 +24008,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/src/collaborator/collaborators.controller.spec.ts
+++ b/src/collaborator/collaborators.controller.spec.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { Collaborator } from './entities/collaborator.entity';
 import { BadRequestException, NotFoundException } from '@nestjs/common';
 import { CollaboratorService } from './collaborators.service';
+import { CollaboratorRole } from './dto/create-collaborator.dto';
 
 describe('CollaboratorService', () => {
   let service: CollaboratorService;
@@ -44,6 +45,8 @@ describe('CollaboratorService', () => {
         email: 'john@example.com',
         image: 'https://example.com/image.jpg',
         conferenceId: '123',
+        eventId: '456',
+        role: CollaboratorRole.VIEWER,
       };
       
       mockRepository.findOne.mockResolvedValue(null);
@@ -66,6 +69,8 @@ describe('CollaboratorService', () => {
         email: 'john@example.com',
         image: 'https://example.com/image.jpg',
         conferenceId: '123',
+        eventId: '456',
+        role: CollaboratorRole.VIEWER,
       };
       
       mockRepository.findOne.mockResolvedValue({ id: '1', ...createDto });
@@ -79,6 +84,8 @@ describe('CollaboratorService', () => {
         email: 'john@example.com',
         image: 'https://example.com/image.jpg',
         conferenceId: '123',
+        eventId: '456',
+        role: CollaboratorRole.VIEWER,
       };
       
       mockRepository.findOne.mockResolvedValue(null);
@@ -96,6 +103,8 @@ describe('CollaboratorService', () => {
         email: 'john@example.com',
         image: 'https://example.com/image.jpg',
         conferenceId: '123',
+        eventId: '456',
+        role: CollaboratorRole.VIEWER,
       };
       
       mockRepository.findOne.mockResolvedValue(collaborator);

--- a/src/collaborator/collaborators.controller.ts
+++ b/src/collaborator/collaborators.controller.ts
@@ -21,7 +21,6 @@ import {
   ApiQuery,
   ApiConsumes,
 } from "@nestjs/swagger";
-import { CollaboratorsService } from "./collaborators.service";
 import { CreateCollaboratorDto } from "./dto/create-collaborator.dto";
 import { UpdateCollaboratorDto } from "./dto/update-collaborator.dto";
 import { JwtAuthGuard } from "security/guards/jwt-auth.guard";
@@ -29,6 +28,7 @@ import { RolesGuard } from "security/guards/rolesGuard/roles.guard";
 import { RoleDecorator } from "security/decorators/roles.decorator";
 import { UserRole } from "src/common/enums/users-roles.enum";
 import { Collaborator } from "./entities/collaborator.entity";
+import { CollaboratorService } from "./collaborators.service";
 
 @ApiTags("Collaborators")
 @ApiBearerAuth()
@@ -36,7 +36,7 @@ import { Collaborator } from "./entities/collaborator.entity";
 @UseGuards(JwtAuthGuard, RolesGuard)
 @ApiBearerAuth()
 export class CollaboratorController {
-  constructor(private readonly collaboratorService: CollaboratorService) {}
+  constructor(private readonly collaboratorsService: CollaboratorService) {}
 
   @Post()
   @RoleDecorator(UserRole.Admin)
@@ -58,7 +58,7 @@ export class CollaboratorController {
     @UploadedFile() file: Express.Multer.File,
     @Body() createCollaboratorDto: CreateCollaboratorDto,
   ) {
-    return this.collaboratorsService.create(file, createCollaboratorDto);
+    return this.collaboratorsService.create(createCollaboratorDto, file);
   }
 
   @Get()
@@ -132,7 +132,8 @@ export class CollaboratorController {
     @UploadedFile() file: Express.Multer.File,
     @Body() updateCollaboratorDto: UpdateCollaboratorDto,
   ) {
-    return this.collaboratorsService.update(id, file, updateCollaboratorDto);
+    const updateData = { ...updateCollaboratorDto, file };
+    return this.collaboratorsService.update(id, updateData);
   }
 
   @Delete(":id")

--- a/src/collaborator/dto/create-collaborator.dto.ts
+++ b/src/collaborator/dto/create-collaborator.dto.ts
@@ -34,6 +34,14 @@ export class CreateCollaboratorDto {
   eventId: string;
 
   @ApiProperty({
+    description: 'Conference ID associated with the collaborator',
+    example: '456e4567-e89b-12d3-a456-426614174000'
+  })
+  @IsNotEmpty()
+  @IsUUID()
+  conferenceId: string;
+
+  @ApiProperty({
     description: 'Role of the collaborator for the event',
     enum: CollaboratorRole,
     example: CollaboratorRole.EVENT_MANAGER

--- a/src/collaborator/dto/update-collaborator.dto.ts
+++ b/src/collaborator/dto/update-collaborator.dto.ts
@@ -28,6 +28,14 @@ export class UpdateCollaboratorDto {
   eventId?: string;
 
   @ApiPropertyOptional({
+    description: 'Updated conference ID for the collaborator',
+    example: '456e4567-e89b-12d3-a456-426614174000'
+  })
+  @IsOptional()
+  @IsUUID()
+  conferenceId?: string;
+
+  @ApiPropertyOptional({
     description: 'Updated role of the collaborator',
     enum: CollaboratorRole,
     example: CollaboratorRole.EVENT_MANAGER

--- a/src/collaborator/entities/collaborator.entity.ts
+++ b/src/collaborator/entities/collaborator.entity.ts
@@ -9,6 +9,7 @@ import {
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { Event } from "../../events/entities/event.entity";
 import { CollaboratorRole } from "../dto/create-collaborator.dto";
+import { Conference } from "src/conference/entities/conference.entity";
 
 @Entity()
 export class Collaborator {
@@ -79,6 +80,20 @@ export class Collaborator {
   })
   @Column({ default: true })
   isActive: boolean;
+  
+  @ApiProperty({
+    description: "Conference this collaborator is associated with",
+    type: () => Conference,
+  })
+  @ManyToOne(() => Conference, (conference) => conference.collaborators)
+  conference: Conference;
+
+  @ApiProperty({
+    description: "ID of the conference this collaborator is associated with",
+    example: "456e4567-e89b-12d3-a456-426614174000",
+  })
+  @Column({ name: "conference_id" })
+  conferenceId: string;
 
   @ApiProperty({
     description: "Date when the collaborator was added",

--- a/src/conference-sponsors/conference-sponsors.service.spec.ts
+++ b/src/conference-sponsors/conference-sponsors.service.spec.ts
@@ -66,7 +66,7 @@ describe('ConferenceSponsorsService', () => {
     sponsors: [],
     createdAt: new Date(),
     updatedAt: new Date(),
-  } as Conference;
+  } as unknown as  Conference;
 
   const mockConferenceSponsor: ConferenceSponsor = {
     id: 'sponsor-1',

--- a/src/conference/controllers/conference.controller.spec.ts
+++ b/src/conference/controllers/conference.controller.spec.ts
@@ -1,36 +1,55 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { CreateConferenceDto, UpdateConferenceDto } from '../dto';
-import { Conference } from '../entities/conference.entity';
-import { ConferenceController } from './conference.controller';
-import { ConferenceService } from '../providers/conference.service';
-import { JwtAuthGuard } from 'security/guards/jwt-auth.guard';
-import { RolesGuard } from 'security/guards/rolesGuard/roles.guard';
+import { Test, TestingModule } from "@nestjs/testing";
+import { CreateConferenceDto, UpdateConferenceDto } from "../dto";
+import {
+  Conference,
+  ConferenceVisibility,
+} from "../entities/conference.entity";
+import { ConferenceController } from "./conference.controller";
+import { ConferenceService } from "../providers/conference.service";
+import { JwtAuthGuard } from "security/guards/jwt-auth.guard";
+import { RolesGuard } from "security/guards/rolesGuard/roles.guard";
+import { UserRole } from "src/common/enums/users-roles.enum";
+import { User } from "src/users/entities/user.entity";
 
-const mockConference: Conference = {
-  id: 'test-id',
-  conferenceName: 'Test Conference',
-  conferenceCategory: 'Technology',
+const mockUser: User = {
+  id: "user-1",
+  email: "test@example.com",
+  password: "hashedPassword",
+  firstName: "Test",
+  lastName: "User",
+  role: UserRole.Organizer,
+  conferences: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as unknown as User;
+
+const mockConference = {
+  id: "test-id",
+  conferenceName: "Test Conference",
+  conferenceCategory: "Technology",
   conferenceDate: new Date(),
   conferenceClosingDate: new Date(),
-  conferenceDescription: 'A test conference',
-  conferenceImage: 'https://example.com/image.jpg',
-  country: 'Nigeria',
-  state: 'Lagos',
-  street: '123 Main St',
-  localGovernment: 'Ikeja',
-  direction: 'Near the mall',
+  conferenceDescription: "A test conference",
+  conferenceImage: "https://example.com/image.jpg",
+  country: "Nigeria",
+  state: "Lagos",
+  street: "123 Main St",
+  localGovernment: "Ikeja",
+  direction: "Near the mall",
   hideLocation: false,
   comingSoon: false,
   transactionCharge: false,
-  bankName: 'Test Bank',
-  bankAccountNumber: '1234567890',
-  accountName: 'Test Account',
-  facebook: 'facebook.com/test',
-  twitter: 'twitter.com/test',
-  instagram: 'instagram.com/test',
+  bankName: "Test Bank",
+  bankAccountNumber: "1234567890",
+  accountName: "Test Account",
+  facebook: "facebook.com/test",
+  twitter: "twitter.com/test",
+  instagram: "instagram.com/test",
   createdAt: new Date(),
   updatedAt: new Date(),
-};
+  visibility: ConferenceVisibility.PUBLIC, // Added missing property
+  organizer: mockUser,
+} as unknown as Conference;
 
 const mockConferenceService = {
   create: jest.fn().mockResolvedValue(mockConference),
@@ -43,7 +62,7 @@ const mockConferenceService = {
 const mockJwtAuthGuard = { canActivate: jest.fn().mockReturnValue(true) };
 const mockRolesGuard = { canActivate: jest.fn().mockReturnValue(true) };
 
-describe('ConferenceController', () => {
+describe("ConferenceController", () => {
   let controller: ConferenceController;
   let service: ConferenceService;
 
@@ -67,35 +86,35 @@ describe('ConferenceController', () => {
     service = module.get<ConferenceService>(ConferenceService);
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(controller).toBeDefined();
   });
 
-  describe('create', () => {
-    it('should create a conference', async () => {
+  describe("create", () => {
+    it("should create a conference", async () => {
       const createDto: CreateConferenceDto = {
-        conferenceName: 'Test Conference',
-        conferenceCategory: 'Technology',
+        conferenceName: "Test Conference",
+        conferenceCategory: "Technology",
         conferenceDate: new Date(),
         conferenceClosingDate: new Date(),
-        conferenceDescription: 'A test conference',
-        conferenceImage: 'https://example.com/image.jpg',
+        conferenceDescription: "A test conference",
+        conferenceImage: "https://example.com/image.jpg",
         location: {
-          country: 'Nigeria',
-          state: 'Lagos',
-          street: '123 Main St',
-          localGovernment: 'Ikeja',
-          direction: 'Near the mall',
+          country: "Nigeria",
+          state: "Lagos",
+          street: "123 Main St",
+          localGovernment: "Ikeja",
+          direction: "Near the mall",
         },
         bankDetails: {
-          bankName: 'Test Bank',
-          bankAccountNumber: '1234567890',
-          accountName: 'Test Account',
+          bankName: "Test Bank",
+          bankAccountNumber: "1234567890",
+          accountName: "Test Account",
         },
         socialMedia: {
-          facebook: 'facebook.com/test',
-          twitter: 'twitter.com/test',
-          instagram: 'instagram.com/test',
+          facebook: "facebook.com/test",
+          twitter: "twitter.com/test",
+          instagram: "instagram.com/test",
         },
       };
 
@@ -104,26 +123,26 @@ describe('ConferenceController', () => {
     });
   });
 
-  describe('findAll', () => {
-    it('should return an array of conferences', async () => {
+  describe("findAll", () => {
+    it("should return an array of conferences", async () => {
       expect(await controller.findAll()).toEqual([mockConference]);
       expect(service.findAll).toHaveBeenCalled();
     });
   });
 
-  describe('findOne', () => {
-    it('should return a single conference', async () => {
-      const id = 'test-id';
+  describe("findOne", () => {
+    it("should return a single conference", async () => {
+      const id = "test-id";
       expect(await controller.findOne(id)).toEqual(mockConference);
       expect(service.findOne).toHaveBeenCalledWith(id);
     });
   });
 
-  describe('update', () => {
-    it('should update a conference', async () => {
-      const id = 'test-id';
+  describe("update", () => {
+    it("should update a conference", async () => {
+      const id = "test-id";
       const updateDto: UpdateConferenceDto = {
-        conferenceName: 'Updated Conference',
+        conferenceName: "Updated Conference",
       };
 
       expect(await controller.update(id, updateDto)).toEqual(mockConference);
@@ -131,9 +150,9 @@ describe('ConferenceController', () => {
     });
   });
 
-  describe('remove', () => {
-    it('should remove a conference', async () => {
-      const id = 'test-id';
+  describe("remove", () => {
+    it("should remove a conference", async () => {
+      const id = "test-id";
       expect(await controller.remove(id)).toBeUndefined();
       expect(service.remove).toHaveBeenCalledWith(id);
     });

--- a/src/conference/controllers/conference.controller.ts
+++ b/src/conference/controllers/conference.controller.ts
@@ -1,31 +1,41 @@
-import { 
-  Controller, 
-  Get, 
-  Post, 
-  Body, 
-  Param, 
-  Put, 
-  Delete, 
-  UseGuards, 
-  ParseUUIDPipe 
-} from '@nestjs/common';
-import { ConferenceService } from '../providers/conference.service';
-import { CreateConferenceDto, UpdateConferenceDto } from '../dto';
-import { Conference } from '../entities/conference.entity';
-import { JwtAuthGuard } from 'security/guards/jwt-auth.guard';
-import { RolesGuard } from 'security/guards/rolesGuard/roles.guard';
-import { Roles } from 'src/dynamic-pricing/auth/decorators/roles.decorator';
-import { UserRole } from 'src/common/enums/users-roles.enum';
-import { RoleDecorator } from 'security/decorators/roles.decorator';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Put,
+  Delete,
+  UseGuards,
+  ParseUUIDPipe,
+  Query,
+  Req,
+} from "@nestjs/common";
+import { ApiTags, ApiOperation, ApiQuery, ApiResponse } from "@nestjs/swagger";
+import { ConferenceService } from "../providers/conference.service";
+import {
+  CreateConferenceDto,
+  UpdateConferenceDto,
+  ConferenceFilterDto,
+} from "../dto";
+import { Conference } from "../entities/conference.entity";
+import { JwtAuthGuard } from "security/guards/jwt-auth.guard";
+import { RolesGuard } from "security/guards/rolesGuard/roles.guard";
+import { Roles } from "src/dynamic-pricing/auth/decorators/roles.decorator";
+import { UserRole } from "src/common/enums/users-roles.enum";
+import { RoleDecorator } from "security/decorators/roles.decorator";
+import { Request } from "express";
 
-@Controller('conference')
+@Controller("conference")
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class ConferenceController {
   constructor(private readonly conferenceService: ConferenceService) {}
 
   @Post()
   @RoleDecorator(UserRole.Admin, UserRole.Organizer)
-  create(@Body() createConferenceDto: CreateConferenceDto): Promise<Conference> {
+  create(
+    @Body() createConferenceDto: CreateConferenceDto,
+  ): Promise<Conference> {
     return this.conferenceService.create(createConferenceDto);
   }
 
@@ -34,23 +44,116 @@ export class ConferenceController {
     return this.conferenceService.findAll();
   }
 
-  @Get(':id')
-  findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Conference> {
+  @Get(":id")
+  findOne(@Param("id", ParseUUIDPipe) id: string): Promise<Conference> {
     return this.conferenceService.findOne(id);
   }
 
-  @Put(':id')
+  @Put(":id")
   @RoleDecorator(UserRole.Admin, UserRole.Organizer)
   update(
-    @Param('id', ParseUUIDPipe) id: string,
+    @Param("id", ParseUUIDPipe) id: string,
     @Body() updateConferenceDto: UpdateConferenceDto,
   ): Promise<Conference> {
     return this.conferenceService.update(id, updateConferenceDto);
   }
 
-  @Delete(':id')
+  @Delete(":id")
   @RoleDecorator(UserRole.Admin)
-  remove(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+  remove(@Param("id", ParseUUIDPipe) id: string): Promise<void> {
     return this.conferenceService.remove(id);
+  }
+
+  @Get("conferences")
+  @ApiOperation({ summary: "Get conferences with filtering and pagination" })
+  @ApiQuery({
+    name: "name",
+    required: false,
+    description: "Filter by conference name (partial match)",
+  })
+  @ApiQuery({
+    name: "category",
+    required: false,
+    description: "Filter by conference category",
+  })
+  @ApiQuery({
+    name: "location",
+    required: false,
+    description:
+      "Filter by any location field (country, state, street, LGA - partial match)",
+  })
+  @ApiQuery({
+    name: "visibility",
+    required: false,
+    description: "Filter by visibility (public/private/draft)",
+  })
+  @ApiQuery({
+    name: "page",
+    required: false,
+    description: "Page number (default: 1)",
+  })
+  @ApiQuery({
+    name: "limit",
+    required: false,
+    description: "Items per page (default: 10)",
+  })
+  @ApiResponse({
+    status: 200,
+    description: "Returns a paginated list of conferences with metadata",
+    schema: {
+      properties: {
+        data: {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "string" },
+              name: { type: "string" },
+              category: { type: "string" },
+              date: { type: "string", format: "date-time" },
+              location: {
+                type: "object",
+                properties: {
+                  country: { type: "string" },
+                  state: { type: "string" },
+                  street: { type: "string" },
+                  lga: { type: "string" },
+                },
+              },
+              image: { type: "string" },
+              description: { type: "string" },
+              visibility: {
+                type: "string",
+                enum: ["public", "private", "draft"],
+              },
+              organizer: {
+                type: "object",
+                properties: {
+                  id: { type: "number" },
+                  name: { type: "string" },
+                  firstName: { type: "string" },
+                  lastName: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+        meta: {
+          type: "object",
+          properties: {
+            page: { type: "number" },
+            limit: { type: "number" },
+            totalCount: { type: "number" },
+            totalPages: { type: "number" },
+          },
+        },
+      },
+    },
+  })
+  async getConferences(
+    @Query() filter: ConferenceFilterDto,
+    @Req() req: Request,
+  ) {
+    return this.conferenceService.findAllWithFilters(filter, req.user as any);
   }
 }

--- a/src/conference/dto/conference-filter.dto.ts
+++ b/src/conference/dto/conference-filter.dto.ts
@@ -1,0 +1,33 @@
+import { IsEnum, IsInt, IsOptional, IsString, Min } from "class-validator";
+import { ConferenceVisibility } from "../entities/conference.entity";
+import { Type } from "class-transformer";
+
+export class ConferenceFilterDto {
+  @IsOptional()
+  @IsString()
+  name?: string;
+
+  @IsOptional()
+  @IsString()
+  category?: string;
+
+  @IsOptional()
+  @IsString()
+  location?: string;
+
+  @IsOptional()
+  @IsEnum(ConferenceVisibility)
+  visibility?: ConferenceVisibility;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  page?: number = 1;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  limit?: number = 10;
+}

--- a/src/conference/dto/index.ts
+++ b/src/conference/dto/index.ts
@@ -1,2 +1,3 @@
 export * from './create-conference.dto';
 export * from './update-conference.dto';
+export * from './conference-filter.dto';

--- a/src/conference/entities/conference.entity.ts
+++ b/src/conference/entities/conference.entity.ts
@@ -11,16 +11,24 @@ import {
   OneToMany,
   ManyToOne,
   JoinColumn,
+  Index,
 } from "typeorm";
 
+export enum ConferenceVisibility {
+  PUBLIC = "public",
+  PRIVATE = "private",
+  DRAFT = "draft",
+}
 @Entity()
 export class Conference {
   @PrimaryGeneratedColumn("uuid")
   id: string;
 
+  @Index()
   @Column({ name: "conference_name" })
   conferenceName: string;
 
+  @Index()
   @Column({ name: "conference_category" })
   conferenceCategory: string;
 
@@ -36,16 +44,27 @@ export class Conference {
   @Column({ name: "conference_image" })
   conferenceImage: string;
 
+  @Column({
+    type: "enum",
+    enum: ConferenceVisibility,
+    default: ConferenceVisibility.PUBLIC,
+  })
+  visibility: ConferenceVisibility;
+
   // Location details
+  @Index()
   @Column()
   country: string;
 
+  @Index()
   @Column()
   state: string;
 
+  @Index()
   @Column()
   street: string;
 
+  @Index()
   @Column({ name: "local_government" })
   localGovernment: string;
 

--- a/src/events/events.module.ts
+++ b/src/events/events.module.ts
@@ -11,6 +11,7 @@ import { Collaborator } from "src/collaborator/entities/collaborator.entity";
 import { EventRevenueAnalyticsController } from "./event-revenue-analytics.controller";
 import { EventRevenueAnalyticsService } from "./event-revenue-analytics.service";
 import { CategoryModule } from "src/category/category.module";
+import { PricingRule } from "src/dynamic-pricing/pricing/entities/pricing-rule.entity";
 
 @Module({
   imports: [
@@ -18,6 +19,7 @@ import { CategoryModule } from "src/category/category.module";
       Event,
       Collaborator,
       Ticket /* Ticket, SpecialGuest */,
+      PricingRule,
     ]),
     CategoryModule,
   ],

--- a/src/special-speaker/special-speaker.module.ts
+++ b/src/special-speaker/special-speaker.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { SpecialSpeakerService } from './special-speaker.service';
 import { SpecialSpeakerController } from './special-speaker.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SpecialSpeaker } from './entities/special-speaker.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([SpecialSpeaker])], // Register the entity here
   controllers: [SpecialSpeakerController],
   providers: [SpecialSpeakerService],
 })


### PR DESCRIPTION
## Description

 I implemented a flexible and performant API to fetch all conferences with support for filters like name, category, and location. This allows users to browse and search for conferences of interest easily.

## Related Issues
Fixes #87 

## Changes Made

- The API should return a list of conferences with fields:
`name`, `category`, `date`, `location`, `image`, `description`, etc.
- Filtering by:
 - name (partial match)
 - category (exact or partial)
 - location (country, state, street, LGA — partial or exact match)
- Supports pagination via page and limit.
- Returns metadata (totalCount, page, totalPages) alongside results.
- Optimized queries with indexes on filtered fields.
- Secure access, based on the application’s visibility rules.

## How to Test

<!-- Describe how a reviewer can test these changes. -->

## Screenshots (if applicable)

<!-- Upload screenshots for UI-related changes. -->

## Checklist

- [x] My code follows the project's coding style.
- [x] I have tested these changes locally.
- [x] Documentation has been updated where necessary.
