### PR TITLE
Feature retrieve all conferences

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@nestjs/cache-manager": "^3.0.1",
         "@nestjs/common": "^11.0.10",
         "@nestjs/config": "^4.0.0",
         "@nestjs/core": "^11.0.10",
@@ -21,6 +22,7 @@
         "@nestjs/typeorm": "^11.0.0",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^3.0.2",
+        "cache-manager": "^6.4.2",
         "class-transformer": "^0.5.1",
         "class-validator": "^0.14.1",
         "connect": "^3.7.0",
@@ -1954,6 +1956,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@keyv/serialize": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.0.3.tgz",
+      "integrity": "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@keyv/serialize/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
@@ -2347,6 +2382,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@nestjs/cache-manager": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/cache-manager/-/cache-manager-3.0.1.tgz",
+      "integrity": "sha512-4UxTnR0fsmKL5YDalU2eLFVnL+OBebWUpX+hEduKGncrVKH4PPNoiRn1kXyOCjmzb0UvWgqubpssNouc8e0MCw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@nestjs/common": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "@nestjs/core": "^9.0.0 || ^10.0.0 || ^11.0.0",
+        "cache-manager": ">=6",
+        "keyv": ">=5",
+        "rxjs": "^7.8.1"
       }
     },
     "node_modules/@nestjs/cli": {
@@ -5662,6 +5710,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cache-manager": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-6.4.2.tgz",
+      "integrity": "sha512-oT0d1cGWZAlqEGDPjOfhmldTS767jT6kBT3KIdn7MX5OevlRVYqJT+LxRv5WY4xW9heJtYxeRRXaoKlEW+Biew==",
+      "license": "MIT",
+      "dependencies": {
+        "keyv": "^5.3.2"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
@@ -5689,6 +5746,16 @@
       },
       "engines": {
         "node": ">=14.16"
+      }
+    },
+    "node_modules/cacheable-request/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -18399,6 +18466,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/flat-cache/node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/flatted": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
@@ -20247,13 +20324,12 @@
       }
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.3.3.tgz",
+      "integrity": "sha512-Rwu4+nXI9fqcxiEHtbkvoes2X+QfkTRo1TMkPfwzipGsJlJO/z69vqB4FNl9xJ3xCpAcbkvmEabZfPzrwN3+gQ==",
       "license": "MIT",
       "dependencies": {
-        "json-buffer": "3.0.1"
+        "@keyv/serialize": "^1.0.3"
       }
     },
     "node_modules/kind-of": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "migration:run": "npm run typeorm -- migration:run -d ./src/data-source.ts"
   },
   "dependencies": {
+    "@nestjs/cache-manager": "^3.0.1",
     "@nestjs/common": "^11.0.10",
     "@nestjs/config": "^4.0.0",
     "@nestjs/core": "^11.0.10",
@@ -37,6 +38,7 @@
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^3.0.2",
+    "cache-manager": "^6.4.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.1",
     "connect": "^3.7.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -10,25 +10,31 @@ import { ConfigModule, ConfigService } from "@nestjs/config";
 import { PdfService } from "./utils/pdf.service";
 import { TicketModule } from "./tickets/tickets.module";
 import { SpecialGuestModule } from "./special-guests/special-guests.module";
-import { NotificationModule } from './notification/notification.module';
+import { NotificationModule } from "./notification/notification.module";
 import { EventsModule } from "./events/events.module";
 import { PostersModule } from "./posters/posters.module";
 import databaseConfig from "src/config/database.config";
 import jwtConfig from "src/config/jwt.config";
 import { EventDashboardModule } from "./dashboard/dashboard.module";
 import { EventGalleryModule } from "./event-gallery/event-gallery.module";
-import { ContactUsModule } from './contact-us/contact-us.module';
-import { ConferenceModule } from './conference/conference.module';
-import { ContactModule } from './contact/contact.module';
-import { ConferenceSponsorsModule } from './conference-sponsors/conference-sponsors.module';
-import { ConferencePosterManagementModule } from './conference-poster-management/conference-poster-management.module';
-import { SpecialSpeakerModule } from './special-speaker/special-speaker.module';
+import { ContactUsModule } from "./contact-us/contact-us.module";
+import { ConferenceModule } from "./conference/conference.module";
+import { ContactModule } from "./contact/contact.module";
+import { ConferenceSponsorsModule } from "./conference-sponsors/conference-sponsors.module";
+import { SpecialSpeakerModule } from "./special-speaker/special-speaker.module";
+import { CacheModule } from "@nestjs/cache-manager";
+import { ConferencePosterManagementModule } from "./conference-poster-management/conference-poster-management.module";
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ".env",
-      load: [databaseConfig, jwtConfig], 
+      load: [databaseConfig, jwtConfig],
+    }),
+    CacheModule.register({
+      isGlobal: true,
+      ttl: 300, // 5 minutes
+      max: 100, // maximum number of items in cache
     }),
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
@@ -59,7 +65,7 @@ import { SpecialSpeakerModule } from './special-speaker/special-speaker.module';
     ConferenceModule,
     ContactModule,
     ConferenceSponsorsModule,
-    ConferencePosterManagementModule
+    ConferencePosterManagementModule,
     SpecialSpeakerModule
   ],
   controllers: [AppController],
@@ -71,12 +77,14 @@ export class AppModule implements OnModuleInit {
   private readonly logger = new Logger(AppModule.name);
 
   onModuleInit() {
-    const dbType = this.configService.get('database.type');
-    const dbHost = this.configService.get('database.host');
-    const dbUrl = this.configService.get('database.url');
+    const dbType = this.configService.get("database.type");
+    const dbHost = this.configService.get("database.host");
+    const dbUrl = this.configService.get("database.url");
     this.logger.log(`Database Type: ${dbType}`);
     this.logger.log(`Database Host: ${dbHost}`);
     this.logger.log(`Database URL: ${dbUrl}`);
-    this.logger.log(`Connection to ${dbType} database established successfully through ${dbUrl}.`);
+    this.logger.log(
+      `Connection to ${dbType} database established successfully through ${dbUrl}.`,
+    );
   }
 }

--- a/src/common/filters/database-exception.filter.ts
+++ b/src/common/filters/database-exception.filter.ts
@@ -27,14 +27,19 @@ export class DatabaseExceptionFilter implements ExceptionFilter {
     let statusCode = HttpStatus.INTERNAL_SERVER_ERROR;
     let message = "Database operation failed";
     let errorCode: string | null = null;
-    const detail = (exception as any).detail as string;
-    const match = detail.match(/\((['"]?)([^'"]+)\1\)=\([^)]+\)/); // find the field name
-    const field = match ? match[2] : "unknown_field";
+    let field = "unknown_field";
 
     if (exception instanceof QueryFailedError) {
       statusCode = HttpStatus.BAD_REQUEST;
-      statusCode = HttpStatus.BAD_REQUEST;
       const pgError = exception as any;
+      const detail = pgError.detail as string;
+
+      if (detail) {
+        const match = detail.match(/\((['"]?)([^'"]+)\1\)=\([^)]+\)/);
+        if (match) {
+          field = match[2];
+        }
+      }
 
       switch (pgError.code) {
         case "23505":

--- a/src/conference-sponsors/conference-sponsors.controller.ts
+++ b/src/conference-sponsors/conference-sponsors.controller.ts
@@ -108,7 +108,7 @@ export class ConferenceSponsorsController {
   }
 
   @Get()
-  @UseGuards(JwtAuthGuard)
+  // @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: "Get all sponsors" })
   @ApiResponse({ status: 200, description: "Return all sponsors." })

--- a/src/conference-sponsors/conference-sponsors.controller.ts
+++ b/src/conference-sponsors/conference-sponsors.controller.ts
@@ -108,7 +108,7 @@ export class ConferenceSponsorsController {
   }
 
   @Get()
-  // @UseGuards(JwtAuthGuard)
+  @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: "Get all sponsors" })
   @ApiResponse({ status: 200, description: "Return all sponsors." })

--- a/src/conference-sponsors/conference-sponsors.service.spec.ts
+++ b/src/conference-sponsors/conference-sponsors.service.spec.ts
@@ -5,7 +5,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { ConferenceSponsorsService } from './conference-sponsors.service';
 import { ConferenceSponsor } from './entities/conference-sponsor.entity';
-import { Conference } from './../conference/entities/conference.entity';
+import { Conference, ConferenceVisibility } from './../conference/entities/conference.entity';
 import { CreateConferenceSponsorDto } from './dto/create-conference-sponsor.dto';
 import { UpdateConferenceSponsorDto } from './dto/update-conference-sponsor.dto';
 import { User } from '../users/entities/user.entity';
@@ -61,6 +61,7 @@ describe('ConferenceSponsorsService', () => {
     endDate: new Date(),
     location: 'Test location',
     organizerId: 'user-1',
+    visibility: ConferenceVisibility.PUBLIC,
     organizer: mockUser,
     speakers: [],
     sponsors: [],

--- a/src/conference/conference.module.ts
+++ b/src/conference/conference.module.ts
@@ -1,18 +1,15 @@
-import { Module } from '@nestjs/common';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { Conference } from './entities/conference.entity';
-import { Ticket } from '../tickets/entities/ticket.entity';
-import { AuthModule } from '../auth/auth.module';
-import { ConferenceService } from './providers/conference.service';
-import { ConferenceController } from './controllers/conference.controller';
-import { AnalyticsService } from '../conference/Analytics/analytics.service';
-import { AnalyticsController } from '../conference/Analytics/analytics.controller';
+import { Module } from "@nestjs/common";
+import { TypeOrmModule } from "@nestjs/typeorm";
+import { Conference } from "./entities/conference.entity";
+import { Ticket } from "../tickets/entities/ticket.entity";
+import { AuthModule } from "../auth/auth.module";
+import { ConferenceService } from "./providers/conference.service";
+import { ConferenceController } from "./controllers/conference.controller";
+import { AnalyticsService } from "../conference/Analytics/analytics.service";
+import { AnalyticsController } from "../conference/Analytics/analytics.controller";
 
 @Module({
-  imports: [
-    TypeOrmModule.forFeature([Conference, Ticket]),
-    AuthModule,
-  ],
+  imports: [TypeOrmModule.forFeature([Conference, Ticket]), AuthModule],
   controllers: [ConferenceController, AnalyticsController],
   providers: [ConferenceService, AnalyticsService],
   exports: [ConferenceService],

--- a/src/conference/controllers/conference.controller.ts
+++ b/src/conference/controllers/conference.controller.ts
@@ -10,6 +10,7 @@ import {
   ParseUUIDPipe,
   Query,
   Req,
+  UnauthorizedException,
 } from "@nestjs/common";
 import { ApiTags, ApiOperation, ApiQuery, ApiResponse } from "@nestjs/swagger";
 import { ConferenceService } from "../providers/conference.service";
@@ -18,51 +19,22 @@ import {
   UpdateConferenceDto,
   ConferenceFilterDto,
 } from "../dto";
-import { Conference } from "../entities/conference.entity";
+import {
+  Conference,
+  ConferenceVisibility,
+} from "../entities/conference.entity";
 import { JwtAuthGuard } from "security/guards/jwt-auth.guard";
 import { RolesGuard } from "security/guards/rolesGuard/roles.guard";
 import { Roles } from "src/dynamic-pricing/auth/decorators/roles.decorator";
 import { UserRole } from "src/common/enums/users-roles.enum";
 import { RoleDecorator } from "security/decorators/roles.decorator";
 import { Request } from "express";
+import { User } from "src/users/entities/user.entity";
 
 @Controller("conference")
-@UseGuards(JwtAuthGuard, RolesGuard)
+// @UseGuards(JwtAuthGuard, RolesGuard)
 export class ConferenceController {
   constructor(private readonly conferenceService: ConferenceService) {}
-
-  @Post()
-  @RoleDecorator(UserRole.Admin, UserRole.Organizer)
-  create(
-    @Body() createConferenceDto: CreateConferenceDto,
-  ): Promise<Conference> {
-    return this.conferenceService.create(createConferenceDto);
-  }
-
-  @Get()
-  findAll(): Promise<Conference[]> {
-    return this.conferenceService.findAll();
-  }
-
-  @Get(":id")
-  findOne(@Param("id", ParseUUIDPipe) id: string): Promise<Conference> {
-    return this.conferenceService.findOne(id);
-  }
-
-  @Put(":id")
-  @RoleDecorator(UserRole.Admin, UserRole.Organizer)
-  update(
-    @Param("id", ParseUUIDPipe) id: string,
-    @Body() updateConferenceDto: UpdateConferenceDto,
-  ): Promise<Conference> {
-    return this.conferenceService.update(id, updateConferenceDto);
-  }
-
-  @Delete(":id")
-  @RoleDecorator(UserRole.Admin)
-  remove(@Param("id", ParseUUIDPipe) id: string): Promise<void> {
-    return this.conferenceService.remove(id);
-  }
 
   @Get("conferences")
   @ApiOperation({ summary: "Get conferences with filtering and pagination" })
@@ -121,20 +93,6 @@ export class ConferenceController {
                 },
               },
               image: { type: "string" },
-              description: { type: "string" },
-              visibility: {
-                type: "string",
-                enum: ["public", "private", "draft"],
-              },
-              organizer: {
-                type: "object",
-                properties: {
-                  id: { type: "number" },
-                  name: { type: "string" },
-                  firstName: { type: "string" },
-                  lastName: { type: "string" },
-                },
-              },
             },
           },
         },
@@ -154,6 +112,58 @@ export class ConferenceController {
     @Query() filter: ConferenceFilterDto,
     @Req() req: Request,
   ) {
-    return this.conferenceService.findAllWithFilters(filter, req.user as any);
+    // If requesting non-public conferences, ensure user is authenticated
+    if (
+      filter.visibility &&
+      filter.visibility !== ConferenceVisibility.PUBLIC
+    ) {
+      if (!req.user) {
+        throw new UnauthorizedException(
+          "Authentication required to view non-public conferences",
+        );
+      }
+    }
+
+    return this.conferenceService.findAllWithFilters(filter, req.user as User);
+  }
+
+  @Post()
+  @ApiOperation({ summary: "Create a new conference" })
+  @ApiResponse({
+    status: 201,
+    description: "The conference has been successfully created.",
+  })
+  @ApiResponse({ status: 400, description: "Bad request." })
+  create(
+    @Body() createConferenceDto: CreateConferenceDto,
+    @Req() req: Request,
+  ): Promise<Conference> {
+    const user = req.user as User;
+    return this.conferenceService.create(createConferenceDto, user);
+  }
+
+  @Get()
+  findAll(): Promise<Conference[]> {
+    return this.conferenceService.findAll();
+  }
+
+  @Get(":id")
+  findOne(@Param("id", ParseUUIDPipe) id: string): Promise<Conference> {
+    return this.conferenceService.findOne(id);
+  }
+
+  @Put(":id")
+  @RoleDecorator(UserRole.Admin, UserRole.Organizer)
+  update(
+    @Param("id", ParseUUIDPipe) id: string,
+    @Body() updateConferenceDto: UpdateConferenceDto,
+  ): Promise<Conference> {
+    return this.conferenceService.update(id, updateConferenceDto);
+  }
+
+  @Delete(":id")
+  @RoleDecorator(UserRole.Admin)
+  remove(@Param("id", ParseUUIDPipe) id: string): Promise<void> {
+    return this.conferenceService.remove(id);
   }
 }

--- a/src/conference/controllers/conference.controller.ts
+++ b/src/conference/controllers/conference.controller.ts
@@ -32,7 +32,7 @@ import { Request } from "express";
 import { User } from "src/users/entities/user.entity";
 
 @Controller("conference")
-// @UseGuards(JwtAuthGuard, RolesGuard)
+@UseGuards(JwtAuthGuard, RolesGuard)
 export class ConferenceController {
   constructor(private readonly conferenceService: ConferenceService) {}
 

--- a/src/conference/dto/create-conference.dto.ts
+++ b/src/conference/dto/create-conference.dto.ts
@@ -3,6 +3,7 @@ import { Type } from 'class-transformer';
 import { SocialMediaDto } from './socialMedia.dto';
 import { BankDetailsDto } from './bankDetails.dto';
 import { LocationDto } from './location.dto';
+import { ConferenceVisibility } from '../entities/conference.entity';
 
 export class CreateConferenceDto {
   @IsString()
@@ -28,6 +29,10 @@ export class CreateConferenceDto {
   @IsUrl()
   @IsNotEmpty()
   conferenceImage: string;
+
+  @IsString()
+  @IsNotEmpty()
+  visibility: ConferenceVisibility;
 
   @IsNotEmpty()
   location: LocationDto;

--- a/src/conference/entities/conference.entity.ts
+++ b/src/conference/entities/conference.entity.ts
@@ -101,8 +101,8 @@ export class Conference {
   @Column({ nullable: true })
   instagram: string;
 
-  @Column()
-  organizerId: number; // This will hold the ID of the organizer (User)
+  @Column({ type: "uuid", nullable:true })
+  organizerId: string; // This will hold the ID of the organizer (User)
 
   @ManyToOne(() => User, (user) => user.conferences) // Assuming you have a User entity
   @JoinColumn({ name: "organizerId" })
@@ -112,7 +112,7 @@ export class Conference {
   @OneToMany(() => Ticket, (ticket) => ticket.conference)
   tickets: Ticket[];
 
-  @OneToMany(() => Collaborator, collaborator => collaborator.conference)
+  @OneToMany(() => Collaborator, (collaborator) => collaborator.conference)
   collaborators: Collaborator[];
 
   @CreateDateColumn({ name: "created_at" })

--- a/src/conference/providers/conference.service.spec.ts
+++ b/src/conference/providers/conference.service.spec.ts
@@ -1,33 +1,38 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { getRepositoryToken } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { Conference } from '../entities/conference.entity';
-import { NotFoundException } from '@nestjs/common';
-import { ConferenceService } from './conference.service';
-import { UpdateConferenceDto } from '../dto';
+import { Test, TestingModule } from "@nestjs/testing";
+import { getRepositoryToken } from "@nestjs/typeorm";
+import { Repository } from "typeorm";
+import {
+  Conference,
+  ConferenceVisibility,
+} from "../entities/conference.entity";
+import { NotFoundException } from "@nestjs/common";
+import { ConferenceService } from "./conference.service";
+import { UpdateConferenceDto } from "../dto";
+import { UserRole } from "src/common/enums/users-roles.enum";
+import { User } from "src/users/entities/user.entity";
 
 const mockConference = {
-  id: 'test-id',
-  conferenceName: 'Test Conference',
-  conferenceCategory: 'Technology',
+  id: "test-id",
+  conferenceName: "Test Conference",
+  conferenceCategory: "Technology",
   conferenceDate: new Date(),
   conferenceClosingDate: new Date(),
-  conferenceDescription: 'A test conference',
-  conferenceImage: 'https://example.com/image.jpg',
-  country: 'Nigeria',
-  state: 'Lagos',
-  street: '123 Main St',
-  localGovernment: 'Ikeja',
-  direction: 'Near the mall',
+  conferenceDescription: "A test conference",
+  conferenceImage: "https://example.com/image.jpg",
+  country: "Nigeria",
+  state: "Lagos",
+  street: "123 Main St",
+  localGovernment: "Ikeja",
+  direction: "Near the mall",
   hideLocation: false,
   comingSoon: false,
   transactionCharge: false,
-  bankName: 'Test Bank',
-  bankAccountNumber: '1234567890',
-  accountName: 'Test Account',
-  facebook: 'facebook.com/test',
-  twitter: 'twitter.com/test',
-  instagram: 'instagram.com/test',
+  bankName: "Test Bank",
+  bankAccountNumber: "1234567890",
+  accountName: "Test Account",
+  facebook: "facebook.com/test",
+  twitter: "twitter.com/test",
+  instagram: "instagram.com/test",
   createdAt: new Date(),
   updatedAt: new Date(),
 };
@@ -40,7 +45,7 @@ const mockRepository = {
   remove: jest.fn().mockResolvedValue(undefined),
 };
 
-describe('ConferenceService', () => {
+describe("ConferenceService", () => {
   let service: ConferenceService;
   let repository: Repository<Conference>;
 
@@ -56,96 +61,117 @@ describe('ConferenceService', () => {
     }).compile();
 
     service = module.get<ConferenceService>(ConferenceService);
-    repository = module.get<Repository<Conference>>(getRepositoryToken(Conference));
+    repository = module.get<Repository<Conference>>(
+      getRepositoryToken(Conference),
+    );
   });
 
-  it('should be defined', () => {
+  it("should be defined", () => {
     expect(service).toBeDefined();
   });
 
-  describe('create', () => {
-    it('should create a new conference', async () => {
+  describe("create", () => {
+    it("should create a new conference", async () => {
+      const mockUser: User = {
+        id: "user-1",
+        email: "test@example.com",
+        password: "hashedPassword",
+        firstName: "Test",
+        lastName: "User",
+        role: UserRole.Organizer,
+        conferences: [],
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as unknown as User;
+
       const createDto = {
-        conferenceName: 'Test Conference',
-        conferenceCategory: 'Technology',
+        conferenceName: "Test Conference",
+        conferenceCategory: "Technology",
         conferenceDate: new Date(),
         conferenceClosingDate: new Date(),
-        conferenceDescription: 'A test conference',
-        conferenceImage: 'https://example.com/image.jpg',
+        conferenceDescription: "A test conference",
+        conferenceImage: "https://example.com/image.jpg",
+        visibility: ConferenceVisibility.PUBLIC,
         location: {
-          country: 'Nigeria',
-          state: 'Lagos',
-          street: '123 Main St',
-          localGovernment: 'Ikeja',
-          direction: 'Near the mall',
+          country: "Nigeria",
+          state: "Lagos",
+          street: "123 Main St",
+          localGovernment: "Ikeja",
+          direction: "Near the mall",
         },
         bankDetails: {
-          bankName: 'Test Bank',
-          bankAccountNumber: '1234567890',
-          accountName: 'Test Account',
+          bankName: "Test Bank",
+          bankAccountNumber: "1234567890",
+          accountName: "Test Account",
         },
         socialMedia: {
-          facebook: 'facebook.com/test',
-          twitter: 'twitter.com/test',
-          instagram: 'instagram.com/test',
+          facebook: "facebook.com/test",
+          twitter: "twitter.com/test",
+          instagram: "instagram.com/test",
         },
       };
 
-      expect(await service.create(createDto)).toEqual(mockConference);
+      expect(await service.create(createDto, mockUser)).toEqual(mockConference);
       expect(repository.create).toHaveBeenCalled();
       expect(repository.save).toHaveBeenCalled();
     });
   });
 
-  describe('findAll', () => {
-    it('should return an array of conferences', async () => {
+  describe("findAll", () => {
+    it("should return an array of conferences", async () => {
       expect(await service.findAll()).toEqual([mockConference]);
       expect(repository.find).toHaveBeenCalled();
     });
   });
 
-  describe('findOne', () => {
-    it('should return a single conference', async () => {
+  describe("findOne", () => {
+    it("should return a single conference", async () => {
       mockRepository.findOne.mockResolvedValueOnce(mockConference);
-      expect(await service.findOne('test-id')).toEqual(mockConference);
-      expect(repository.findOne).toHaveBeenCalledWith({ where: { id: 'test-id' } });
+      expect(await service.findOne("test-id")).toEqual(mockConference);
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { id: "test-id" },
+      });
     });
 
-    it('should throw NotFoundException if conference not found', async () => {
+    it("should throw NotFoundException if conference not found", async () => {
       mockRepository.findOne.mockResolvedValueOnce(null);
-      await expect(service.findOne('non-existent-id')).rejects.toThrow(NotFoundException);
+      await expect(service.findOne("non-existent-id")).rejects.toThrow(
+        NotFoundException,
+      );
     });
   });
 
-  describe('update', () => {
-    it('should update a conference', async () => {
+  describe("update", () => {
+    it("should update a conference", async () => {
       mockRepository.findOne.mockResolvedValueOnce(mockConference);
-  
+
       const updateDto: UpdateConferenceDto = {
-        conferenceName: 'Updated Conference',
+        conferenceName: "Updated Conference",
         location: {
-          country: 'Updated Country',
-          state: 'Lagos',
-          street: '123 Main St',
-          localGovernment: 'Ikeja',
-          direction: 'Near the mall',
+          country: "Updated Country",
+          state: "Lagos",
+          street: "123 Main St",
+          localGovernment: "Ikeja",
+          direction: "Near the mall",
         },
         bankDetails: {
-          bankName: 'Updated Bank',
-          bankAccountNumber: '1234567890',
-          accountName: 'Test Account',
+          bankName: "Updated Bank",
+          bankAccountNumber: "1234567890",
+          accountName: "Test Account",
         },
       };
-  
-      expect(await service.update('test-id', updateDto)).toEqual(mockConference);
+
+      expect(await service.update("test-id", updateDto)).toEqual(
+        mockConference,
+      );
       expect(repository.save).toHaveBeenCalled();
     });
   });
-  
-  describe('remove', () => {
-    it('should delete a conference', async () => {
+
+  describe("remove", () => {
+    it("should delete a conference", async () => {
       mockRepository.findOne.mockResolvedValueOnce(mockConference);
-      await service.remove('test-id');
+      await service.remove("test-id");
       expect(repository.remove).toHaveBeenCalledWith(mockConference);
     });
   });

--- a/src/conference/providers/conference.service.ts
+++ b/src/conference/providers/conference.service.ts
@@ -58,7 +58,7 @@ export class ConferenceService {
       comingSoon: conferenceData.comingSoon || false,
       transactionCharge: conferenceData.transactionCharge || false,
       // Set the organizer
-      organizerId: user.id ?? null,
+      organizerId: (user && user?.id )? user?.id : null,
     });
 
     return this.conferenceRepository.save(conference);

--- a/src/conference/providers/conference.service.ts
+++ b/src/conference/providers/conference.service.ts
@@ -15,15 +15,23 @@ import {
   ConferenceFilterDto,
 } from "../dto";
 import { User } from "src/users/entities/user.entity";
+import { UserRole } from "src/common/enums/users-roles.enum";
+import { Cache } from "cache-manager";
+import { CACHE_MANAGER } from "@nestjs/cache-manager";
+import { Inject } from "@nestjs/common";
 
 @Injectable()
 export class ConferenceService {
   constructor(
     @InjectRepository(Conference)
     private conferenceRepository: Repository<Conference>,
+    @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
 
-  async create(createConferenceDto: CreateConferenceDto): Promise<Conference> {
+  async create(
+    createConferenceDto: CreateConferenceDto,
+    user: User,
+  ): Promise<Conference> {
     const { location, bankDetails, socialMedia, ...conferenceData } =
       createConferenceDto;
 
@@ -46,10 +54,11 @@ export class ConferenceService {
       facebook: socialMedia?.facebook,
       twitter: socialMedia?.twitter,
       instagram: socialMedia?.instagram,
-
       // Default values
       comingSoon: conferenceData.comingSoon || false,
       transactionCharge: conferenceData.transactionCharge || false,
+      // Set the organizer
+      organizerId: user.id ?? null,
     });
 
     return this.conferenceRepository.save(conference);
@@ -124,13 +133,62 @@ export class ConferenceService {
   }
 
   async findCollaborator(id: string): Promise<Conference> {
-    const conference = await this.conferenceRepository.findOne({ where: { id } });
-    
+    const conference = await this.conferenceRepository.findOne({
+      where: { id },
+    });
+
     if (!conference) {
       throw new NotFoundException(`Collaborator with ID ${id} not found`);
     }
-    
+
     return conference;
+  }
+
+  private async checkConferenceAccess(
+    conference: Conference,
+    user?: User,
+  ): Promise<boolean> {
+    if (conference.visibility === ConferenceVisibility.PUBLIC) {
+      return true;
+    }
+
+    if (!user) {
+      return false;
+    }
+
+    // Allow access if user is admin
+    if (user.role === UserRole.Admin) {
+      return true;
+    }
+
+    // Allow access if user is the organizer
+    if (conference.organizerId.toString() == user.id) {
+      return true;
+    }
+
+    // For private conferences, check if user has specific access
+    if (conference.visibility === ConferenceVisibility.PRIVATE) {
+      // TODO: Implement specific access checks (e.g., ticket holders, collaborators)
+      // Check if the user is a collaborator
+      if (
+        conference.collaborators?.some(
+          (collaborator) => collaborator.id === user.id,
+        )
+      ) {
+        return true;
+      }
+      // Check if the user has purchased a ticket for the conference
+      if (
+        conference.tickets?.some(
+          (ticketHolder) => ticketHolder.id.toString() === user.id,
+        )
+      ) {
+        return true;
+      }
+      return false;
+    }
+
+    return false;
   }
   async findAllWithFilters(filter: ConferenceFilterDto, user?: User) {
     const {
@@ -141,6 +199,17 @@ export class ConferenceService {
       page = 1,
       limit = 10,
     } = filter;
+
+    // Generate cache key based on filter parameters
+    const cacheKey = `conferences:${JSON.stringify({ name, category, location, visibility, page, limit })}`;
+
+    // Try to get cached results for public conferences
+    if (!visibility || visibility === ConferenceVisibility.PUBLIC) {
+      const cached = await this.cacheManager.get(cacheKey);
+      if (cached) {
+        return cached;
+      }
+    }
 
     let where: any = {};
 
@@ -174,8 +243,16 @@ export class ConferenceService {
       relations: ["organizer"],
     });
 
+    // Filter results based on user access
+    const accessibleResults = await Promise.all(
+      results.map(async (conference) => {
+        const hasAccess = await this.checkConferenceAccess(conference, user);
+        return hasAccess ? conference : null;
+      }),
+    ).then((results) => results.filter(Boolean));
+
     // Transform results to match the required format
-    const transformedResults = results.map((conference) => ({
+    const transformedResults = accessibleResults.map((conference) => ({
       id: conference.id,
       name: conference.conferenceName,
       category: conference.conferenceCategory,
@@ -187,14 +264,6 @@ export class ConferenceService {
         lga: conference.localGovernment,
       },
       image: conference.conferenceImage,
-      description: conference.conferenceDescription,
-      visibility: conference.visibility,
-      organizer: {
-        id: conference.organizer.id,
-        name: conference.organizer.userName,
-        firstName: conference.organizer.firstName,
-        lastName: conference.organizer.lastName,
-      },
     }));
 
     return {
@@ -205,7 +274,6 @@ export class ConferenceService {
         totalCount,
         totalPages: Math.ceil(totalCount / limit),
       },
-    }
+    };
   }
 }
-

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,29 +1,47 @@
-import { DataSource } from 'typeorm';
-import { User } from './users/entities/user.entity';
-import { Ticket } from './tickets/entities/ticket.entity';
-import { Event } from './events/entities/event.entity';
-import { Admin } from './admin/entities/admin.entity';
-import { Sponsor } from './sponsors/sponsor.entity';
-import { SpecialGuest } from './special-guests/entities/special-guest.entity';
-import { Collaborator } from './collaborator/entities/collaborator.entity';
-import { Poster } from './posters/entities/poster.entity';
-import { EventGallery } from './event-gallery/entities/event-gallery.entity';
-import { Category } from './category/category.entity';
-import { Conference } from './conference/entities/conference.entity';
-import { config } from 'dotenv';
+import { DataSource } from "typeorm";
+import { User } from "./users/entities/user.entity";
+import { Ticket } from "./tickets/entities/ticket.entity";
+import { Event } from "./events/entities/event.entity";
+import { Admin } from "./admin/entities/admin.entity";
+import { Sponsor } from "./sponsors/sponsor.entity";
+import { SpecialGuest } from "./special-guests/entities/special-guest.entity";
+import { Collaborator } from "./collaborator/entities/collaborator.entity";
+import { Poster } from "./posters/entities/poster.entity";
+import { EventGallery } from "./event-gallery/entities/event-gallery.entity";
+import { Category } from "./category/category.entity";
+import { Conference } from "./conference/entities/conference.entity";
+import { GalleryItem } from "./event-gallery/entities/gallery-item.entity";
+import { config } from "dotenv";
+import { PricingRule } from "./dynamic-pricing/pricing/entities/pricing-rule.entity";
+import { SpecialSpeaker } from "./special-speaker/entities/special-speaker.entity";
 
 // Load environment variables from .env file
 config();
 export const AppDataSource = new DataSource({
-  type: 'postgres',
+  type: "postgres",
   url: process.env.DB_URL || undefined,
   host: process.env.DB_HOST,
   port: Number(process.env.DB_PORT) || 5432,
   username: process.env.DB_USERNAME,
   password: process.env.DB_PASSWORD,
   database: process.env.DB_NAME,
-  entities: [User, Ticket, Admin, Event, Sponsor, SpecialGuest, Collaborator, Poster, EventGallery, Category, Conference],
-  migrations: ['src/migrations/*.ts'],
+  entities: [
+    User,
+    Ticket,
+    Admin,
+    Event,
+    Sponsor,
+    SpecialGuest,
+    Collaborator,
+    Poster,
+    EventGallery,
+    PricingRule,
+    Category,
+    SpecialSpeaker,
+    Conference,
+    GalleryItem,
+  ],
+  migrations: ["src/migrations/*.ts"],
   synchronize: false,
   logging: true,
 });

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -48,7 +48,7 @@ export class TicketService {
     const conference = await this.conferenceService.findOne(
       createTicketDto.eventId,
     );
-    if (!conference || conference.organizerId !== Number(user.id)) {
+    if (!conference || conference.organizerId !== user.id) {
       throw new ForbiddenException(
         "You do not have permission to create tickets for this conference",
       );
@@ -100,7 +100,7 @@ export class TicketService {
     const conference = await this.conferenceService.findOne(
       ticket.conferenceId,
     );
-    if (conference.organizerId !== Number(user.id)) {
+    if (conference.organizerId !== user.id) {
       throw new ForbiddenException(
         "You do not have permission to update this ticket",
       );
@@ -118,7 +118,7 @@ export class TicketService {
     }
 
     const conference = await this.conferenceService.findOne(ticket.eventId);
-    if (conference.organizerId !== Number(user.id)) {
+    if (conference.organizerId !== user.id) {
       throw new ForbiddenException(
         "You do not have permission to delete this ticket",
       );


### PR DESCRIPTION
## Description

 I implemented a flexible and performant API to fetch all conferences with support for filters like name, category, and location. This allows users to browse and search for conferences of interest easily.

## Related Issues
Fixes #87 

## Changes Made

- The API should return a list of conferences with fields:
`name`, `category`, `date`, `location`, `image`, `description`, etc.
- Filtering by:
 - name (partial match)
 - category (exact or partial)
 - location (country, state, street, LGA — partial or exact match)
- Supports pagination via page and limit.
- Returns metadata (totalCount, page, totalPages) alongside results.
- Optimized queries with indexes on filtered fields.
- Secure access is based on the application’s visibility rules.

## How to Test

<!-- Describe how a reviewer can test these changes. -->

## Screenshots (if applicable)
![Screenshot from 2025-05-04 13-47-31](https://github.com/user-attachments/assets/1bff26af-9139-43db-aa49-fea4e408398b)
![Screenshot from 2025-05-04 14-19-14](https://github.com/user-attachments/assets/38e50cb7-bee2-4eca-9352-3c949b42ce50)

https://github.com/user-attachments/assets/ec9085f9-838b-4fe3-a8bc-ebc6032c37d4

## Checklist

- [x] My code follows the project's coding style.
- [x] I have tested these changes locally.
- [x] Documentation has been updated where necessary.

