### PR TITLE
Implement Refund System for Ticket Organizers

### DIFF
--- a/src/refunds/controllers/refund.controller.ts
+++ b/src/refunds/controllers/refund.controller.ts
@@ -1,0 +1,80 @@
+import { Controller, Post, Get, Patch, Delete, Param, Query } from "@nestjs/common"
+import type { RefundService } from "../services/refund.service"
+import type { CreateRefundDto } from "../dto/create-refund.dto"
+import type { UpdateRefundDto } from "../dto/update-refund.dto"
+import type { BulkRefundDto } from "../dto/bulk-refund.dto"
+
+@Controller("refunds")
+export class RefundController {
+  constructor(private readonly refundService: RefundService) {}
+
+  @Post("create")
+  async createRefund(createRefundDto: CreateRefundDto) {
+    return this.refundService.createRefund(createRefundDto)
+  }
+
+  @Post("bulk")
+  async processBulkRefunds(bulkRefundDto: BulkRefundDto) {
+    return this.refundService.processBulkRefunds(bulkRefundDto)
+  }
+
+  @Post("event/:eventId/cancel-all")
+  async processEventCancellationRefunds(
+    @Param("eventId") eventId: string,
+    @Query("organizerId") organizerId: string,
+    @Query("refundPercentage") refundPercentage?: number,
+    @Query("processingFee") processingFee?: number,
+  ) {
+    return this.refundService.processEventCancellationRefunds(
+      eventId,
+      organizerId,
+      refundPercentage ? Number(refundPercentage) : 100,
+      processingFee ? Number(processingFee) : 0,
+    )
+  }
+
+  @Get(":refundId")
+  async getRefund(@Param("refundId") refundId: string) {
+    return this.refundService.getRefund(refundId)
+  }
+
+  @Get("event/:eventId")
+  async getRefundsByEvent(@Param("eventId") eventId: string, @Query("organizerId") organizerId: string) {
+    return this.refundService.getRefundsByEvent(eventId, organizerId)
+  }
+
+  @Get("purchaser/:purchaserId")
+  async getRefundsByPurchaser(@Param("purchaserId") purchaserId: string) {
+    return this.refundService.getRefundsByPurchaser(purchaserId)
+  }
+
+  @Get("event/:eventId/stats")
+  async getRefundStats(@Param("eventId") eventId: string, @Query("organizerId") organizerId: string) {
+    return this.refundService.getRefundStats(eventId, organizerId)
+  }
+
+  @Patch(":refundId/process")
+  async processRefund(@Param("refundId") refundId: string, updateDto: UpdateRefundDto) {
+    return this.refundService.processRefund(refundId, updateDto)
+  }
+
+  @Delete(":refundId")
+  async cancelRefund(@Param("refundId") refundId: string, @Query("requesterId") requesterId: string) {
+    return this.refundService.cancelRefund(refundId, requesterId)
+  }
+}
+
+// Additional controller for the specific endpoint requested
+@Controller("tickets")
+export class TicketRefundController {
+  constructor(private readonly refundService: RefundService) {}
+
+  @Post("refund/:ticketId")
+  async refundTicket(@Param("ticketId") ticketId: string, createRefundDto: any) {
+    const fullRefundDto: any = {
+      ...createRefundDto,
+      ticketId,
+    }
+    return this.refundService.createRefund(fullRefundDto)
+  }
+}

--- a/src/refunds/dto/bulk-refund.dto.ts
+++ b/src/refunds/dto/bulk-refund.dto.ts
@@ -1,0 +1,41 @@
+import { IsArray, IsUUID, IsOptional, IsEnum, IsString, IsNumber, Min, Max, IsBoolean } from "class-validator"
+import { RefundReason } from "../entities/refund.entity"
+
+export class BulkRefundDto {
+  @IsArray()
+  @IsUUID(4, { each: true })
+  ticketIds: string[]
+
+  @IsUUID()
+  processedBy: string
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  @Max(100)
+  refundPercentage?: number
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  processingFee?: number
+
+  @IsEnum(RefundReason)
+  reason: RefundReason
+
+  @IsOptional()
+  @IsString()
+  reasonDescription?: string
+
+  @IsOptional()
+  @IsString()
+  internalNotes?: string
+
+  @IsOptional()
+  @IsString()
+  customerMessage?: string
+
+  @IsOptional()
+  @IsBoolean()
+  autoProcess?: boolean = false
+}

--- a/src/refunds/dto/create-refund.dto.ts
+++ b/src/refunds/dto/create-refund.dto.ts
@@ -1,0 +1,45 @@
+import { IsUUID, IsOptional, IsNumber, IsEnum, IsString, Min, Max, IsBoolean } from "class-validator"
+import { RefundReason } from "../entities/refund.entity"
+
+export class CreateRefundDto {
+  @IsUUID()
+  ticketId: string
+
+  @IsUUID()
+  processedBy: string
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  refundAmount?: number
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  processingFee?: number
+
+  @IsEnum(RefundReason)
+  reason: RefundReason
+
+  @IsOptional()
+  @IsString()
+  reasonDescription?: string
+
+  @IsOptional()
+  @IsString()
+  internalNotes?: string
+
+  @IsOptional()
+  @IsString()
+  customerMessage?: string
+
+  @IsOptional()
+  @IsBoolean()
+  autoProcess?: boolean = false
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  refundPercentage?: number
+}

--- a/src/refunds/dto/refund-response.dto.ts
+++ b/src/refunds/dto/refund-response.dto.ts
@@ -1,0 +1,48 @@
+import type { RefundStatus, RefundReason } from "../entities/refund.entity"
+
+export class RefundResponseDto {
+  id: string
+  ticketId: string
+  ticketNumber: string
+  eventId: string
+  eventName: string
+  purchaserId: string
+  purchaserName: string
+  purchaserEmail: string
+  originalAmount: number
+  refundAmount: number
+  processingFee: number
+  reason: RefundReason
+  reasonDescription?: string
+  status: RefundStatus
+  processedBy: string
+  processedAt?: Date
+  refundTransactionId?: string
+  internalNotes?: string
+  customerMessage?: string
+  isPartialRefund: boolean
+  refundPercentage: number
+  createdAt: Date
+}
+
+export class RefundStatsDto {
+  totalRefunds: number
+  totalRefundAmount: number
+  pendingRefunds: number
+  processedRefunds: number
+  rejectedRefunds: number
+  averageRefundAmount: number
+  refundsByReason: Record<RefundReason, number>
+  refundsByStatus: Record<RefundStatus, number>
+}
+
+export class BulkRefundResponseDto {
+  success: boolean
+  message: string
+  processedRefunds: RefundResponseDto[]
+  failedRefunds: Array<{
+    ticketId: string
+    error: string
+  }>
+  totalAmount: number
+}

--- a/src/refunds/dto/update-refund.dto.ts
+++ b/src/refunds/dto/update-refund.dto.ts
@@ -1,0 +1,25 @@
+import { IsOptional, IsEnum, IsString, IsNumber, Min } from "class-validator"
+import { RefundStatus } from "../entities/refund.entity"
+
+export class UpdateRefundDto {
+  @IsOptional()
+  @IsEnum(RefundStatus)
+  status?: RefundStatus
+
+  @IsOptional()
+  @IsString()
+  refundTransactionId?: string
+
+  @IsOptional()
+  @IsString()
+  internalNotes?: string
+
+  @IsOptional()
+  @IsString()
+  customerMessage?: string
+
+  @IsOptional()
+  @IsNumber({ maxDecimalPlaces: 2 })
+  @Min(0)
+  processingFee?: number
+}

--- a/src/refunds/entities/refund.entity.ts
+++ b/src/refunds/entities/refund.entity.ts
@@ -1,0 +1,99 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, CreateDateColumn, JoinColumn } from "typeorm"
+import { Ticket } from "../../ticketing/entities/ticket.entity"
+
+export enum RefundStatus {
+  PENDING = "pending",
+  APPROVED = "approved",
+  PROCESSED = "processed",
+  REJECTED = "rejected",
+  FAILED = "failed",
+}
+
+export enum RefundReason {
+  EVENT_CANCELLED = "event_cancelled",
+  EVENT_POSTPONED = "event_postponed",
+  CUSTOMER_REQUEST = "customer_request",
+  DUPLICATE_PURCHASE = "duplicate_purchase",
+  TECHNICAL_ISSUE = "technical_issue",
+  ORGANIZER_DISCRETION = "organizer_discretion",
+  FRAUDULENT_ACTIVITY = "fraudulent_activity",
+  OTHER = "other",
+}
+
+@Entity("refunds")
+export class Refund {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  ticketId: string
+
+  @Column({ type: "uuid" })
+  eventId: string
+
+  @Column({ type: "uuid" })
+  organizerId: string
+
+  @Column({ type: "uuid" })
+  purchaserId: string
+
+  @Column({ type: "decimal", precision: 10, scale: 2 })
+  originalAmount: number
+
+  @Column({ type: "decimal", precision: 10, scale: 2 })
+  refundAmount: number
+
+  @Column({ type: "decimal", precision: 10, scale: 2, default: 0 })
+  processingFee: number
+
+  @Column({
+    type: "enum",
+    enum: RefundReason,
+    default: RefundReason.CUSTOMER_REQUEST,
+  })
+  reason: RefundReason
+
+  @Column({ type: "text", nullable: true })
+  reasonDescription: string
+
+  @Column({
+    type: "enum",
+    enum: RefundStatus,
+    default: RefundStatus.PENDING,
+  })
+  status: RefundStatus
+
+  @Column({ type: "uuid" })
+  processedBy: string // Organizer or admin who processed the refund
+
+  @Column({ type: "timestamp", nullable: true })
+  processedAt: Date
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  paymentMethod: string // Original payment method
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  refundTransactionId: string // External payment processor transaction ID
+
+  @Column({ type: "text", nullable: true })
+  internalNotes: string // Internal notes for organizers
+
+  @Column({ type: "text", nullable: true })
+  customerMessage: string // Message to send to customer
+
+  @Column({ type: "boolean", default: false })
+  isPartialRefund: boolean
+
+  @Column({ type: "int", default: 0 })
+  refundPercentage: number // Percentage of original amount being refunded
+
+  @ManyToOne(
+    () => Ticket,
+    (ticket) => ticket.id,
+  )
+  @JoinColumn({ name: "ticketId" })
+  ticket: Ticket
+
+  @CreateDateColumn()
+  createdAt: Date
+}

--- a/src/refunds/refunds.module.ts
+++ b/src/refunds/refunds.module.ts
@@ -1,0 +1,15 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { RefundController, TicketRefundController } from "./controllers/refund.controller"
+import { RefundService } from "./services/refund.service"
+import { Refund } from "./entities/refund.entity"
+import { Ticket } from "../ticketing/entities/ticket.entity"
+import { Event } from "../ticketing/entities/event.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Refund, Ticket, Event])],
+  controllers: [RefundController, TicketRefundController],
+  providers: [RefundService],
+  exports: [RefundService],
+})
+export class RefundsModule {}

--- a/src/refunds/services/refund.service.ts
+++ b/src/refunds/services/refund.service.ts
@@ -1,0 +1,428 @@
+import { Injectable, NotFoundException, BadRequestException, ForbiddenException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import { type Refund, RefundStatus, RefundReason } from "../entities/refund.entity"
+import type { Ticket } from "../../ticketing/entities/ticket.entity"
+import { TicketStatus } from "../../ticketing/entities/ticket.entity"
+import type { Event } from "../../ticketing/entities/event.entity"
+import type { CreateRefundDto } from "../dto/create-refund.dto"
+import type { UpdateRefundDto } from "../dto/update-refund.dto"
+import type { BulkRefundDto } from "../dto/bulk-refund.dto"
+import type { RefundResponseDto, RefundStatsDto, BulkRefundResponseDto } from "../dto/refund-response.dto"
+
+@Injectable()
+export class RefundService {
+  constructor(
+    private refundRepository: Repository<Refund>,
+    private ticketRepository: Repository<Ticket>,
+    private eventRepository: Repository<Event>,
+  ) {}
+
+  /**
+   * Create a refund request
+   */
+  async createRefund(createRefundDto: CreateRefundDto): Promise<RefundResponseDto> {
+    const {
+      ticketId,
+      processedBy,
+      refundAmount,
+      processingFee = 0,
+      reason,
+      reasonDescription,
+      internalNotes,
+      customerMessage,
+      autoProcess = false,
+      refundPercentage,
+    } = createRefundDto
+
+    // Get ticket with event details
+    const ticket = await this.ticketRepository.findOne({
+      where: { id: ticketId },
+      relations: ["event"],
+    })
+
+    if (!ticket) {
+      throw new NotFoundException("Ticket not found")
+    }
+
+    // Verify ticket can be refunded
+    if (ticket.status === TicketStatus.CANCELLED) {
+      throw new BadRequestException("Cannot refund a cancelled ticket")
+    }
+
+    if (ticket.status === TicketStatus.EXPIRED) {
+      throw new BadRequestException("Cannot refund an expired ticket")
+    }
+
+    // Check if refund already exists
+    const existingRefund = await this.refundRepository.findOne({
+      where: { ticketId },
+    })
+
+    if (existingRefund) {
+      throw new BadRequestException("Refund request already exists for this ticket")
+    }
+
+    // Calculate refund amount
+    let finalRefundAmount = refundAmount
+    let finalRefundPercentage = 0
+
+    if (refundPercentage !== undefined) {
+      finalRefundAmount = (Number(ticket.pricePaid) * refundPercentage) / 100
+      finalRefundPercentage = refundPercentage
+    } else if (finalRefundAmount === undefined) {
+      // Full refund by default
+      finalRefundAmount = Number(ticket.pricePaid)
+      finalRefundPercentage = 100
+    } else {
+      finalRefundPercentage = Math.round((finalRefundAmount / Number(ticket.pricePaid)) * 100)
+    }
+
+    // Validate refund amount
+    if (finalRefundAmount > Number(ticket.pricePaid)) {
+      throw new BadRequestException("Refund amount cannot exceed original ticket price")
+    }
+
+    if (finalRefundAmount < 0) {
+      throw new BadRequestException("Refund amount cannot be negative")
+    }
+
+    // Create refund record
+    const refund = this.refundRepository.create({
+      ticketId,
+      eventId: ticket.eventId,
+      organizerId: ticket.event.organizerId,
+      purchaserId: ticket.purchaserId,
+      originalAmount: Number(ticket.pricePaid),
+      refundAmount: finalRefundAmount,
+      processingFee,
+      reason,
+      reasonDescription,
+      status: autoProcess ? RefundStatus.APPROVED : RefundStatus.PENDING,
+      processedBy,
+      processedAt: autoProcess ? new Date() : null,
+      internalNotes,
+      customerMessage,
+      isPartialRefund: finalRefundPercentage < 100,
+      refundPercentage: finalRefundPercentage,
+    })
+
+    const savedRefund = await this.refundRepository.save(refund)
+
+    // If auto-processing, update ticket status
+    if (autoProcess) {
+      await this.processRefundTicket(ticket, savedRefund)
+    }
+
+    return this.mapToResponseDto(savedRefund, ticket)
+  }
+
+  /**
+   * Process a pending refund
+   */
+  async processRefund(refundId: string, updateDto: UpdateRefundDto): Promise<RefundResponseDto> {
+    const refund = await this.refundRepository.findOne({
+      where: { id: refundId },
+      relations: ["ticket", "ticket.event"],
+    })
+
+    if (!refund) {
+      throw new NotFoundException("Refund not found")
+    }
+
+    if (refund.status !== RefundStatus.PENDING && refund.status !== RefundStatus.APPROVED) {
+      throw new BadRequestException("Refund has already been processed or rejected")
+    }
+
+    // Update refund details
+    Object.assign(refund, updateDto)
+
+    if (updateDto.status === RefundStatus.PROCESSED) {
+      refund.processedAt = new Date()
+      await this.processRefundTicket(refund.ticket, refund)
+    } else if (updateDto.status === RefundStatus.REJECTED) {
+      refund.processedAt = new Date()
+    }
+
+    const updatedRefund = await this.refundRepository.save(refund)
+    return this.mapToResponseDto(updatedRefund, refund.ticket)
+  }
+
+  /**
+   * Process bulk refunds
+   */
+  async processBulkRefunds(bulkRefundDto: BulkRefundDto): Promise<BulkRefundResponseDto> {
+    const {
+      ticketIds,
+      processedBy,
+      refundPercentage = 100,
+      processingFee = 0,
+      reason,
+      reasonDescription,
+      internalNotes,
+      customerMessage,
+      autoProcess = false,
+    } = bulkRefundDto
+
+    const processedRefunds: RefundResponseDto[] = []
+    const failedRefunds: Array<{ ticketId: string; error: string }> = []
+    let totalAmount = 0
+
+    for (const ticketId of ticketIds) {
+      try {
+        const refundDto: CreateRefundDto = {
+          ticketId,
+          processedBy,
+          refundPercentage,
+          processingFee,
+          reason,
+          reasonDescription,
+          internalNotes,
+          customerMessage,
+          autoProcess,
+        }
+
+        const refund = await this.createRefund(refundDto)
+        processedRefunds.push(refund)
+        totalAmount += refund.refundAmount
+      } catch (error) {
+        failedRefunds.push({
+          ticketId,
+          error: error.message,
+        })
+      }
+    }
+
+    return {
+      success: failedRefunds.length === 0,
+      message: `Processed ${processedRefunds.length} refunds, ${failedRefunds.length} failed`,
+      processedRefunds,
+      failedRefunds,
+      totalAmount,
+    }
+  }
+
+  /**
+   * Get refund by ID
+   */
+  async getRefund(refundId: string): Promise<RefundResponseDto> {
+    const refund = await this.refundRepository.findOne({
+      where: { id: refundId },
+      relations: ["ticket", "ticket.event"],
+    })
+
+    if (!refund) {
+      throw new NotFoundException("Refund not found")
+    }
+
+    return this.mapToResponseDto(refund, refund.ticket)
+  }
+
+  /**
+   * Get refunds by event (for organizers)
+   */
+  async getRefundsByEvent(eventId: string, organizerId: string): Promise<RefundResponseDto[]> {
+    // Verify organizer owns the event
+    const event = await this.eventRepository.findOne({
+      where: { id: eventId, organizerId },
+    })
+
+    if (!event) {
+      throw new ForbiddenException("You don't have permission to view refunds for this event")
+    }
+
+    const refunds = await this.refundRepository.find({
+      where: { eventId },
+      relations: ["ticket", "ticket.event"],
+      order: { createdAt: "DESC" },
+    })
+
+    return refunds.map((refund) => this.mapToResponseDto(refund, refund.ticket))
+  }
+
+  /**
+   * Get refunds by purchaser
+   */
+  async getRefundsByPurchaser(purchaserId: string): Promise<RefundResponseDto[]> {
+    const refunds = await this.refundRepository.find({
+      where: { purchaserId },
+      relations: ["ticket", "ticket.event"],
+      order: { createdAt: "DESC" },
+    })
+
+    return refunds.map((refund) => this.mapToResponseDto(refund, refund.ticket))
+  }
+
+  /**
+   * Get refund statistics for an event
+   */
+  async getRefundStats(eventId: string, organizerId: string): Promise<RefundStatsDto> {
+    // Verify organizer owns the event
+    const event = await this.eventRepository.findOne({
+      where: { id: eventId, organizerId },
+    })
+
+    if (!event) {
+      throw new ForbiddenException("You don't have permission to view refund stats for this event")
+    }
+
+    const refunds = await this.refundRepository.find({
+      where: { eventId },
+    })
+
+    const totalRefunds = refunds.length
+    const totalRefundAmount = refunds.reduce((sum, refund) => sum + Number(refund.refundAmount), 0)
+    const pendingRefunds = refunds.filter((r) => r.status === RefundStatus.PENDING).length
+    const processedRefunds = refunds.filter((r) => r.status === RefundStatus.PROCESSED).length
+    const rejectedRefunds = refunds.filter((r) => r.status === RefundStatus.REJECTED).length
+    const averageRefundAmount = totalRefunds > 0 ? totalRefundAmount / totalRefunds : 0
+
+    // Group by reason
+    const refundsByReason = refunds.reduce(
+      (acc, refund) => {
+        acc[refund.reason] = (acc[refund.reason] || 0) + 1
+        return acc
+      },
+      {} as Record<RefundReason, number>,
+    )
+
+    // Group by status
+    const refundsByStatus = refunds.reduce(
+      (acc, refund) => {
+        acc[refund.status] = (acc[refund.status] || 0) + 1
+        return acc
+      },
+      {} as Record<RefundStatus, number>,
+    )
+
+    return {
+      totalRefunds,
+      totalRefundAmount,
+      pendingRefunds,
+      processedRefunds,
+      rejectedRefunds,
+      averageRefundAmount,
+      refundsByReason,
+      refundsByStatus,
+    }
+  }
+
+  /**
+   * Cancel a refund request (only if pending)
+   */
+  async cancelRefund(refundId: string, requesterId: string): Promise<{ success: boolean; message: string }> {
+    const refund = await this.refundRepository.findOne({
+      where: { id: refundId },
+      relations: ["ticket", "ticket.event"],
+    })
+
+    if (!refund) {
+      throw new NotFoundException("Refund not found")
+    }
+
+    // Only organizer or purchaser can cancel
+    if (refund.purchaserId !== requesterId && refund.ticket.event.organizerId !== requesterId) {
+      throw new ForbiddenException("You don't have permission to cancel this refund")
+    }
+
+    if (refund.status !== RefundStatus.PENDING) {
+      throw new BadRequestException("Can only cancel pending refund requests")
+    }
+
+    await this.refundRepository.remove(refund)
+
+    return {
+      success: true,
+      message: "Refund request cancelled successfully",
+    }
+  }
+
+  /**
+   * Process refund for event cancellation
+   */
+  async processEventCancellationRefunds(
+    eventId: string,
+    organizerId: string,
+    refundPercentage = 100,
+    processingFee = 0,
+  ): Promise<BulkRefundResponseDto> {
+    // Verify organizer owns the event
+    const event = await this.eventRepository.findOne({
+      where: { id: eventId, organizerId },
+    })
+
+    if (!event) {
+      throw new ForbiddenException("You don't have permission to process refunds for this event")
+    }
+
+    // Get all active tickets for the event
+    const tickets = await this.ticketRepository.find({
+      where: { eventId, status: TicketStatus.ACTIVE },
+    })
+
+    if (tickets.length === 0) {
+      return {
+        success: true,
+        message: "No active tickets found for refund",
+        processedRefunds: [],
+        failedRefunds: [],
+        totalAmount: 0,
+      }
+    }
+
+    const ticketIds = tickets.map((ticket) => ticket.id)
+
+    return this.processBulkRefunds({
+      ticketIds,
+      processedBy: organizerId,
+      refundPercentage,
+      processingFee,
+      reason: RefundReason.EVENT_CANCELLED,
+      reasonDescription: `Event "${event.name}" has been cancelled`,
+      customerMessage: `We apologize for the inconvenience. Your ticket for "${event.name}" has been refunded due to event cancellation.`,
+      autoProcess: true,
+    })
+  }
+
+  /**
+   * Helper method to process ticket status after refund
+   */
+  private async processRefundTicket(ticket: Ticket, refund: Refund): Promise<void> {
+    // Mark ticket as cancelled if full refund, or keep as refunded for partial
+    if (refund.refundPercentage === 100) {
+      ticket.status = TicketStatus.CANCELLED
+    }
+    // Note: We could add a REFUNDED status to TicketStatus enum if needed
+
+    await this.ticketRepository.save(ticket)
+  }
+
+  /**
+   * Helper method to map refund entity to response DTO
+   */
+  private mapToResponseDto(refund: Refund, ticket: Ticket): RefundResponseDto {
+    return {
+      id: refund.id,
+      ticketId: refund.ticketId,
+      ticketNumber: ticket.ticketNumber,
+      eventId: refund.eventId,
+      eventName: ticket.event?.name || "Unknown Event",
+      purchaserId: refund.purchaserId,
+      purchaserName: ticket.purchaserName,
+      purchaserEmail: ticket.purchaserEmail,
+      originalAmount: Number(refund.originalAmount),
+      refundAmount: Number(refund.refundAmount),
+      processingFee: Number(refund.processingFee),
+      reason: refund.reason,
+      reasonDescription: refund.reasonDescription,
+      status: refund.status,
+      processedBy: refund.processedBy,
+      processedAt: refund.processedAt,
+      refundTransactionId: refund.refundTransactionId,
+      internalNotes: refund.internalNotes,
+      customerMessage: refund.customerMessage,
+      isPartialRefund: refund.isPartialRefund,
+      refundPercentage: refund.refundPercentage,
+      createdAt: refund.createdAt,
+    }
+  }
+}

--- a/src/refunds/test/dto.spec.ts
+++ b/src/refunds/test/dto.spec.ts
@@ -1,0 +1,248 @@
+import { validate } from "class-validator"
+import { plainToClass } from "class-transformer"
+import { CreateRefundDto } from "../dto/create-refund.dto"
+import { UpdateRefundDto } from "../dto/update-refund.dto"
+import { BulkRefundDto } from "../dto/bulk-refund.dto"
+import { RefundReason, RefundStatus } from "../entities/refund.entity"
+
+describe("Refund DTOs", () => {
+  describe("CreateRefundDto", () => {
+    it("should validate valid refund creation data", async () => {
+      const refundData = {
+        ticketId: "550e8400-e29b-41d4-a716-446655440001",
+        processedBy: "550e8400-e29b-41d4-a716-446655440002",
+        refundAmount: 75.5,
+        processingFee: 2.5,
+        reason: RefundReason.CUSTOMER_REQUEST,
+        reasonDescription: "Customer unable to attend due to illness",
+        internalNotes: "Approved due to medical emergency",
+        customerMessage: "Your refund has been processed",
+        autoProcess: true,
+        refundPercentage: 75,
+      }
+
+      const dto = plainToClass(CreateRefundDto, refundData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.ticketId).toBe("550e8400-e29b-41d4-a716-446655440001")
+      expect(dto.processedBy).toBe("550e8400-e29b-41d4-a716-446655440002")
+      expect(dto.refundAmount).toBe(75.5)
+      expect(dto.processingFee).toBe(2.5)
+      expect(dto.reason).toBe(RefundReason.CUSTOMER_REQUEST)
+      expect(dto.reasonDescription).toBe("Customer unable to attend due to illness")
+      expect(dto.autoProcess).toBe(true)
+      expect(dto.refundPercentage).toBe(75)
+    })
+
+    it("should set default autoProcess to false", async () => {
+      const refundData = {
+        ticketId: "550e8400-e29b-41d4-a716-446655440001",
+        processedBy: "550e8400-e29b-41d4-a716-446655440002",
+        reason: RefundReason.CUSTOMER_REQUEST,
+      }
+
+      const dto = plainToClass(CreateRefundDto, refundData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.autoProcess).toBe(false)
+    })
+
+    it("should reject invalid UUID for ticketId", async () => {
+      const refundData = {
+        ticketId: "invalid-uuid",
+        processedBy: "550e8400-e29b-41d4-a716-446655440002",
+        reason: RefundReason.CUSTOMER_REQUEST,
+      }
+
+      const dto = plainToClass(CreateRefundDto, refundData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("ticketId")
+    })
+
+    it("should reject negative refund amount", async () => {
+      const refundData = {
+        ticketId: "550e8400-e29b-41d4-a716-446655440001",
+        processedBy: "550e8400-e29b-41d4-a716-446655440002",
+        refundAmount: -10,
+        reason: RefundReason.CUSTOMER_REQUEST,
+      }
+
+      const dto = plainToClass(CreateRefundDto, refundData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("refundAmount")
+    })
+
+    it("should reject refund percentage over 100", async () => {
+      const refundData = {
+        ticketId: "550e8400-e29b-41d4-a716-446655440001",
+        processedBy: "550e8400-e29b-41d4-a716-446655440002",
+        refundPercentage: 150,
+        reason: RefundReason.CUSTOMER_REQUEST,
+      }
+
+      const dto = plainToClass(CreateRefundDto, refundData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("refundPercentage")
+    })
+
+    it("should reject invalid refund reason", async () => {
+      const refundData = {
+        ticketId: "550e8400-e29b-41d4-a716-446655440001",
+        processedBy: "550e8400-e29b-41d4-a716-446655440002",
+        reason: "invalid_reason",
+      }
+
+      const dto = plainToClass(CreateRefundDto, refundData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("reason")
+    })
+  })
+
+  describe("UpdateRefundDto", () => {
+    it("should validate valid update data", async () => {
+      const updateData = {
+        status: RefundStatus.PROCESSED,
+        refundTransactionId: "txn-123456",
+        internalNotes: "Processed successfully",
+        customerMessage: "Your refund has been completed",
+        processingFee: 1.5,
+      }
+
+      const dto = plainToClass(UpdateRefundDto, updateData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.status).toBe(RefundStatus.PROCESSED)
+      expect(dto.refundTransactionId).toBe("txn-123456")
+      expect(dto.processingFee).toBe(1.5)
+    })
+
+    it("should allow empty update data", async () => {
+      const updateData = {}
+
+      const dto = plainToClass(UpdateRefundDto, updateData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+    })
+
+    it("should reject invalid status", async () => {
+      const updateData = {
+        status: "invalid_status",
+      }
+
+      const dto = plainToClass(UpdateRefundDto, updateData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("status")
+    })
+
+    it("should reject negative processing fee", async () => {
+      const updateData = {
+        processingFee: -5,
+      }
+
+      const dto = plainToClass(UpdateRefundDto, updateData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("processingFee")
+    })
+  })
+
+  describe("BulkRefundDto", () => {
+    it("should validate valid bulk refund data", async () => {
+      const bulkData = {
+        ticketIds: [
+          "550e8400-e29b-41d4-a716-446655440001",
+          "550e8400-e29b-41d4-a716-446655440002",
+          "550e8400-e29b-41d4-a716-446655440003",
+        ],
+        processedBy: "550e8400-e29b-41d4-a716-446655440000",
+        refundPercentage: 100,
+        processingFee: 0,
+        reason: RefundReason.EVENT_CANCELLED,
+        reasonDescription: "Event cancelled due to weather",
+        internalNotes: "Mass refund for cancelled event",
+        customerMessage: "Event cancelled, full refund issued",
+        autoProcess: true,
+      }
+
+      const dto = plainToClass(BulkRefundDto, bulkData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.ticketIds).toHaveLength(3)
+      expect(dto.refundPercentage).toBe(100)
+      expect(dto.autoProcess).toBe(true)
+    })
+
+    it("should set default autoProcess to false", async () => {
+      const bulkData = {
+        ticketIds: ["550e8400-e29b-41d4-a716-446655440001"],
+        processedBy: "550e8400-e29b-41d4-a716-446655440000",
+        reason: RefundReason.EVENT_CANCELLED,
+      }
+
+      const dto = plainToClass(BulkRefundDto, bulkData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.autoProcess).toBe(false)
+    })
+
+    it("should reject empty ticket IDs array", async () => {
+      const bulkData = {
+        ticketIds: [],
+        processedBy: "550e8400-e29b-41d4-a716-446655440000",
+        reason: RefundReason.EVENT_CANCELLED,
+      }
+
+      const dto = plainToClass(BulkRefundDto, bulkData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("ticketIds")
+    })
+
+    it("should reject invalid UUIDs in ticket IDs", async () => {
+      const bulkData = {
+        ticketIds: ["valid-550e8400-e29b-41d4-a716-446655440001", "invalid-uuid"],
+        processedBy: "550e8400-e29b-41d4-a716-446655440000",
+        reason: RefundReason.EVENT_CANCELLED,
+      }
+
+      const dto = plainToClass(BulkRefundDto, bulkData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("ticketIds")
+    })
+
+    it("should reject refund percentage over 100", async () => {
+      const bulkData = {
+        ticketIds: ["550e8400-e29b-41d4-a716-446655440001"],
+        processedBy: "550e8400-e29b-41d4-a716-446655440000",
+        refundPercentage: 150,
+        reason: RefundReason.EVENT_CANCELLED,
+      }
+
+      const dto = plainToClass(BulkRefundDto, bulkData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("refundPercentage")
+    })
+  })
+})

--- a/src/refunds/test/entities.spec.ts
+++ b/src/refunds/test/entities.spec.ts
@@ -1,0 +1,59 @@
+import { Refund, RefundStatus, RefundReason } from "../entities/refund.entity"
+
+describe("Refund Entities", () => {
+  describe("Refund", () => {
+    it("should create a refund instance", () => {
+      const refund = new Refund()
+      refund.ticketId = "ticket-1"
+      refund.eventId = "event-1"
+      refund.organizerId = "organizer-1"
+      refund.purchaserId = "user-1"
+      refund.originalAmount = 100.0
+      refund.refundAmount = 75.0
+      refund.processingFee = 5.0
+      refund.reason = RefundReason.CUSTOMER_REQUEST
+      refund.reasonDescription = "Customer unable to attend"
+      refund.status = RefundStatus.PENDING
+      refund.processedBy = "organizer-1"
+      refund.isPartialRefund = true
+      refund.refundPercentage = 75
+
+      expect(refund.ticketId).toBe("ticket-1")
+      expect(refund.eventId).toBe("event-1")
+      expect(refund.organizerId).toBe("organizer-1")
+      expect(refund.purchaserId).toBe("user-1")
+      expect(refund.originalAmount).toBe(100.0)
+      expect(refund.refundAmount).toBe(75.0)
+      expect(refund.processingFee).toBe(5.0)
+      expect(refund.reason).toBe(RefundReason.CUSTOMER_REQUEST)
+      expect(refund.reasonDescription).toBe("Customer unable to attend")
+      expect(refund.status).toBe(RefundStatus.PENDING)
+      expect(refund.processedBy).toBe("organizer-1")
+      expect(refund.isPartialRefund).toBe(true)
+      expect(refund.refundPercentage).toBe(75)
+    })
+  })
+
+  describe("RefundStatus", () => {
+    it("should validate refund status enum values", () => {
+      expect(RefundStatus.PENDING).toBe("pending")
+      expect(RefundStatus.APPROVED).toBe("approved")
+      expect(RefundStatus.PROCESSED).toBe("processed")
+      expect(RefundStatus.REJECTED).toBe("rejected")
+      expect(RefundStatus.FAILED).toBe("failed")
+    })
+  })
+
+  describe("RefundReason", () => {
+    it("should validate refund reason enum values", () => {
+      expect(RefundReason.EVENT_CANCELLED).toBe("event_cancelled")
+      expect(RefundReason.EVENT_POSTPONED).toBe("event_postponed")
+      expect(RefundReason.CUSTOMER_REQUEST).toBe("customer_request")
+      expect(RefundReason.DUPLICATE_PURCHASE).toBe("duplicate_purchase")
+      expect(RefundReason.TECHNICAL_ISSUE).toBe("technical_issue")
+      expect(RefundReason.ORGANIZER_DISCRETION).toBe("organizer_discretion")
+      expect(RefundReason.FRAUDULENT_ACTIVITY).toBe("fraudulent_activity")
+      expect(RefundReason.OTHER).toBe("other")
+    })
+  })
+})

--- a/src/refunds/test/integration/refund.integration.spec.ts
+++ b/src/refunds/test/integration/refund.integration.spec.ts
@@ -1,0 +1,490 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { RefundsModule } from "../../refunds.module"
+import { RefundService } from "../../services/refund.service"
+import { Refund, RefundStatus, RefundReason } from "../../entities/refund.entity"
+import { Event } from "../../../ticketing/entities/event.entity"
+import { Ticket, TicketStatus } from "../../../ticketing/entities/ticket.entity"
+
+describe("Refund Integration Tests", () => {
+  let module: TestingModule
+  let refundService: RefundService
+  let refundRepository: Repository<Refund>
+  let eventRepository: Repository<Event>
+  let ticketRepository: Repository<Ticket>
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: "sqlite",
+          database: ":memory:",
+          entities: [Refund, Event, Ticket],
+          synchronize: true,
+        }),
+        RefundsModule,
+      ],
+    }).compile()
+
+    refundService = module.get<RefundService>(RefundService)
+    refundRepository = module.get("RefundRepository")
+    eventRepository = module.get("EventRepository")
+    ticketRepository = module.get("TicketRepository")
+  })
+
+  afterAll(async () => {
+    await module.close()
+  })
+
+  beforeEach(async () => {
+    // Clean up database before each test
+    await refundRepository.clear()
+    await ticketRepository.clear()
+    await eventRepository.clear()
+  })
+
+  describe("End-to-End Refund Flow", () => {
+    it("should complete full refund lifecycle", async () => {
+      // 1. Create an event
+      const event = await eventRepository.save({
+        name: "Refund Test Event",
+        description: "Event for testing refunds",
+        startDate: new Date("2024-12-01T09:00:00"),
+        endDate: new Date("2024-12-01T18:00:00"),
+        location: "Test Venue",
+        organizerId: "organizer-123",
+        ticketPrice: 100.0,
+        maxCapacity: 50,
+        isActive: true,
+      })
+
+      // 2. Create a ticket
+      const ticket = await ticketRepository.save({
+        ticketNumber: "REFUND-TEST-001",
+        eventId: event.id,
+        purchaserId: "user-123",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        qrCodeData: "test-qr-data",
+        qrCodeImage: "test-qr-image",
+        secureHash: "test-hash",
+        status: TicketStatus.ACTIVE,
+        pricePaid: 100.0,
+        purchaseDate: new Date(),
+      })
+
+      // 3. Create a refund request
+      const refundResult = await refundService.createRefund({
+        ticketId: ticket.id,
+        processedBy: "organizer-123",
+        refundPercentage: 75,
+        reason: RefundReason.CUSTOMER_REQUEST,
+        reasonDescription: "Customer unable to attend due to illness",
+        internalNotes: "Medical emergency documented",
+        customerMessage: "We understand your situation and have processed a partial refund",
+      })
+
+      expect(refundResult.refundAmount).toBe(75)
+      expect(refundResult.refundPercentage).toBe(75)
+      expect(refundResult.isPartialRefund).toBe(true)
+      expect(refundResult.status).toBe(RefundStatus.PENDING)
+
+      // 4. Process the refund
+      const processedRefund = await refundService.processRefund(refundResult.id, {
+        status: RefundStatus.PROCESSED,
+        refundTransactionId: "txn-123456789",
+        customerMessage: "Your refund has been processed and will appear in your account within 3-5 business days",
+      })
+
+      expect(processedRefund.status).toBe(RefundStatus.PROCESSED)
+      expect(processedRefund.refundTransactionId).toBe("txn-123456789")
+      expect(processedRefund.processedAt).toBeDefined()
+
+      // 5. Verify ticket status was updated
+      const updatedTicket = await ticketRepository.findOne({
+        where: { id: ticket.id },
+      })
+      // For partial refunds, ticket remains active but refund is recorded
+      expect(updatedTicket?.status).toBe(TicketStatus.ACTIVE)
+
+      // 6. Get refund statistics
+      const stats = await refundService.getRefundStats(event.id, "organizer-123")
+      expect(stats.totalRefunds).toBe(1)
+      expect(stats.totalRefundAmount).toBe(75)
+      expect(stats.processedRefunds).toBe(1)
+      expect(stats.pendingRefunds).toBe(0)
+      expect(stats.refundsByReason[RefundReason.CUSTOMER_REQUEST]).toBe(1)
+    })
+
+    it("should handle full refund and cancel ticket", async () => {
+      // Create event and ticket
+      const event = await eventRepository.save({
+        name: "Full Refund Test Event",
+        startDate: new Date("2024-12-01T09:00:00"),
+        endDate: new Date("2024-12-01T18:00:00"),
+        location: "Test Venue",
+        organizerId: "organizer-123",
+        ticketPrice: 150.0,
+        maxCapacity: 100,
+        isActive: true,
+      })
+
+      const ticket = await ticketRepository.save({
+        ticketNumber: "FULL-REFUND-001",
+        eventId: event.id,
+        purchaserId: "user-456",
+        purchaserName: "Jane Smith",
+        purchaserEmail: "jane@example.com",
+        qrCodeData: "test-qr-data-2",
+        qrCodeImage: "test-qr-image-2",
+        secureHash: "test-hash-2",
+        status: TicketStatus.ACTIVE,
+        pricePaid: 150.0,
+        purchaseDate: new Date(),
+      })
+
+      // Create and auto-process full refund
+      const refundResult = await refundService.createRefund({
+        ticketId: ticket.id,
+        processedBy: "organizer-123",
+        refundPercentage: 100,
+        reason: RefundReason.EVENT_CANCELLED,
+        reasonDescription: "Event cancelled due to venue issues",
+        autoProcess: true,
+      })
+
+      expect(refundResult.refundAmount).toBe(150)
+      expect(refundResult.refundPercentage).toBe(100)
+      expect(refundResult.isPartialRefund).toBe(false)
+      expect(refundResult.status).toBe(RefundStatus.APPROVED)
+
+      // Verify ticket was cancelled for full refund
+      const updatedTicket = await ticketRepository.findOne({
+        where: { id: ticket.id },
+      })
+      expect(updatedTicket?.status).toBe(TicketStatus.CANCELLED)
+    })
+
+    it("should process bulk refunds for event cancellation", async () => {
+      // Create event
+      const event = await eventRepository.save({
+        name: "Bulk Refund Test Event",
+        startDate: new Date("2024-12-01T09:00:00"),
+        endDate: new Date("2024-12-01T18:00:00"),
+        location: "Test Venue",
+        organizerId: "organizer-123",
+        ticketPrice: 75.0,
+        maxCapacity: 100,
+        isActive: true,
+      })
+
+      // Create multiple tickets
+      const tickets = await Promise.all([
+        ticketRepository.save({
+          ticketNumber: "BULK-001",
+          eventId: event.id,
+          purchaserId: "user-1",
+          purchaserName: "User One",
+          purchaserEmail: "user1@example.com",
+          qrCodeData: "qr-1",
+          qrCodeImage: "img-1",
+          secureHash: "hash-1",
+          status: TicketStatus.ACTIVE,
+          pricePaid: 75.0,
+          purchaseDate: new Date(),
+        }),
+        ticketRepository.save({
+          ticketNumber: "BULK-002",
+          eventId: event.id,
+          purchaserId: "user-2",
+          purchaserName: "User Two",
+          purchaserEmail: "user2@example.com",
+          qrCodeData: "qr-2",
+          qrCodeImage: "img-2",
+          secureHash: "hash-2",
+          status: TicketStatus.ACTIVE,
+          pricePaid: 75.0,
+          purchaseDate: new Date(),
+        }),
+        ticketRepository.save({
+          ticketNumber: "BULK-003",
+          eventId: event.id,
+          purchaserId: "user-3",
+          purchaserName: "User Three",
+          purchaserEmail: "user3@example.com",
+          qrCodeData: "qr-3",
+          qrCodeImage: "img-3",
+          secureHash: "hash-3",
+          status: TicketStatus.ACTIVE,
+          pricePaid: 75.0,
+          purchaseDate: new Date(),
+        }),
+      ])
+
+      // Process event cancellation refunds
+      const bulkResult = await refundService.processEventCancellationRefunds(
+        event.id,
+        "organizer-123",
+        100, // 100% refund
+        0, // No processing fee
+      )
+
+      expect(bulkResult.success).toBe(true)
+      expect(bulkResult.processedRefunds).toHaveLength(3)
+      expect(bulkResult.failedRefunds).toHaveLength(0)
+      expect(bulkResult.totalAmount).toBe(225) // 3 * 75
+
+      // Verify all tickets were cancelled
+      const updatedTickets = await ticketRepository.find({
+        where: { eventId: event.id },
+      })
+      expect(updatedTickets.every((t) => t.status === TicketStatus.CANCELLED)).toBe(true)
+
+      // Verify refunds were created
+      const refunds = await refundRepository.find({
+        where: { eventId: event.id },
+      })
+      expect(refunds).toHaveLength(3)
+      expect(refunds.every((r) => r.reason === RefundReason.EVENT_CANCELLED)).toBe(true)
+      expect(refunds.every((r) => r.status === RefundStatus.APPROVED)).toBe(true)
+    })
+
+    it("should handle partial bulk refunds with processing fees", async () => {
+      // Create event
+      const event = await eventRepository.save({
+        name: "Partial Bulk Refund Event",
+        startDate: new Date("2024-12-01T09:00:00"),
+        endDate: new Date("2024-12-01T18:00:00"),
+        location: "Test Venue",
+        organizerId: "organizer-123",
+        ticketPrice: 100.0,
+        maxCapacity: 50,
+        isActive: true,
+      })
+
+      // Create tickets
+      const tickets = await Promise.all([
+        ticketRepository.save({
+          ticketNumber: "PARTIAL-001",
+          eventId: event.id,
+          purchaserId: "user-1",
+          purchaserName: "User One",
+          purchaserEmail: "user1@example.com",
+          qrCodeData: "qr-1",
+          qrCodeImage: "img-1",
+          secureHash: "hash-1",
+          status: TicketStatus.ACTIVE,
+          pricePaid: 100.0,
+          purchaseDate: new Date(),
+        }),
+        ticketRepository.save({
+          ticketNumber: "PARTIAL-002",
+          eventId: event.id,
+          purchaserId: "user-2",
+          purchaserName: "User Two",
+          purchaserEmail: "user2@example.com",
+          qrCodeData: "qr-2",
+          qrCodeImage: "img-2",
+          secureHash: "hash-2",
+          status: TicketStatus.ACTIVE,
+          pricePaid: 100.0,
+          purchaseDate: new Date(),
+        }),
+      ])
+
+      // Process bulk partial refunds
+      const bulkResult = await refundService.processBulkRefunds({
+        ticketIds: tickets.map((t) => t.id),
+        processedBy: "organizer-123",
+        refundPercentage: 80,
+        processingFee: 5.0,
+        reason: RefundReason.EVENT_POSTPONED,
+        reasonDescription: "Event postponed, offering 80% refund",
+        customerMessage: "Event postponed. You can attend the new date or accept this partial refund.",
+        autoProcess: true,
+      })
+
+      expect(bulkResult.success).toBe(true)
+      expect(bulkResult.processedRefunds).toHaveLength(2)
+      expect(bulkResult.totalAmount).toBe(160) // 2 * 80
+
+      // Verify refunds have correct amounts and fees
+      const refunds = await refundRepository.find({
+        where: { eventId: event.id },
+      })
+      expect(refunds).toHaveLength(2)
+      expect(refunds.every((r) => r.refundAmount === 80)).toBe(true)
+      expect(refunds.every((r) => r.processingFee === 5)).toBe(true)
+      expect(refunds.every((r) => r.isPartialRefund === true)).toBe(true)
+      expect(refunds.every((r) => r.refundPercentage === 80)).toBe(true)
+
+      // Tickets should remain active for partial refunds
+      const updatedTickets = await ticketRepository.find({
+        where: { eventId: event.id },
+      })
+      expect(updatedTickets.every((t) => t.status === TicketStatus.ACTIVE)).toBe(true)
+    })
+
+    it("should prevent duplicate refunds", async () => {
+      // Create event and ticket
+      const event = await eventRepository.save({
+        name: "Duplicate Refund Test",
+        startDate: new Date("2024-12-01T09:00:00"),
+        endDate: new Date("2024-12-01T18:00:00"),
+        location: "Test Venue",
+        organizerId: "organizer-123",
+        ticketPrice: 50.0,
+        maxCapacity: 100,
+        isActive: true,
+      })
+
+      const ticket = await ticketRepository.save({
+        ticketNumber: "DUPLICATE-001",
+        eventId: event.id,
+        purchaserId: "user-123",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        qrCodeData: "qr-data",
+        qrCodeImage: "qr-image",
+        secureHash: "hash",
+        status: TicketStatus.ACTIVE,
+        pricePaid: 50.0,
+        purchaseDate: new Date(),
+      })
+
+      // Create first refund
+      const firstRefund = await refundService.createRefund({
+        ticketId: ticket.id,
+        processedBy: "organizer-123",
+        reason: RefundReason.CUSTOMER_REQUEST,
+      })
+
+      expect(firstRefund).toBeDefined()
+
+      // Try to create second refund for same ticket (should fail)
+      await expect(
+        refundService.createRefund({
+          ticketId: ticket.id,
+          processedBy: "organizer-123",
+          reason: RefundReason.DUPLICATE_PURCHASE,
+        }),
+      ).rejects.toThrow("Refund request already exists for this ticket")
+    })
+
+    it("should handle refund cancellation", async () => {
+      // Create event and ticket
+      const event = await eventRepository.save({
+        name: "Refund Cancellation Test",
+        startDate: new Date("2024-12-01T09:00:00"),
+        endDate: new Date("2024-12-01T18:00:00"),
+        location: "Test Venue",
+        organizerId: "organizer-123",
+        ticketPrice: 80.0,
+        maxCapacity: 100,
+        isActive: true,
+      })
+
+      const ticket = await ticketRepository.save({
+        ticketNumber: "CANCEL-001",
+        eventId: event.id,
+        purchaserId: "user-123",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        qrCodeData: "qr-data",
+        qrCodeImage: "qr-image",
+        secureHash: "hash",
+        status: TicketStatus.ACTIVE,
+        pricePaid: 80.0,
+        purchaseDate: new Date(),
+      })
+
+      // Create refund request
+      const refund = await refundService.createRefund({
+        ticketId: ticket.id,
+        processedBy: "organizer-123",
+        reason: RefundReason.CUSTOMER_REQUEST,
+      })
+
+      expect(refund.status).toBe(RefundStatus.PENDING)
+
+      // Cancel the refund request
+      const cancelResult = await refundService.cancelRefund(refund.id, "user-123")
+      expect(cancelResult.success).toBe(true)
+
+      // Verify refund was removed
+      const deletedRefund = await refundRepository.findOne({
+        where: { id: refund.id },
+      })
+      expect(deletedRefund).toBeNull()
+    })
+  })
+
+  describe("Authorization and Security", () => {
+    it("should enforce organizer authorization for event refunds", async () => {
+      const event = await eventRepository.save({
+        name: "Authorization Test Event",
+        startDate: new Date("2024-12-01T09:00:00"),
+        endDate: new Date("2024-12-01T18:00:00"),
+        location: "Test Venue",
+        organizerId: "organizer-123",
+        ticketPrice: 100.0,
+        maxCapacity: 100,
+        isActive: true,
+      })
+
+      // Try to get refunds with wrong organizer ID
+      await expect(refundService.getRefundsByEvent(event.id, "wrong-organizer")).rejects.toThrow(
+        "You don't have permission to view refunds for this event",
+      )
+
+      // Try to get stats with wrong organizer ID
+      await expect(refundService.getRefundStats(event.id, "wrong-organizer")).rejects.toThrow(
+        "You don't have permission to view refund stats for this event",
+      )
+
+      // Try to process event cancellation with wrong organizer ID
+      await expect(refundService.processEventCancellationRefunds(event.id, "wrong-organizer")).rejects.toThrow(
+        "You don't have permission to process refunds for this event",
+      )
+    })
+
+    it("should enforce refund cancellation authorization", async () => {
+      const event = await eventRepository.save({
+        name: "Cancellation Auth Test",
+        startDate: new Date("2024-12-01T09:00:00"),
+        endDate: new Date("2024-12-01T18:00:00"),
+        location: "Test Venue",
+        organizerId: "organizer-123",
+        ticketPrice: 100.0,
+        maxCapacity: 100,
+        isActive: true,
+      })
+
+      const ticket = await ticketRepository.save({
+        ticketNumber: "AUTH-001",
+        eventId: event.id,
+        purchaserId: "user-123",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        qrCodeData: "qr-data",
+        qrCodeImage: "qr-image",
+        secureHash: "hash",
+        status: TicketStatus.ACTIVE,
+        pricePaid: 100.0,
+        purchaseDate: new Date(),
+      })
+
+      const refund = await refundService.createRefund({
+        ticketId: ticket.id,
+        processedBy: "organizer-123",
+        reason: RefundReason.CUSTOMER_REQUEST,
+      })
+
+      // Try to cancel with unauthorized user
+      await expect(refundService.cancelRefund(refund.id, "unauthorized-user")).rejects.toThrow(
+        "You don't have permission to cancel this refund",
+      )
+    })
+  })
+})

--- a/src/refunds/test/refund.controller.spec.ts
+++ b/src/refunds/test/refund.controller.spec.ts
@@ -1,0 +1,288 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { RefundController, TicketRefundController } from "../controllers/refund.controller"
+import { RefundService } from "../services/refund.service"
+import { RefundReason, RefundStatus } from "../entities/refund.entity"
+import type { CreateRefundDto } from "../dto/create-refund.dto"
+import type { BulkRefundDto } from "../dto/bulk-refund.dto"
+import { jest } from "@jest/globals"
+
+describe("RefundController", () => {
+  let controller: RefundController
+  let ticketController: TicketRefundController
+  let refundService: RefundService
+
+  const mockRefundService = {
+    createRefund: jest.fn(),
+    processBulkRefunds: jest.fn(),
+    processEventCancellationRefunds: jest.fn(),
+    getRefund: jest.fn(),
+    getRefundsByEvent: jest.fn(),
+    getRefundsByPurchaser: jest.fn(),
+    getRefundStats: jest.fn(),
+    processRefund: jest.fn(),
+    cancelRefund: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [RefundController, TicketRefundController],
+      providers: [
+        {
+          provide: RefundService,
+          useValue: mockRefundService,
+        },
+      ],
+    }).compile()
+
+    controller = module.get<RefundController>(RefundController)
+    ticketController = module.get<TicketRefundController>(TicketRefundController)
+    refundService = module.get<RefundService>(RefundService)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+    expect(ticketController).toBeDefined()
+  })
+
+  describe("RefundController", () => {
+    describe("createRefund", () => {
+      it("should create a refund successfully", async () => {
+        const createRefundDto: CreateRefundDto = {
+          ticketId: "ticket-1",
+          processedBy: "organizer-1",
+          reason: RefundReason.CUSTOMER_REQUEST,
+          reasonDescription: "Customer request",
+        }
+
+        const mockResponse = {
+          id: "refund-1",
+          ticketId: "ticket-1",
+          refundAmount: 100,
+          status: RefundStatus.PENDING,
+        }
+
+        mockRefundService.createRefund.mockResolvedValue(mockResponse)
+
+        const result = await controller.createRefund(createRefundDto)
+
+        expect(result).toEqual(mockResponse)
+        expect(mockRefundService.createRefund).toHaveBeenCalledWith(createRefundDto)
+      })
+    })
+
+    describe("processBulkRefunds", () => {
+      it("should process bulk refunds successfully", async () => {
+        const bulkRefundDto: BulkRefundDto = {
+          ticketIds: ["ticket-1", "ticket-2"],
+          processedBy: "organizer-1",
+          reason: RefundReason.EVENT_CANCELLED,
+          refundPercentage: 100,
+        }
+
+        const mockResponse = {
+          success: true,
+          message: "Processed 2 refunds, 0 failed",
+          processedRefunds: [],
+          failedRefunds: [],
+          totalAmount: 250,
+        }
+
+        mockRefundService.processBulkRefunds.mockResolvedValue(mockResponse)
+
+        const result = await controller.processBulkRefunds(bulkRefundDto)
+
+        expect(result).toEqual(mockResponse)
+        expect(mockRefundService.processBulkRefunds).toHaveBeenCalledWith(bulkRefundDto)
+      })
+    })
+
+    describe("processEventCancellationRefunds", () => {
+      it("should process event cancellation refunds", async () => {
+        const eventId = "event-1"
+        const organizerId = "organizer-1"
+        const refundPercentage = 100
+        const processingFee = 5
+
+        const mockResponse = {
+          success: true,
+          message: "Processed 5 refunds",
+          processedRefunds: [],
+          failedRefunds: [],
+          totalAmount: 500,
+        }
+
+        mockRefundService.processEventCancellationRefunds.mockResolvedValue(mockResponse)
+
+        const result = await controller.processEventCancellationRefunds(
+          eventId,
+          organizerId,
+          refundPercentage,
+          processingFee,
+        )
+
+        expect(result).toEqual(mockResponse)
+        expect(mockRefundService.processEventCancellationRefunds).toHaveBeenCalledWith(eventId, organizerId, 100, 5)
+      })
+
+      it("should use default values when parameters not provided", async () => {
+        const eventId = "event-1"
+        const organizerId = "organizer-1"
+
+        mockRefundService.processEventCancellationRefunds.mockResolvedValue({})
+
+        await controller.processEventCancellationRefunds(eventId, organizerId)
+
+        expect(mockRefundService.processEventCancellationRefunds).toHaveBeenCalledWith(eventId, organizerId, 100, 0)
+      })
+    })
+
+    describe("getRefund", () => {
+      it("should get refund by ID", async () => {
+        const refundId = "refund-1"
+        const mockRefund = {
+          id: refundId,
+          ticketId: "ticket-1",
+          refundAmount: 100,
+        }
+
+        mockRefundService.getRefund.mockResolvedValue(mockRefund)
+
+        const result = await controller.getRefund(refundId)
+
+        expect(result).toEqual(mockRefund)
+        expect(mockRefundService.getRefund).toHaveBeenCalledWith(refundId)
+      })
+    })
+
+    describe("getRefundsByEvent", () => {
+      it("should get refunds by event", async () => {
+        const eventId = "event-1"
+        const organizerId = "organizer-1"
+        const mockRefunds = [
+          { id: "refund-1", eventId },
+          { id: "refund-2", eventId },
+        ]
+
+        mockRefundService.getRefundsByEvent.mockResolvedValue(mockRefunds)
+
+        const result = await controller.getRefundsByEvent(eventId, organizerId)
+
+        expect(result).toEqual(mockRefunds)
+        expect(mockRefundService.getRefundsByEvent).toHaveBeenCalledWith(eventId, organizerId)
+      })
+    })
+
+    describe("getRefundsByPurchaser", () => {
+      it("should get refunds by purchaser", async () => {
+        const purchaserId = "user-1"
+        const mockRefunds = [
+          { id: "refund-1", purchaserId },
+          { id: "refund-2", purchaserId },
+        ]
+
+        mockRefundService.getRefundsByPurchaser.mockResolvedValue(mockRefunds)
+
+        const result = await controller.getRefundsByPurchaser(purchaserId)
+
+        expect(result).toEqual(mockRefunds)
+        expect(mockRefundService.getRefundsByPurchaser).toHaveBeenCalledWith(purchaserId)
+      })
+    })
+
+    describe("getRefundStats", () => {
+      it("should get refund statistics", async () => {
+        const eventId = "event-1"
+        const organizerId = "organizer-1"
+        const mockStats = {
+          totalRefunds: 10,
+          totalRefundAmount: 1000,
+          pendingRefunds: 2,
+          processedRefunds: 7,
+          rejectedRefunds: 1,
+        }
+
+        mockRefundService.getRefundStats.mockResolvedValue(mockStats)
+
+        const result = await controller.getRefundStats(eventId, organizerId)
+
+        expect(result).toEqual(mockStats)
+        expect(mockRefundService.getRefundStats).toHaveBeenCalledWith(eventId, organizerId)
+      })
+    })
+
+    describe("processRefund", () => {
+      it("should process a refund", async () => {
+        const refundId = "refund-1"
+        const updateDto = {
+          status: RefundStatus.PROCESSED,
+          refundTransactionId: "txn-123",
+        }
+
+        const mockResponse = {
+          id: refundId,
+          status: RefundStatus.PROCESSED,
+        }
+
+        mockRefundService.processRefund.mockResolvedValue(mockResponse)
+
+        const result = await controller.processRefund(refundId, updateDto)
+
+        expect(result).toEqual(mockResponse)
+        expect(mockRefundService.processRefund).toHaveBeenCalledWith(refundId, updateDto)
+      })
+    })
+
+    describe("cancelRefund", () => {
+      it("should cancel a refund", async () => {
+        const refundId = "refund-1"
+        const requesterId = "user-1"
+        const mockResponse = {
+          success: true,
+          message: "Refund request cancelled successfully",
+        }
+
+        mockRefundService.cancelRefund.mockResolvedValue(mockResponse)
+
+        const result = await controller.cancelRefund(refundId, requesterId)
+
+        expect(result).toEqual(mockResponse)
+        expect(mockRefundService.cancelRefund).toHaveBeenCalledWith(refundId, requesterId)
+      })
+    })
+  })
+
+  describe("TicketRefundController", () => {
+    describe("refundTicket", () => {
+      it("should create refund for specific ticket", async () => {
+        const ticketId = "ticket-1"
+        const refundDto = {
+          processedBy: "organizer-1",
+          reason: RefundReason.CUSTOMER_REQUEST,
+          reasonDescription: "Customer request",
+        }
+
+        const expectedDto: CreateRefundDto = {
+          ...refundDto,
+          ticketId,
+        }
+
+        const mockResponse = {
+          id: "refund-1",
+          ticketId,
+          refundAmount: 100,
+        }
+
+        mockRefundService.createRefund.mockResolvedValue(mockResponse)
+
+        const result = await ticketController.refundTicket(ticketId, refundDto)
+
+        expect(result).toEqual(mockResponse)
+        expect(mockRefundService.createRefund).toHaveBeenCalledWith(expectedDto)
+      })
+    })
+  })
+})

--- a/src/refunds/test/refund.service.spec.ts
+++ b/src/refunds/test/refund.service.spec.ts
@@ -1,0 +1,496 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { NotFoundException, BadRequestException, ForbiddenException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import { RefundService } from "../services/refund.service"
+import { Refund, RefundStatus, RefundReason } from "../entities/refund.entity"
+import { Ticket, TicketStatus } from "../../ticketing/entities/ticket.entity"
+import { Event } from "../../ticketing/entities/event.entity"
+import type { CreateRefundDto } from "../dto/create-refund.dto"
+import { jest } from "@jest/globals"
+
+describe("RefundService", () => {
+  let service: RefundService
+  let refundRepository: Repository<Refund>
+  let ticketRepository: Repository<Ticket>
+  let eventRepository: Repository<Event>
+
+  const mockRefundRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    findOne: jest.fn(),
+    find: jest.fn(),
+    remove: jest.fn(),
+  }
+
+  const mockTicketRepository = {
+    findOne: jest.fn(),
+    find: jest.fn(),
+    save: jest.fn(),
+  }
+
+  const mockEventRepository = {
+    findOne: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        RefundService,
+        {
+          provide: getRepositoryToken(Refund),
+          useValue: mockRefundRepository,
+        },
+        {
+          provide: getRepositoryToken(Ticket),
+          useValue: mockTicketRepository,
+        },
+        {
+          provide: getRepositoryToken(Event),
+          useValue: mockEventRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<RefundService>(RefundService)
+    refundRepository = module.get<Repository<Refund>>(getRepositoryToken(Refund))
+    ticketRepository = module.get<Repository<Ticket>>(getRepositoryToken(Ticket))
+    eventRepository = module.get<Repository<Event>>(getRepositoryToken(Event))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("createRefund", () => {
+    const mockTicket: Ticket = {
+      id: "ticket-1",
+      ticketNumber: "TICKET-123",
+      eventId: "event-1",
+      purchaserId: "user-1",
+      purchaserName: "John Doe",
+      purchaserEmail: "john@example.com",
+      pricePaid: 100,
+      status: TicketStatus.ACTIVE,
+      event: {
+        id: "event-1",
+        name: "Test Event",
+        organizerId: "organizer-1",
+      } as Event,
+    } as Ticket
+
+    const createRefundDto: CreateRefundDto = {
+      ticketId: "ticket-1",
+      processedBy: "organizer-1",
+      reason: RefundReason.CUSTOMER_REQUEST,
+      reasonDescription: "Customer request",
+    }
+
+    it("should create a full refund successfully", async () => {
+      mockTicketRepository.findOne.mockResolvedValue(mockTicket)
+      mockRefundRepository.findOne.mockResolvedValue(null) // No existing refund
+      mockRefundRepository.create.mockReturnValue({
+        id: "refund-1",
+        ticketId: "ticket-1",
+        refundAmount: 100,
+        refundPercentage: 100,
+        isPartialRefund: false,
+      })
+      mockRefundRepository.save.mockResolvedValue({
+        id: "refund-1",
+        ticketId: "ticket-1",
+        refundAmount: 100,
+        refundPercentage: 100,
+        isPartialRefund: false,
+        status: RefundStatus.PENDING,
+      })
+
+      const result = await service.createRefund(createRefundDto)
+
+      expect(result).toBeDefined()
+      expect(result.refundAmount).toBe(100)
+      expect(result.refundPercentage).toBe(100)
+      expect(result.isPartialRefund).toBe(false)
+      expect(mockRefundRepository.create).toHaveBeenCalled()
+      expect(mockRefundRepository.save).toHaveBeenCalled()
+    })
+
+    it("should create a partial refund with percentage", async () => {
+      const partialRefundDto = {
+        ...createRefundDto,
+        refundPercentage: 50,
+      }
+
+      mockTicketRepository.findOne.mockResolvedValue(mockTicket)
+      mockRefundRepository.findOne.mockResolvedValue(null)
+      mockRefundRepository.create.mockReturnValue({
+        id: "refund-1",
+        refundAmount: 50,
+        refundPercentage: 50,
+        isPartialRefund: true,
+      })
+      mockRefundRepository.save.mockResolvedValue({
+        id: "refund-1",
+        refundAmount: 50,
+        refundPercentage: 50,
+        isPartialRefund: true,
+      })
+
+      const result = await service.createRefund(partialRefundDto)
+
+      expect(result.refundAmount).toBe(50)
+      expect(result.refundPercentage).toBe(50)
+      expect(result.isPartialRefund).toBe(true)
+    })
+
+    it("should create a partial refund with specific amount", async () => {
+      const partialRefundDto = {
+        ...createRefundDto,
+        refundAmount: 75,
+      }
+
+      mockTicketRepository.findOne.mockResolvedValue(mockTicket)
+      mockRefundRepository.findOne.mockResolvedValue(null)
+      mockRefundRepository.create.mockReturnValue({
+        id: "refund-1",
+        refundAmount: 75,
+        refundPercentage: 75,
+        isPartialRefund: true,
+      })
+      mockRefundRepository.save.mockResolvedValue({
+        id: "refund-1",
+        refundAmount: 75,
+        refundPercentage: 75,
+        isPartialRefund: true,
+      })
+
+      const result = await service.createRefund(partialRefundDto)
+
+      expect(result.refundAmount).toBe(75)
+      expect(result.refundPercentage).toBe(75)
+      expect(result.isPartialRefund).toBe(true)
+    })
+
+    it("should throw NotFoundException for non-existent ticket", async () => {
+      mockTicketRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.createRefund(createRefundDto)).rejects.toThrow(NotFoundException)
+    })
+
+    it("should throw BadRequestException for cancelled ticket", async () => {
+      const cancelledTicket = { ...mockTicket, status: TicketStatus.CANCELLED }
+      mockTicketRepository.findOne.mockResolvedValue(cancelledTicket)
+
+      await expect(service.createRefund(createRefundDto)).rejects.toThrow(BadRequestException)
+    })
+
+    it("should throw BadRequestException if refund already exists", async () => {
+      mockTicketRepository.findOne.mockResolvedValue(mockTicket)
+      mockRefundRepository.findOne.mockResolvedValue({ id: "existing-refund" })
+
+      await expect(service.createRefund(createRefundDto)).rejects.toThrow(BadRequestException)
+    })
+
+    it("should throw BadRequestException for refund amount exceeding ticket price", async () => {
+      const invalidRefundDto = {
+        ...createRefundDto,
+        refundAmount: 150, // More than ticket price of 100
+      }
+
+      mockTicketRepository.findOne.mockResolvedValue(mockTicket)
+      mockRefundRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.createRefund(invalidRefundDto)).rejects.toThrow(BadRequestException)
+    })
+
+    it("should auto-process refund when autoProcess is true", async () => {
+      const autoProcessDto = {
+        ...createRefundDto,
+        autoProcess: true,
+      }
+
+      mockTicketRepository.findOne.mockResolvedValue(mockTicket)
+      mockRefundRepository.findOne.mockResolvedValue(null)
+      mockRefundRepository.create.mockReturnValue({
+        id: "refund-1",
+        status: RefundStatus.APPROVED,
+        processedAt: new Date(),
+      })
+      mockRefundRepository.save.mockResolvedValue({
+        id: "refund-1",
+        status: RefundStatus.APPROVED,
+        processedAt: new Date(),
+      })
+      mockTicketRepository.save.mockResolvedValue(mockTicket)
+
+      const result = await service.createRefund(autoProcessDto)
+
+      expect(result.status).toBe(RefundStatus.APPROVED)
+      expect(mockTicketRepository.save).toHaveBeenCalled()
+    })
+  })
+
+  describe("processRefund", () => {
+    const mockRefund = {
+      id: "refund-1",
+      status: RefundStatus.PENDING,
+      ticket: {
+        id: "ticket-1",
+        status: TicketStatus.ACTIVE,
+      },
+      refundPercentage: 100,
+    }
+
+    it("should process a pending refund", async () => {
+      mockRefundRepository.findOne.mockResolvedValue(mockRefund)
+      mockRefundRepository.save.mockResolvedValue({
+        ...mockRefund,
+        status: RefundStatus.PROCESSED,
+        processedAt: new Date(),
+      })
+      mockTicketRepository.save.mockResolvedValue(mockRefund.ticket)
+
+      const result = await service.processRefund("refund-1", {
+        status: RefundStatus.PROCESSED,
+        refundTransactionId: "txn-123",
+      })
+
+      expect(result.status).toBe(RefundStatus.PROCESSED)
+      expect(mockRefundRepository.save).toHaveBeenCalled()
+      expect(mockTicketRepository.save).toHaveBeenCalled()
+    })
+
+    it("should throw NotFoundException for non-existent refund", async () => {
+      mockRefundRepository.findOne.mockResolvedValue(null)
+
+      await expect(
+        service.processRefund("non-existent", {
+          status: RefundStatus.PROCESSED,
+        }),
+      ).rejects.toThrow(NotFoundException)
+    })
+
+    it("should throw BadRequestException for already processed refund", async () => {
+      const processedRefund = {
+        ...mockRefund,
+        status: RefundStatus.PROCESSED,
+      }
+      mockRefundRepository.findOne.mockResolvedValue(processedRefund)
+
+      await expect(
+        service.processRefund("refund-1", {
+          status: RefundStatus.PROCESSED,
+        }),
+      ).rejects.toThrow(BadRequestException)
+    })
+  })
+
+  describe("getRefundsByEvent", () => {
+    it("should return refunds for authorized organizer", async () => {
+      const mockEvent = {
+        id: "event-1",
+        organizerId: "organizer-1",
+      }
+      const mockRefunds = [
+        {
+          id: "refund-1",
+          eventId: "event-1",
+          ticket: { ticketNumber: "TICKET-123", event: { name: "Test Event" } },
+        },
+      ]
+
+      mockEventRepository.findOne.mockResolvedValue(mockEvent)
+      mockRefundRepository.find.mockResolvedValue(mockRefunds)
+
+      const result = await service.getRefundsByEvent("event-1", "organizer-1")
+
+      expect(result).toHaveLength(1)
+      expect(mockEventRepository.findOne).toHaveBeenCalledWith({
+        where: { id: "event-1", organizerId: "organizer-1" },
+      })
+    })
+
+    it("should throw ForbiddenException for unauthorized organizer", async () => {
+      mockEventRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.getRefundsByEvent("event-1", "wrong-organizer")).rejects.toThrow(ForbiddenException)
+    })
+  })
+
+  describe("processBulkRefunds", () => {
+    it("should process multiple refunds successfully", async () => {
+      const bulkRefundDto = {
+        ticketIds: ["ticket-1", "ticket-2"],
+        processedBy: "organizer-1",
+        refundPercentage: 100,
+        reason: RefundReason.EVENT_CANCELLED,
+        autoProcess: true,
+      }
+
+      const mockTicket1 = {
+        id: "ticket-1",
+        pricePaid: 100,
+        status: TicketStatus.ACTIVE,
+        event: { organizerId: "organizer-1", name: "Test Event" },
+      }
+      const mockTicket2 = {
+        id: "ticket-2",
+        pricePaid: 150,
+        status: TicketStatus.ACTIVE,
+        event: { organizerId: "organizer-1", name: "Test Event" },
+      }
+
+      // Mock successful refund creation for both tickets
+      mockTicketRepository.findOne.mockResolvedValueOnce(mockTicket1).mockResolvedValueOnce(mockTicket2)
+      mockRefundRepository.findOne.mockResolvedValue(null) // No existing refunds
+      mockRefundRepository.create
+        .mockReturnValueOnce({ id: "refund-1", refundAmount: 100 })
+        .mockReturnValueOnce({ id: "refund-2", refundAmount: 150 })
+      mockRefundRepository.save
+        .mockResolvedValueOnce({ id: "refund-1", refundAmount: 100 })
+        .mockResolvedValueOnce({ id: "refund-2", refundAmount: 150 })
+
+      const result = await service.processBulkRefunds(bulkRefundDto)
+
+      expect(result.success).toBe(true)
+      expect(result.processedRefunds).toHaveLength(2)
+      expect(result.failedRefunds).toHaveLength(0)
+      expect(result.totalAmount).toBe(250)
+    })
+
+    it("should handle partial failures in bulk processing", async () => {
+      const bulkRefundDto = {
+        ticketIds: ["ticket-1", "non-existent-ticket"],
+        processedBy: "organizer-1",
+        refundPercentage: 100,
+        reason: RefundReason.EVENT_CANCELLED,
+      }
+
+      const mockTicket1 = {
+        id: "ticket-1",
+        pricePaid: 100,
+        status: TicketStatus.ACTIVE,
+        event: { organizerId: "organizer-1", name: "Test Event" },
+      }
+
+      // First ticket succeeds, second fails
+      mockTicketRepository.findOne.mockResolvedValueOnce(mockTicket1).mockResolvedValueOnce(null)
+      mockRefundRepository.findOne.mockResolvedValue(null)
+      mockRefundRepository.create.mockReturnValue({ id: "refund-1", refundAmount: 100 })
+      mockRefundRepository.save.mockResolvedValue({ id: "refund-1", refundAmount: 100 })
+
+      const result = await service.processBulkRefunds(bulkRefundDto)
+
+      expect(result.success).toBe(false)
+      expect(result.processedRefunds).toHaveLength(1)
+      expect(result.failedRefunds).toHaveLength(1)
+      expect(result.failedRefunds[0].ticketId).toBe("non-existent-ticket")
+    })
+  })
+
+  describe("getRefundStats", () => {
+    it("should return comprehensive refund statistics", async () => {
+      const mockEvent = {
+        id: "event-1",
+        organizerId: "organizer-1",
+      }
+
+      const mockRefunds = [
+        {
+          refundAmount: 100,
+          status: RefundStatus.PROCESSED,
+          reason: RefundReason.CUSTOMER_REQUEST,
+        },
+        {
+          refundAmount: 150,
+          status: RefundStatus.PENDING,
+          reason: RefundReason.EVENT_CANCELLED,
+        },
+        {
+          refundAmount: 75,
+          status: RefundStatus.REJECTED,
+          reason: RefundReason.CUSTOMER_REQUEST,
+        },
+      ]
+
+      mockEventRepository.findOne.mockResolvedValue(mockEvent)
+      mockRefundRepository.find.mockResolvedValue(mockRefunds)
+
+      const result = await service.getRefundStats("event-1", "organizer-1")
+
+      expect(result.totalRefunds).toBe(3)
+      expect(result.totalRefundAmount).toBe(325)
+      expect(result.pendingRefunds).toBe(1)
+      expect(result.processedRefunds).toBe(1)
+      expect(result.rejectedRefunds).toBe(1)
+      expect(result.averageRefundAmount).toBeCloseTo(108.33, 2)
+      expect(result.refundsByReason[RefundReason.CUSTOMER_REQUEST]).toBe(2)
+      expect(result.refundsByStatus[RefundStatus.PROCESSED]).toBe(1)
+    })
+  })
+
+  describe("cancelRefund", () => {
+    it("should cancel a pending refund by purchaser", async () => {
+      const mockRefund = {
+        id: "refund-1",
+        status: RefundStatus.PENDING,
+        purchaserId: "user-1",
+        ticket: { event: { organizerId: "organizer-1" } },
+      }
+
+      mockRefundRepository.findOne.mockResolvedValue(mockRefund)
+      mockRefundRepository.remove.mockResolvedValue(mockRefund)
+
+      const result = await service.cancelRefund("refund-1", "user-1")
+
+      expect(result.success).toBe(true)
+      expect(mockRefundRepository.remove).toHaveBeenCalledWith(mockRefund)
+    })
+
+    it("should cancel a pending refund by organizer", async () => {
+      const mockRefund = {
+        id: "refund-1",
+        status: RefundStatus.PENDING,
+        purchaserId: "user-1",
+        ticket: { event: { organizerId: "organizer-1" } },
+      }
+
+      mockRefundRepository.findOne.mockResolvedValue(mockRefund)
+      mockRefundRepository.remove.mockResolvedValue(mockRefund)
+
+      const result = await service.cancelRefund("refund-1", "organizer-1")
+
+      expect(result.success).toBe(true)
+    })
+
+    it("should throw ForbiddenException for unauthorized user", async () => {
+      const mockRefund = {
+        id: "refund-1",
+        status: RefundStatus.PENDING,
+        purchaserId: "user-1",
+        ticket: { event: { organizerId: "organizer-1" } },
+      }
+
+      mockRefundRepository.findOne.mockResolvedValue(mockRefund)
+
+      await expect(service.cancelRefund("refund-1", "unauthorized-user")).rejects.toThrow(ForbiddenException)
+    })
+
+    it("should throw BadRequestException for non-pending refund", async () => {
+      const mockRefund = {
+        id: "refund-1",
+        status: RefundStatus.PROCESSED,
+        purchaserId: "user-1",
+        ticket: { event: { organizerId: "organizer-1" } },
+      }
+
+      mockRefundRepository.findOne.mockResolvedValue(mockRefund)
+
+      await expect(service.cancelRefund("refund-1", "user-1")).rejects.toThrow(BadRequestException)
+    })
+  })
+})


### PR DESCRIPTION
This PR introduces a refund system that allows event organizers to issue full or partial refunds for purchased tickets. It includes:

* A new endpoint: `POST /tickets/refund/:ticketId`
* Functionality to mark tickets as refunded and update the ticket quantity
* Support for specifying an optional refund amount and reason

This lays the foundation for managing refunds within the platform and improves event handling flexibility.

closes #224 
