### PR TITLE
feat: add conference poster management module with CRUD operations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -21,6 +21,7 @@ import { ContactUsModule } from './contact-us/contact-us.module';
 import { ConferenceModule } from './conference/conference.module';
 import { ContactModule } from './contact/contact.module';
 import { ConferenceSponsorsModule } from './conference-sponsors/conference-sponsors.module';
+import { ConferencePosterManagementModule } from './conference-poster-management/conference-poster-management.module';
 @Module({
   imports: [
     ConfigModule.forRoot({
@@ -56,7 +57,8 @@ import { ConferenceSponsorsModule } from './conference-sponsors/conference-spons
     ContactUsModule,
     ConferenceModule,
     ContactModule,
-    ConferenceSponsorsModule
+    ConferenceSponsorsModule,
+    ConferencePosterManagementModule
   ],
   controllers: [AppController],
   providers: [AppService, PdfService],

--- a/src/conference-poster-management/conference-poster-management.controller.spec.ts
+++ b/src/conference-poster-management/conference-poster-management.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConferencePosterManagementController } from './conference-poster-management.controller';
+import { ConferencePosterManagementService } from './conference-poster-management.service';
+
+describe('ConferencePosterManagementController', () => {
+  let controller: ConferencePosterManagementController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ConferencePosterManagementController],
+      providers: [ConferencePosterManagementService],
+    }).compile();
+
+    controller = module.get<ConferencePosterManagementController>(ConferencePosterManagementController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/conference-poster-management/conference-poster-management.controller.ts
+++ b/src/conference-poster-management/conference-poster-management.controller.ts
@@ -1,0 +1,138 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Param,
+  Body,
+  UseInterceptors,
+  UploadedFile,
+  UseGuards,
+  HttpStatus,
+  ParseUUIDPipe,
+  HttpCode,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { ConferencePosterManagementService } from './conference-poster-management.service';
+import { CreateConferencePosterDto } from './dto/create-conference-poster.dto';
+import { UpdateConferencePosterDto } from './dto/update-conference-poster.dto';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiConsumes, ApiBody } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../../security/guards/jwt-auth.guard';
+import { RolesGuard } from '../../security/guards/rolesGuard/roles.guard';
+import { RoleDecorator } from '../../security/decorators/roles.decorator';
+import { UserRole } from '../../src/common/enums/users-roles.enum';
+import type { Express } from 'express';
+
+@ApiTags('conference-posters')
+@Controller('posters')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class ConferencePosterManagementController {
+  constructor(private readonly conferencePosterService: ConferencePosterManagementService) {}
+
+  @Post()
+  @RoleDecorator(UserRole.Admin, UserRole.Organizer)
+  @UseInterceptors(FileInterceptor('image'))
+  @ApiOperation({ summary: 'Upload a new conference poster' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        image: {
+          type: 'string',
+          format: 'binary',
+        },
+        description: {
+          type: 'string',
+        },
+        conferenceId: {
+          type: 'string',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Poster created successfully' })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid input' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden' })
+  async uploadConferencePoster(@UploadedFile() file: Express.Multer.File, @Body() createPosterDto: CreateConferencePosterDto) {
+    return this.conferencePosterService.create(file, createPosterDto);
+  }
+
+  @Get()
+  @RoleDecorator(UserRole.Admin, UserRole.Organizer, UserRole.User)
+  @ApiOperation({ summary: 'Retrieve all posters' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Retrieved all posters' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+  async findAll() {
+    return this.conferencePosterService.findAll();
+  }
+
+  @Get('conference/:conferenceId')
+  @RoleDecorator(UserRole.Admin, UserRole.Organizer, UserRole.User)
+  @ApiOperation({ summary: 'Retrieve all posters for a specific conference' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Retrieved posters for conference' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+  async findPosterByConference(@Param('conferenceId', new ParseUUIDPipe()) conferenceId: string) {
+    return this.conferencePosterService.findByConference(conferenceId);
+  }
+
+  @Get(':id')
+  @RoleDecorator(UserRole.Admin, UserRole.Organizer, UserRole.User)
+  @ApiOperation({ summary: 'Retrieve a single poster by ID' })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Retrieved poster' })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Poster not found' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+  async findPosterById(@Param('id', new ParseUUIDPipe()) id: string) {
+    return this.conferencePosterService.findOne(id);
+  }
+
+  @Put(':id')
+  @RoleDecorator(UserRole.Admin, UserRole.Organizer)
+  @UseInterceptors(FileInterceptor('image'))
+  @ApiOperation({ summary: 'Update a poster' })
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        image: {
+          type: 'string',
+          format: 'binary',
+        },
+        description: {
+          type: 'string',
+        },
+        conferenceId: {
+          type: 'string',
+        },
+      },
+    },
+  })
+  @ApiResponse({ status: HttpStatus.OK, description: 'Poster updated successfully' })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Invalid input' })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Poster not found' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden' })
+  async updatePoster(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Body() updatePosterDto: UpdateConferencePosterDto,
+  ) {
+    return this.conferencePosterService.update(id, file, updatePosterDto);
+  }
+
+  @Delete(':id')
+  @RoleDecorator(UserRole.Admin, UserRole.Organizer)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Delete a poster' })
+  @ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'Poster deleted successfully' })
+  @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Poster not found' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Unauthorized' })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden' })
+  async removePoster(@Param('id', new ParseUUIDPipe()) id: string) {
+    await this.conferencePosterService.remove(id);
+  }
+}

--- a/src/conference-poster-management/conference-poster-management.module.ts
+++ b/src/conference-poster-management/conference-poster-management.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MulterModule } from '@nestjs/platform-express';
+import { ConferencePosterManagementService } from './conference-poster-management.service';
+import { ConferencePosterManagementController } from './conference-poster-management.controller';
+import { ConferencePoster } from './entities/conference-poster.entity';
+import { Conference } from '../conference/entities/conference.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ConferencePoster, Conference]),
+    MulterModule.register({
+      dest: './uploads/conference-posters',
+    }),
+  ],
+  controllers: [ConferencePosterManagementController],
+  providers: [ConferencePosterManagementService],
+  exports: [ConferencePosterManagementService],
+})
+export class ConferencePosterManagementModule {}

--- a/src/conference-poster-management/conference-poster-management.service.spec.ts
+++ b/src/conference-poster-management/conference-poster-management.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConferencePosterManagementService } from './conference-poster-management.service';
+
+describe('ConferencePosterManagementService', () => {
+  let service: ConferencePosterManagementService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ConferencePosterManagementService],
+    }).compile();
+
+    service = module.get<ConferencePosterManagementService>(ConferencePosterManagementService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/conference-poster-management/conference-poster-management.service.ts
+++ b/src/conference-poster-management/conference-poster-management.service.ts
@@ -1,0 +1,118 @@
+import { Injectable, NotFoundException, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as fs from 'fs';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { ConferencePoster } from './entities/conference-poster.entity';
+import { CreateConferencePosterDto } from './dto/create-conference-poster.dto';
+import { UpdateConferencePosterDto } from './dto/update-conference-poster.dto';
+
+@Injectable()
+export class ConferencePosterManagementService {
+  constructor(
+    @InjectRepository(ConferencePoster)
+    private conferencePosterRepository: Repository<ConferencePoster>,
+  ) {}
+
+  async create(file: Express.Multer.File, createConferencePosterDto: CreateConferencePosterDto): Promise<ConferencePoster> {
+    if (!file) {
+      throw new BadRequestException('Poster image is required');
+    }
+    const uploadsDir = path.join(process.cwd(), 'uploads', 'conference-posters');
+    
+    if (!fs.existsSync(uploadsDir)) {
+      fs.mkdirSync(uploadsDir, { recursive: true });
+    }
+    
+    const uniqueFilename = `${uuidv4()}_${file.originalname}`;
+    const filePath = path.join(uploadsDir, uniqueFilename);
+    
+    fs.writeFileSync(filePath, file.buffer);
+    
+    const relativePath = path.join('uploads', 'conference-posters', uniqueFilename);
+
+    const newPoster = this.conferencePosterRepository.create({
+      ...createConferencePosterDto,
+      imageUrl: relativePath.replace(/\\/g, '/'),
+    });
+
+    return this.conferencePosterRepository.save(newPoster);
+  }
+
+  async findAll(): Promise<ConferencePoster[]> {
+    return this.conferencePosterRepository.find({
+      relations: ['conference'],
+    });
+  }
+
+  async findOne(id: string): Promise<ConferencePoster> {
+    const poster = await this.conferencePosterRepository.findOne({
+      where: { id },
+      relations: ['conference'],
+    });
+
+    if (!poster) {
+      throw new NotFoundException(`Poster with ID '${id}' not found`);
+    }
+
+    return poster;
+  }
+
+  async findByConference(conferenceId: string): Promise<ConferencePoster[]> {
+    return this.conferencePosterRepository.find({
+      where: { conferenceId },
+      relations: ['conference'],
+    });
+  }
+
+  async update(id: string, file: Express.Multer.File, updateConferencePosterDto: UpdateConferencePosterDto): Promise<ConferencePoster> {
+    const poster = await this.findOne(id);
+    
+    if (file) {
+      if (poster.imageUrl) {
+        const oldFilePath = path.join(process.cwd(), poster.imageUrl);
+        if (fs.existsSync(oldFilePath)) {
+          fs.unlinkSync(oldFilePath);
+        }
+      }
+      
+      const uploadsDir = path.join(process.cwd(), 'uploads', 'conference-posters');
+      
+      if (!fs.existsSync(uploadsDir)) {
+        fs.mkdirSync(uploadsDir, { recursive: true });
+      }
+      
+      const uniqueFilename = `${uuidv4()}_${file.originalname}`;
+      const filePath = path.join(uploadsDir, uniqueFilename);
+      
+      fs.writeFileSync(filePath, file.buffer);
+      
+      const relativePath = path.join('uploads', 'conference-posters', uniqueFilename);
+      poster.imageUrl = relativePath.replace(/\\/g, '/');
+    }
+
+    if (updateConferencePosterDto.description) {
+      poster.description = updateConferencePosterDto.description;
+    }
+    
+    if (updateConferencePosterDto.conferenceId) {
+      poster.conferenceId = updateConferencePosterDto.conferenceId;
+    }
+
+    return this.conferencePosterRepository.save(poster);
+  }
+
+  async remove(id: string): Promise<void> {
+    const poster = await this.findOne(id);
+    
+    if (poster.imageUrl) {
+      const filePath = path.join(process.cwd(), poster.imageUrl);
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    }
+    
+    await this.conferencePosterRepository.remove(poster);
+  }
+}

--- a/src/conference-poster-management/conference-poster.http
+++ b/src/conference-poster-management/conference-poster.http
@@ -1,0 +1,57 @@
+### Variables
+@baseUrl = http://localhost:3002
+@token = your_jwt_token_here
+@posterId = uuid_here
+@conferenceId = uuid_here
+
+### Create a new conference poster
+POST {{baseUrl}}/posters
+Authorization: Bearer {{token}}
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+------WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="image"; filename="poster.jpg"
+Content-Type: image/jpeg
+
+< ./path/to/your/image.jpg
+------WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="description"
+
+Main promotional poster for DevConf 2025
+------WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="conferenceId"
+
+{{conferenceId}}
+------WebKitFormBoundary7MA4YWxkTrZu0gW--
+
+### Get all posters
+GET {{baseUrl}}/posters
+Authorization: Bearer {{token}}
+
+### Get a specific poster by ID
+GET {{baseUrl}}/posters/{{posterId}}
+Authorization: Bearer {{token}}
+
+### Get all posters for a conference
+GET {{baseUrl}}/posters/conference/{{conferenceId}}
+Authorization: Bearer {{token}}
+
+### Update a poster
+PUT {{baseUrl}}/posters/{{posterId}}
+Authorization: Bearer {{token}}
+Content-Type: multipart/form-data; boundary=----WebKitFormBoundary7MA4YWxkTrZu0gW
+
+------WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="image"; filename="updated_poster.jpg"
+Content-Type: image/jpeg
+
+< ./path/to/your/updated_image.jpg
+------WebKitFormBoundary7MA4YWxkTrZu0gW
+Content-Disposition: form-data; name="description"
+
+Updated promotional poster for DevConf 2025
+------WebKitFormBoundary7MA4YWxkTrZu0gW--
+
+### Delete a poster
+DELETE {{baseUrl}}/posters/{{posterId}}
+Authorization: Bearer {{token}}

--- a/src/conference-poster-management/dto/create-conference-poster.dto.ts
+++ b/src/conference-poster-management/dto/create-conference-poster.dto.ts
@@ -1,0 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString, IsUUID } from 'class-validator';
+
+export class CreateConferencePosterDto {
+  @IsNotEmpty()
+  @IsString()
+  description: string;
+
+  @IsNotEmpty()
+  @IsUUID()
+  conferenceId: string;  
+  
+  image: any; // not validated by class-validator. Validation is handled by Multer
+}

--- a/src/conference-poster-management/dto/create-conference-poster.dto.ts
+++ b/src/conference-poster-management/dto/create-conference-poster.dto.ts
@@ -10,5 +10,5 @@ export class CreateConferencePosterDto {
   @IsUUID()
   conferenceId: string;  
   
-  image: any; // not validated by class-validator. Validation is handled by Multer
+  imageUrl: any; // not validated by class-validator. Validation is handled by Multer
 }

--- a/src/conference-poster-management/dto/update-conference-poster.dto.ts
+++ b/src/conference-poster-management/dto/update-conference-poster.dto.ts
@@ -1,0 +1,24 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsOptional, IsString, IsUUID } from 'class-validator';
+import { CreateConferencePosterDto } from './create-conference-poster.dto';
+
+export class UpdateConferencePosterDto extends PartialType(CreateConferencePosterDto) {
+  @ApiProperty({
+    description: 'Description of the conference poster',
+    example: 'Updated promotional poster for DevConf 2025',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @ApiProperty({
+    description: 'UUID of the associated conference',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+    required: false,
+  })
+  @IsOptional()
+  @IsUUID()
+  conferenceId?: string;
+}

--- a/src/conference-poster-management/dto/update-conference-poster.dto.ts
+++ b/src/conference-poster-management/dto/update-conference-poster.dto.ts
@@ -4,21 +4,15 @@ import { IsOptional, IsString, IsUUID } from 'class-validator';
 import { CreateConferencePosterDto } from './create-conference-poster.dto';
 
 export class UpdateConferencePosterDto extends PartialType(CreateConferencePosterDto) {
-  @ApiProperty({
-    description: 'Description of the conference poster',
-    example: 'Updated promotional poster for DevConf 2025',
-    required: false,
-  })
   @IsOptional()
   @IsString()
   description?: string;
 
-  @ApiProperty({
-    description: 'UUID of the associated conference',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-    required: false,
-  })
   @IsOptional()
   @IsUUID()
   conferenceId?: string;
+  
+  @IsOptional()
+  @IsString()
+  imageUrl?: string;
 }

--- a/src/conference-poster-management/entities/conference-poster.entity.ts
+++ b/src/conference-poster-management/entities/conference-poster.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn } from 'typeorm';
+import { Conference } from '../../conference/entities/conference.entity';
+
+@Entity('conference_posters')
+export class ConferencePoster {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  imageUrl: string;
+
+  @Column('text')
+  description: string;
+
+  @Column()
+  conferenceId: string;
+
+  @ManyToOne(() => Conference, (conference) => conference.id, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'conferenceId' })
+  conference: Conference;
+
+  @CreateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  updatedAt: Date;
+}


### PR DESCRIPTION
## Description

<!-- Provide a brief summary of the changes in this PR. -->
The Conference Poster Management API allows authenticated users to upload, view, update, and delete posters associated with conferences, with appropriate role-based restrictions. All required fields are validated, images are handled securely, and the API follows REST conventions.

## Related Issues

<!-- Link related issues using `Closes #issue_number` or `Fixes #issue_number` -->
Closes #79 

## Changes Made

- [ ] Implemented ConferencePoster entity with fields for imageUrl, description, conferenceId
- [ ] Added proper relation to the Conference entity using ManyToOne
- [ ] Created CreateConferencePosterDto with validation for description, conferenceId and image documentation
- [ ] Created UpdateConferencePosterDto extending the create DTO with optional fields
- [ ] Implemented secure file handling with unique filenames and proper storage
- [ ] Implemented all required endpoints (POST, GET, PUT, DELETE)
- [ ] Set up file upload handling with Multer's FileInterceptor
- [ ] Applied proper role restrictions (Admin/Organizer can create/update/delete, all authenticated users can view)
- [ ] Configured TypeORM for the entity
- [ ] Registered the module in the main application

## Checklist

- [ ] My code follows the project's coding style.
- [ ] I have tested these changes locally.
- [ ] Documentation has been updated where necessary.
