### PR TITLE
Add Event Analytics Dashboard Endpoint

### DIFF
--- a/src/event-analytics/controllers/event-analytics.controller.ts
+++ b/src/event-analytics/controllers/event-analytics.controller.ts
@@ -1,0 +1,86 @@
+import { Controller, Get, Post } from "@nestjs/common"
+import type { Request } from "express"
+import type { EventAnalyticsService } from "../services/event-analytics.service"
+import type { AnalyticsTrackingService } from "../services/analytics-tracking.service"
+import type { TrackViewDto } from "../dto/track-view.dto"
+import type { TrackPurchaseDto } from "../dto/track-purchase.dto"
+import type { TrackEngagementDto } from "../dto/track-engagement.dto"
+import type { AnalyticsFilterDto } from "../dto/analytics-response.dto"
+
+@Controller("events")
+export class EventAnalyticsController {
+  private readonly eventAnalyticsService: EventAnalyticsService
+  private readonly analyticsTrackingService: AnalyticsTrackingService
+
+  constructor(eventAnalyticsService: EventAnalyticsService, analyticsTrackingService: AnalyticsTrackingService) {
+    this.eventAnalyticsService = eventAnalyticsService
+    this.analyticsTrackingService = analyticsTrackingService
+  }
+
+  @Get(":id/analytics")
+  async getEventAnalytics(eventId: string, organizerId: string, filters: AnalyticsFilterDto) {
+    return this.eventAnalyticsService.getEventAnalytics(eventId, organizerId, filters)
+  }
+
+  @Post(":id/track/view")
+  async trackView(eventId: string, trackViewDto: TrackViewDto, req: Request) {
+    const ipAddress = req.ip || req.connection.remoteAddress
+    const userAgent = req.headers["user-agent"]
+
+    // Parse user agent if not provided
+    if (userAgent && !trackViewDto.deviceType) {
+      const parsed = this.analyticsTrackingService.parseUserAgent(userAgent)
+      trackViewDto.deviceType = parsed.deviceType
+      trackViewDto.browser = parsed.browser
+      trackViewDto.operatingSystem = parsed.operatingSystem
+    }
+
+    // Get location from IP if not provided
+    if (ipAddress && !trackViewDto.country) {
+      const location = await this.analyticsTrackingService.getLocationFromIP(ipAddress)
+      trackViewDto.country = location.country
+      trackViewDto.city = location.city
+    }
+
+    await this.analyticsTrackingService.trackView(
+      {
+        ...trackViewDto,
+        eventId,
+        userAgent,
+      },
+      ipAddress,
+    )
+
+    return { success: true, message: "View tracked successfully" }
+  }
+
+  @Post(":id/track/purchase")
+  async trackPurchase(eventId: string, trackPurchaseDto: TrackPurchaseDto, req: Request) {
+    const ipAddress = req.ip || req.connection.remoteAddress
+
+    await this.analyticsTrackingService.trackPurchase(
+      {
+        ...trackPurchaseDto,
+        eventId,
+      },
+      ipAddress,
+    )
+
+    return { success: true, message: "Purchase tracked successfully" }
+  }
+
+  @Post(":id/track/engagement")
+  async trackEngagement(eventId: string, trackEngagementDto: TrackEngagementDto, req: Request) {
+    const ipAddress = req.ip || req.connection.remoteAddress
+
+    await this.analyticsTrackingService.trackEngagement(
+      {
+        ...trackEngagementDto,
+        eventId,
+      },
+      ipAddress,
+    )
+
+    return { success: true, message: "Engagement tracked successfully" }
+  }
+}

--- a/src/event-analytics/dto/analytics-response.dto.ts
+++ b/src/event-analytics/dto/analytics-response.dto.ts
@@ -1,0 +1,168 @@
+import { IsOptional } from "class-validator"
+
+export class EventAnalyticsDto {
+  // Basic Event Info
+  eventId: string
+  eventName: string
+  eventDate: Date
+  ticketPrice: number
+  maxCapacity: number
+
+  // Sales Metrics
+  salesMetrics: {
+    totalTicketsSold: number
+    totalRevenue: number
+    averageOrderValue: number
+    conversionRate: number
+    refundRate: number
+    grossRevenue: number
+    netRevenue: number
+    discountAmount: number
+    salesByDay: Array<{
+      date: string
+      tickets: number
+      revenue: number
+    }>
+    salesByHour: Array<{
+      hour: number
+      tickets: number
+      revenue: number
+    }>
+  }
+
+  // Traffic Metrics
+  trafficMetrics: {
+    totalViews: number
+    uniqueVisitors: number
+    averageTimeOnPage: number
+    bounceRate: number
+    viewsBySource: Array<{
+      source: string
+      views: number
+      uniqueVisitors: number
+      conversions: number
+      conversionRate: number
+    }>
+    viewsByDevice: Array<{
+      device: string
+      views: number
+      percentage: number
+    }>
+    viewsByCountry: Array<{
+      country: string
+      views: number
+      percentage: number
+    }>
+    viewsByDay: Array<{
+      date: string
+      views: number
+      uniqueVisitors: number
+    }>
+  }
+
+  // Engagement Metrics
+  engagementMetrics: {
+    totalEngagements: number
+    engagementRate: number
+    engagementsByType: Array<{
+      type: string
+      count: number
+      percentage: number
+    }>
+    socialShares: number
+    favorites: number
+    newsletterSignups: number
+    calendarAdds: number
+  }
+
+  // Campaign Performance
+  campaignMetrics: {
+    utmCampaigns: Array<{
+      campaign: string
+      source: string
+      medium: string
+      views: number
+      conversions: number
+      revenue: number
+      roi: number
+    }>
+    topPerformingCampaigns: Array<{
+      campaign: string
+      conversions: number
+      revenue: number
+      conversionRate: number
+    }>
+  }
+
+  // Demographic Insights
+  demographicMetrics: {
+    topCountries: Array<{
+      country: string
+      visitors: number
+      purchases: number
+      revenue: number
+    }>
+    topCities: Array<{
+      city: string
+      visitors: number
+      purchases: number
+      revenue: number
+    }>
+    deviceBreakdown: Array<{
+      device: string
+      visitors: number
+      purchases: number
+      conversionRate: number
+    }>
+  }
+
+  // Time-based Analysis
+  timeAnalysis: {
+    peakViewingHours: Array<{
+      hour: number
+      views: number
+    }>
+    peakPurchaseHours: Array<{
+      hour: number
+      purchases: number
+      revenue: number
+    }>
+    salesVelocity: Array<{
+      date: string
+      cumulativeTickets: number
+      cumulativeRevenue: number
+    }>
+  }
+
+  // Funnel Analysis
+  funnelMetrics: {
+    viewToTicketView: number
+    ticketViewToPurchase: number
+    overallConversion: number
+    dropOffPoints: Array<{
+      stage: string
+      dropOffRate: number
+      suggestions: string[]
+    }>
+  }
+}
+
+export class AnalyticsFilterDto {
+  @IsOptional()
+  startDate?: string
+
+  @IsOptional()
+  endDate?: string
+
+  @IsOptional()
+  trafficSource?: string
+
+  @IsOptional()
+  deviceType?: string
+
+  @IsOptional()
+  country?: string
+
+  @IsOptional()
+  includeRefunded?: boolean
+}

--- a/src/event-analytics/dto/track-engagement.dto.ts
+++ b/src/event-analytics/dto/track-engagement.dto.ts
@@ -1,0 +1,26 @@
+import { IsUUID, IsEnum, IsOptional, IsString, IsObject } from "class-validator"
+import { EngagementType } from "../entities/event-engagement.entity"
+
+export class TrackEngagementDto {
+  @IsUUID()
+  eventId: string
+
+  @IsOptional()
+  @IsUUID()
+  userId?: string
+
+  @IsEnum(EngagementType)
+  engagementType: EngagementType
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>
+
+  @IsOptional()
+  @IsString()
+  trafficSource?: string
+
+  @IsOptional()
+  @IsString()
+  deviceType?: string
+}

--- a/src/event-analytics/dto/track-purchase.dto.ts
+++ b/src/event-analytics/dto/track-purchase.dto.ts
@@ -1,0 +1,79 @@
+import { IsUUID, IsString, IsNumber, IsOptional, Min } from "class-validator"
+
+export class TrackPurchaseDto {
+  @IsUUID()
+  eventId: string
+
+  @IsUUID()
+  purchaserId: string
+
+  @IsString()
+  purchaserName: string
+
+  @IsString()
+  purchaserEmail: string
+
+  @IsNumber()
+  @Min(1)
+  quantity: number
+
+  @IsNumber()
+  @Min(0)
+  unitPrice: number
+
+  @IsNumber()
+  @Min(0)
+  totalAmount: number
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  discountAmount?: number
+
+  @IsOptional()
+  @IsString()
+  discountCode?: string
+
+  @IsString()
+  status: string
+
+  @IsOptional()
+  @IsString()
+  paymentMethod?: string
+
+  @IsOptional()
+  @IsString()
+  transactionId?: string
+
+  @IsOptional()
+  @IsString()
+  trafficSource?: string
+
+  @IsOptional()
+  @IsString()
+  referrerUrl?: string
+
+  @IsOptional()
+  @IsString()
+  utmSource?: string
+
+  @IsOptional()
+  @IsString()
+  utmMedium?: string
+
+  @IsOptional()
+  @IsString()
+  utmCampaign?: string
+
+  @IsOptional()
+  @IsString()
+  deviceType?: string
+
+  @IsOptional()
+  @IsString()
+  country?: string
+
+  @IsOptional()
+  @IsString()
+  city?: string
+}

--- a/src/event-analytics/dto/track-view.dto.ts
+++ b/src/event-analytics/dto/track-view.dto.ts
@@ -1,0 +1,76 @@
+import { IsUUID, IsOptional, IsString, IsNumber, IsBoolean, Min, Max } from "class-validator"
+
+export class TrackViewDto {
+  @IsUUID()
+  eventId: string
+
+  @IsOptional()
+  @IsUUID()
+  userId?: string
+
+  @IsOptional()
+  @IsString()
+  trafficSource?: string
+
+  @IsOptional()
+  @IsString()
+  referrerUrl?: string
+
+  @IsOptional()
+  @IsString()
+  utmSource?: string
+
+  @IsOptional()
+  @IsString()
+  utmMedium?: string
+
+  @IsOptional()
+  @IsString()
+  utmCampaign?: string
+
+  @IsOptional()
+  @IsString()
+  utmTerm?: string
+
+  @IsOptional()
+  @IsString()
+  utmContent?: string
+
+  @IsOptional()
+  @IsString()
+  userAgent?: string
+
+  @IsOptional()
+  @IsString()
+  deviceType?: string
+
+  @IsOptional()
+  @IsString()
+  browser?: string
+
+  @IsOptional()
+  @IsString()
+  operatingSystem?: string
+
+  @IsOptional()
+  @IsString()
+  country?: string
+
+  @IsOptional()
+  @IsString()
+  city?: string
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(86400) // Max 24 hours
+  timeOnPage?: number
+
+  @IsOptional()
+  @IsBoolean()
+  convertedToPurchase?: boolean
+
+  @IsOptional()
+  @IsUUID()
+  purchaseId?: string
+}

--- a/src/event-analytics/entities/event-engagement.entity.ts
+++ b/src/event-analytics/entities/event-engagement.entity.ts
@@ -1,0 +1,54 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from "typeorm"
+
+export enum EngagementType {
+  PAGE_VIEW = "page_view",
+  TICKET_VIEW = "ticket_view",
+  SHARE = "share",
+  FAVORITE = "favorite",
+  COMMENT = "comment",
+  REVIEW = "review",
+  NEWSLETTER_SIGNUP = "newsletter_signup",
+  CALENDAR_ADD = "calendar_add",
+  CONTACT_ORGANIZER = "contact_organizer",
+}
+
+@Entity("event_engagements")
+@Index(["eventId", "engagementType", "createdAt"])
+@Index(["userId", "createdAt"])
+export class EventEngagement {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  @Index()
+  eventId: string
+
+  @Column({ type: "uuid", nullable: true })
+  @Index()
+  userId: string
+
+  @Column({
+    type: "enum",
+    enum: EngagementType,
+  })
+  @Index()
+  engagementType: EngagementType
+
+  @Column({ type: "json", nullable: true })
+  metadata: Record<string, any> // Additional data specific to engagement type
+
+  @Column({ type: "varchar", length: 45, nullable: true })
+  ipAddress: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  trafficSource: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  deviceType: string
+
+  @CreateDateColumn()
+  @Index()
+  createdAt: Date
+}

--- a/src/event-analytics/entities/event-view.entity.ts
+++ b/src/event-analytics/entities/event-view.entity.ts
@@ -1,0 +1,81 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from "typeorm"
+
+@Entity("event_views")
+@Index(["eventId", "createdAt"])
+@Index(["trafficSource", "createdAt"])
+@Index(["userAgent", "createdAt"])
+export class EventView {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  @Index()
+  eventId: string
+
+  @Column({ type: "uuid", nullable: true })
+  @Index()
+  userId: string // null for anonymous users
+
+  @Column({ type: "varchar", length: 45, nullable: true })
+  @Index()
+  ipAddress: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  trafficSource: string // organic, social, email, direct, referral, paid
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  referrerUrl: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  utmSource: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  utmMedium: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  utmCampaign: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  utmTerm: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  utmContent: string
+
+  @Column({ type: "text", nullable: true })
+  userAgent: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  deviceType: string // desktop, mobile, tablet
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  browser: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  operatingSystem: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  country: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  city: string
+
+  @Column({ type: "int", default: 0 })
+  timeOnPage: number // seconds spent on event page
+
+  @Column({ type: "boolean", default: false })
+  @Index()
+  convertedToPurchase: boolean
+
+  @Column({ type: "uuid", nullable: true })
+  purchaseId: string // links to ticket purchase if converted
+
+  @CreateDateColumn()
+  @Index()
+  createdAt: Date
+}

--- a/src/event-analytics/entities/purchase-log.entity.ts
+++ b/src/event-analytics/entities/purchase-log.entity.ts
@@ -1,0 +1,87 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, Index } from "typeorm"
+
+@Entity("purchase_logs")
+@Index(["eventId", "createdAt"])
+@Index(["purchaserId", "createdAt"])
+@Index(["status", "createdAt"])
+export class PurchaseLog {
+  @PrimaryGeneratedColumn("uuid")
+  id: string
+
+  @Column({ type: "uuid" })
+  @Index()
+  eventId: string
+
+  @Column({ type: "uuid" })
+  @Index()
+  purchaserId: string
+
+  @Column({ type: "varchar", length: 255 })
+  purchaserName: string
+
+  @Column({ type: "varchar", length: 255 })
+  purchaserEmail: string
+
+  @Column({ type: "int" })
+  quantity: number
+
+  @Column({ type: "decimal", precision: 10, scale: 2 })
+  unitPrice: number
+
+  @Column({ type: "decimal", precision: 10, scale: 2 })
+  totalAmount: number
+
+  @Column({ type: "decimal", precision: 10, scale: 2, default: 0 })
+  discountAmount: number
+
+  @Column({ type: "varchar", length: 50, nullable: true })
+  discountCode: string
+
+  @Column({ type: "varchar", length: 50 })
+  @Index()
+  status: string // completed, failed, pending, refunded
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  paymentMethod: string
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  transactionId: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  trafficSource: string
+
+  @Column({ type: "varchar", length: 255, nullable: true })
+  referrerUrl: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  utmSource: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  utmMedium: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  utmCampaign: string
+
+  @Column({ type: "varchar", length: 45, nullable: true })
+  ipAddress: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  deviceType: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  country: string
+
+  @Column({ type: "varchar", length: 100, nullable: true })
+  @Index()
+  city: string
+
+  @Column({ type: "timestamp", nullable: true })
+  completedAt: Date
+
+  @CreateDateColumn()
+  @Index()
+  createdAt: Date
+}

--- a/src/event-analytics/event-analytics.module.ts
+++ b/src/event-analytics/event-analytics.module.ts
@@ -1,0 +1,18 @@
+import { Module } from "@nestjs/common"
+import { TypeOrmModule } from "@nestjs/typeorm"
+import { EventAnalyticsController } from "./controllers/event-analytics.controller"
+import { EventAnalyticsService } from "./services/event-analytics.service"
+import { AnalyticsTrackingService } from "./services/analytics-tracking.service"
+import { EventView } from "./entities/event-view.entity"
+import { PurchaseLog } from "./entities/purchase-log.entity"
+import { EventEngagement } from "./entities/event-engagement.entity"
+import { Event } from "../ticketing/entities/event.entity"
+import { Refund } from "../refunds/entities/refund.entity"
+
+@Module({
+  imports: [TypeOrmModule.forFeature([EventView, PurchaseLog, EventEngagement, Event, Refund])],
+  controllers: [EventAnalyticsController],
+  providers: [EventAnalyticsService, AnalyticsTrackingService],
+  exports: [EventAnalyticsService, AnalyticsTrackingService],
+})
+export class EventAnalyticsModule {}

--- a/src/event-analytics/services/analytics-tracking.service.ts
+++ b/src/event-analytics/services/analytics-tracking.service.ts
@@ -1,0 +1,162 @@
+import { Injectable } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import type { EventView } from "../entities/event-view.entity"
+import type { PurchaseLog } from "../entities/purchase-log.entity"
+import type { EventEngagement } from "../entities/event-engagement.entity"
+import type { TrackViewDto } from "../dto/track-view.dto"
+import type { TrackPurchaseDto } from "../dto/track-purchase.dto"
+import type { TrackEngagementDto } from "../dto/track-engagement.dto"
+
+@Injectable()
+export class AnalyticsTrackingService {
+  constructor(
+    private eventViewRepository: Repository<EventView>,
+    private purchaseLogRepository: Repository<PurchaseLog>,
+    private eventEngagementRepository: Repository<EventEngagement>,
+  ) {}
+
+  /**
+   * Track event page view
+   */
+  async trackView(trackViewDto: TrackViewDto, ipAddress?: string): Promise<void> {
+    const eventView = this.eventViewRepository.create({
+      ...trackViewDto,
+      ipAddress: ipAddress || trackViewDto.ipAddress,
+      trafficSource: this.normalizeTrafficSource(trackViewDto.trafficSource, trackViewDto.referrerUrl),
+    })
+
+    await this.eventViewRepository.save(eventView)
+  }
+
+  /**
+   * Track ticket purchase
+   */
+  async trackPurchase(trackPurchaseDto: TrackPurchaseDto, ipAddress?: string): Promise<void> {
+    const purchaseLog = this.purchaseLogRepository.create({
+      ...trackPurchaseDto,
+      ipAddress: ipAddress || trackPurchaseDto.ipAddress,
+      trafficSource: this.normalizeTrafficSource(trackPurchaseDto.trafficSource, trackPurchaseDto.referrerUrl),
+      completedAt: trackPurchaseDto.status === "completed" ? new Date() : null,
+    })
+
+    await this.purchaseLogRepository.save(purchaseLog)
+
+    // Update conversion flag for related views
+    if (trackPurchaseDto.status === "completed") {
+      await this.updateViewConversion(trackPurchaseDto.eventId, trackPurchaseDto.purchaserId, purchaseLog.id)
+    }
+  }
+
+  /**
+   * Track user engagement
+   */
+  async trackEngagement(trackEngagementDto: TrackEngagementDto, ipAddress?: string): Promise<void> {
+    const engagement = this.eventEngagementRepository.create({
+      ...trackEngagementDto,
+      ipAddress,
+      trafficSource: this.normalizeTrafficSource(trackEngagementDto.trafficSource),
+    })
+
+    await this.eventEngagementRepository.save(engagement)
+  }
+
+  /**
+   * Update view conversion status
+   */
+  private async updateViewConversion(eventId: string, userId: string, purchaseId: string): Promise<void> {
+    await this.eventViewRepository.update(
+      {
+        eventId,
+        userId,
+        convertedToPurchase: false,
+      },
+      {
+        convertedToPurchase: true,
+        purchaseId,
+      },
+    )
+  }
+
+  /**
+   * Normalize traffic source based on referrer and UTM parameters
+   */
+  private normalizeTrafficSource(trafficSource?: string, referrerUrl?: string): string {
+    if (trafficSource) {
+      return trafficSource.toLowerCase()
+    }
+
+    if (!referrerUrl) {
+      return "direct"
+    }
+
+    const referrer = referrerUrl.toLowerCase()
+
+    // Social media sources
+    if (referrer.includes("facebook.com") || referrer.includes("fb.com")) return "facebook"
+    if (referrer.includes("twitter.com") || referrer.includes("t.co")) return "twitter"
+    if (referrer.includes("linkedin.com")) return "linkedin"
+    if (referrer.includes("instagram.com")) return "instagram"
+    if (referrer.includes("youtube.com")) return "youtube"
+    if (referrer.includes("tiktok.com")) return "tiktok"
+
+    // Search engines
+    if (referrer.includes("google.com")) return "google"
+    if (referrer.includes("bing.com")) return "bing"
+    if (referrer.includes("yahoo.com")) return "yahoo"
+    if (referrer.includes("duckduckgo.com")) return "duckduckgo"
+
+    // Email providers
+    if (referrer.includes("gmail.com") || referrer.includes("outlook.com") || referrer.includes("yahoo.com")) {
+      return "email"
+    }
+
+    // Default to referral
+    return "referral"
+  }
+
+  /**
+   * Parse user agent for device information
+   */
+  parseUserAgent(userAgent: string): {
+    deviceType: string
+    browser: string
+    operatingSystem: string
+  } {
+    const ua = userAgent.toLowerCase()
+
+    // Device type detection
+    let deviceType = "desktop"
+    if (ua.includes("mobile") || ua.includes("android")) deviceType = "mobile"
+    else if (ua.includes("tablet") || ua.includes("ipad")) deviceType = "tablet"
+
+    // Browser detection
+    let browser = "unknown"
+    if (ua.includes("chrome")) browser = "chrome"
+    else if (ua.includes("firefox")) browser = "firefox"
+    else if (ua.includes("safari")) browser = "safari"
+    else if (ua.includes("edge")) browser = "edge"
+    else if (ua.includes("opera")) browser = "opera"
+
+    // OS detection
+    let operatingSystem = "unknown"
+    if (ua.includes("windows")) operatingSystem = "windows"
+    else if (ua.includes("mac")) operatingSystem = "macos"
+    else if (ua.includes("linux")) operatingSystem = "linux"
+    else if (ua.includes("android")) operatingSystem = "android"
+    else if (ua.includes("ios")) operatingSystem = "ios"
+
+    return { deviceType, browser, operatingSystem }
+  }
+
+  /**
+   * Get IP-based location (placeholder - integrate with IP geolocation service)
+   */
+  async getLocationFromIP(ipAddress: string): Promise<{ country: string; city: string }> {
+    // Placeholder implementation
+    // In production, integrate with services like MaxMind, IPStack, or similar
+    return {
+      country: "Unknown",
+      city: "Unknown",
+    }
+  }
+}

--- a/src/event-analytics/services/event-analytics.service.ts
+++ b/src/event-analytics/services/event-analytics.service.ts
@@ -1,0 +1,699 @@
+import { Injectable, ForbiddenException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import { Between } from "typeorm"
+import type { EventView } from "../entities/event-view.entity"
+import type { PurchaseLog } from "../entities/purchase-log.entity"
+import { type EventEngagement, EngagementType } from "../entities/event-engagement.entity"
+import type { Event } from "../../ticketing/entities/event.entity"
+import type { Refund } from "../../refunds/entities/refund.entity"
+import type { EventAnalyticsDto, AnalyticsFilterDto } from "../dto/analytics-response.dto"
+
+@Injectable()
+export class EventAnalyticsService {
+  constructor(
+    private eventViewRepository: Repository<EventView>,
+    private purchaseLogRepository: Repository<PurchaseLog>,
+    private eventEngagementRepository: Repository<EventEngagement>,
+    private eventRepository: Repository<Event>,
+    private refundRepository: Repository<Refund>,
+  ) {}
+
+  /**
+   * Get comprehensive analytics for an event
+   */
+  async getEventAnalytics(
+    eventId: string,
+    organizerId: string,
+    filters: AnalyticsFilterDto = {},
+  ): Promise<EventAnalyticsDto> {
+    // Verify organizer owns the event
+    const event = await this.eventRepository.findOne({
+      where: { id: eventId, organizerId },
+    })
+
+    if (!event) {
+      throw new ForbiddenException("You don't have permission to view analytics for this event")
+    }
+
+    const dateRange = this.getDateRange(filters)
+
+    const [
+      salesMetrics,
+      trafficMetrics,
+      engagementMetrics,
+      campaignMetrics,
+      demographicMetrics,
+      timeAnalysis,
+      funnelMetrics,
+    ] = await Promise.all([
+      this.getSalesMetrics(eventId, dateRange, filters),
+      this.getTrafficMetrics(eventId, dateRange, filters),
+      this.getEngagementMetrics(eventId, dateRange, filters),
+      this.getCampaignMetrics(eventId, dateRange, filters),
+      this.getDemographicMetrics(eventId, dateRange, filters),
+      this.getTimeAnalysis(eventId, dateRange, filters),
+      this.getFunnelMetrics(eventId, dateRange, filters),
+    ])
+
+    return {
+      eventId: event.id,
+      eventName: event.name,
+      eventDate: event.startDate,
+      ticketPrice: Number(event.ticketPrice),
+      maxCapacity: event.maxCapacity,
+      salesMetrics,
+      trafficMetrics,
+      engagementMetrics,
+      campaignMetrics,
+      demographicMetrics,
+      timeAnalysis,
+      funnelMetrics,
+    }
+  }
+
+  /**
+   * Get sales metrics
+   */
+  private async getSalesMetrics(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<EventAnalyticsDto["salesMetrics"]> {
+    const baseQuery = this.purchaseLogRepository
+      .createQueryBuilder("purchase")
+      .where("purchase.eventId = :eventId", { eventId })
+      .andWhere("purchase.createdAt BETWEEN :start AND :end", dateRange)
+
+    if (filters.trafficSource) {
+      baseQuery.andWhere("purchase.trafficSource = :trafficSource", {
+        trafficSource: filters.trafficSource,
+      })
+    }
+
+    if (!filters.includeRefunded) {
+      baseQuery.andWhere("purchase.status != :refundedStatus", {
+        refundedStatus: "refunded",
+      })
+    }
+
+    const purchases = await baseQuery.getMany()
+
+    const completedPurchases = purchases.filter((p) => p.status === "completed")
+    const totalTicketsSold = completedPurchases.reduce((sum, p) => sum + p.quantity, 0)
+    const grossRevenue = completedPurchases.reduce((sum, p) => sum + Number(p.totalAmount), 0)
+    const discountAmount = completedPurchases.reduce((sum, p) => sum + Number(p.discountAmount || 0), 0)
+
+    // Get refund amount
+    const refunds = await this.refundRepository.find({
+      where: { eventId, status: "processed" },
+    })
+    const refundAmount = refunds.reduce((sum, r) => sum + Number(r.refundAmount), 0)
+    const netRevenue = grossRevenue - refundAmount
+
+    const averageOrderValue = completedPurchases.length > 0 ? grossRevenue / completedPurchases.length : 0
+
+    // Get total views for conversion rate
+    const totalViews = await this.eventViewRepository.count({
+      where: {
+        eventId,
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+    })
+
+    const conversionRate = totalViews > 0 ? (completedPurchases.length / totalViews) * 100 : 0
+    const refundRate = totalTicketsSold > 0 ? (refunds.length / totalTicketsSold) * 100 : 0
+
+    // Sales by day
+    const salesByDay = await this.getSalesByDay(eventId, dateRange, filters)
+
+    // Sales by hour
+    const salesByHour = await this.getSalesByHour(eventId, dateRange, filters)
+
+    return {
+      totalTicketsSold,
+      totalRevenue: grossRevenue,
+      averageOrderValue,
+      conversionRate,
+      refundRate,
+      grossRevenue,
+      netRevenue,
+      discountAmount,
+      salesByDay,
+      salesByHour,
+    }
+  }
+
+  /**
+   * Get traffic metrics
+   */
+  private async getTrafficMetrics(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<EventAnalyticsDto["trafficMetrics"]> {
+    const baseQuery = this.eventViewRepository
+      .createQueryBuilder("view")
+      .where("view.eventId = :eventId", { eventId })
+      .andWhere("view.createdAt BETWEEN :start AND :end", dateRange)
+
+    if (filters.trafficSource) {
+      baseQuery.andWhere("view.trafficSource = :trafficSource", {
+        trafficSource: filters.trafficSource,
+      })
+    }
+
+    if (filters.deviceType) {
+      baseQuery.andWhere("view.deviceType = :deviceType", {
+        deviceType: filters.deviceType,
+      })
+    }
+
+    if (filters.country) {
+      baseQuery.andWhere("view.country = :country", { country: filters.country })
+    }
+
+    const views = await baseQuery.getMany()
+
+    const totalViews = views.length
+    const uniqueVisitors = new Set(views.map((v) => v.userId || v.ipAddress)).size
+    const averageTimeOnPage = views.length > 0 ? views.reduce((sum, v) => sum + v.timeOnPage, 0) / views.length : 0
+
+    // Calculate bounce rate (views with time on page < 30 seconds)
+    const bounces = views.filter((v) => v.timeOnPage < 30).length
+    const bounceRate = totalViews > 0 ? (bounces / totalViews) * 100 : 0
+
+    // Views by source
+    const viewsBySource = await this.getViewsBySource(eventId, dateRange, filters)
+
+    // Views by device
+    const viewsByDevice = await this.getViewsByDevice(eventId, dateRange, filters)
+
+    // Views by country
+    const viewsByCountry = await this.getViewsByCountry(eventId, dateRange, filters)
+
+    // Views by day
+    const viewsByDay = await this.getViewsByDay(eventId, dateRange, filters)
+
+    return {
+      totalViews,
+      uniqueVisitors,
+      averageTimeOnPage,
+      bounceRate,
+      viewsBySource,
+      viewsByDevice,
+      viewsByCountry,
+      viewsByDay,
+    }
+  }
+
+  /**
+   * Get engagement metrics
+   */
+  private async getEngagementMetrics(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<EventAnalyticsDto["engagementMetrics"]> {
+    const engagements = await this.eventEngagementRepository.find({
+      where: {
+        eventId,
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+    })
+
+    const totalEngagements = engagements.length
+    const totalViews = await this.eventViewRepository.count({
+      where: {
+        eventId,
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+    })
+
+    const engagementRate = totalViews > 0 ? (totalEngagements / totalViews) * 100 : 0
+
+    // Group by engagement type
+    const engagementsByType = Object.values(EngagementType).map((type) => {
+      const count = engagements.filter((e) => e.engagementType === type).length
+      return {
+        type,
+        count,
+        percentage: totalEngagements > 0 ? (count / totalEngagements) * 100 : 0,
+      }
+    })
+
+    const socialShares = engagements.filter((e) => e.engagementType === EngagementType.SHARE).length
+    const favorites = engagements.filter((e) => e.engagementType === EngagementType.FAVORITE).length
+    const newsletterSignups = engagements.filter((e) => e.engagementType === EngagementType.NEWSLETTER_SIGNUP).length
+    const calendarAdds = engagements.filter((e) => e.engagementType === EngagementType.CALENDAR_ADD).length
+
+    return {
+      totalEngagements,
+      engagementRate,
+      engagementsByType,
+      socialShares,
+      favorites,
+      newsletterSignups,
+      calendarAdds,
+    }
+  }
+
+  /**
+   * Get campaign metrics
+   */
+  private async getCampaignMetrics(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<EventAnalyticsDto["campaignMetrics"]> {
+    // Get UTM campaign data from views and purchases
+    const viewsWithUTM = await this.eventViewRepository.find({
+      where: {
+        eventId,
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+      select: ["utmCampaign", "utmSource", "utmMedium", "convertedToPurchase"],
+    })
+
+    const purchasesWithUTM = await this.purchaseLogRepository.find({
+      where: {
+        eventId,
+        createdAt: Between(dateRange.start, dateRange.end),
+        status: "completed",
+      },
+      select: ["utmCampaign", "utmSource", "utmMedium", "totalAmount"],
+    })
+
+    // Group by campaign
+    const campaignMap = new Map()
+
+    viewsWithUTM.forEach((view) => {
+      if (view.utmCampaign) {
+        const key = `${view.utmCampaign}-${view.utmSource}-${view.utmMedium}`
+        if (!campaignMap.has(key)) {
+          campaignMap.set(key, {
+            campaign: view.utmCampaign,
+            source: view.utmSource,
+            medium: view.utmMedium,
+            views: 0,
+            conversions: 0,
+            revenue: 0,
+          })
+        }
+        const campaign = campaignMap.get(key)
+        campaign.views++
+        if (view.convertedToPurchase) {
+          campaign.conversions++
+        }
+      }
+    })
+
+    purchasesWithUTM.forEach((purchase) => {
+      if (purchase.utmCampaign) {
+        const key = `${purchase.utmCampaign}-${purchase.utmSource}-${purchase.utmMedium}`
+        if (campaignMap.has(key)) {
+          const campaign = campaignMap.get(key)
+          campaign.revenue += Number(purchase.totalAmount)
+        }
+      }
+    })
+
+    const utmCampaigns = Array.from(campaignMap.values()).map((campaign) => ({
+      ...campaign,
+      roi: campaign.views > 0 ? (campaign.revenue / campaign.views) * 100 : 0,
+    }))
+
+    const topPerformingCampaigns = utmCampaigns
+      .sort((a, b) => b.revenue - a.revenue)
+      .slice(0, 10)
+      .map((campaign) => ({
+        campaign: campaign.campaign,
+        conversions: campaign.conversions,
+        revenue: campaign.revenue,
+        conversionRate: campaign.views > 0 ? (campaign.conversions / campaign.views) * 100 : 0,
+      }))
+
+    return {
+      utmCampaigns,
+      topPerformingCampaigns,
+    }
+  }
+
+  /**
+   * Get demographic metrics
+   */
+  private async getDemographicMetrics(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<EventAnalyticsDto["demographicMetrics"]> {
+    // Top countries
+    const countryViews = await this.eventViewRepository
+      .createQueryBuilder("view")
+      .select("view.country", "country")
+      .addSelect("COUNT(*)", "visitors")
+      .where("view.eventId = :eventId", { eventId })
+      .andWhere("view.createdAt BETWEEN :start AND :end", dateRange)
+      .andWhere("view.country IS NOT NULL")
+      .groupBy("view.country")
+      .orderBy("visitors", "DESC")
+      .limit(10)
+      .getRawMany()
+
+    const countryPurchases = await this.purchaseLogRepository
+      .createQueryBuilder("purchase")
+      .select("purchase.country", "country")
+      .addSelect("COUNT(*)", "purchases")
+      .addSelect("SUM(purchase.totalAmount)", "revenue")
+      .where("purchase.eventId = :eventId", { eventId })
+      .andWhere("purchase.createdAt BETWEEN :start AND :end", dateRange)
+      .andWhere("purchase.status = :status", { status: "completed" })
+      .andWhere("purchase.country IS NOT NULL")
+      .groupBy("purchase.country")
+      .getRawMany()
+
+    const topCountries = countryViews.map((cv) => {
+      const purchase = countryPurchases.find((cp) => cp.country === cv.country)
+      return {
+        country: cv.country,
+        visitors: Number(cv.visitors),
+        purchases: purchase ? Number(purchase.purchases) : 0,
+        revenue: purchase ? Number(purchase.revenue) : 0,
+      }
+    })
+
+    // Similar logic for cities and devices
+    const topCities = await this.getTopCities(eventId, dateRange)
+    const deviceBreakdown = await this.getDeviceBreakdown(eventId, dateRange)
+
+    return {
+      topCountries,
+      topCities,
+      deviceBreakdown,
+    }
+  }
+
+  /**
+   * Get time-based analysis
+   */
+  private async getTimeAnalysis(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<EventAnalyticsDto["timeAnalysis"]> {
+    // Peak viewing hours
+    const peakViewingHours = await this.eventViewRepository
+      .createQueryBuilder("view")
+      .select("EXTRACT(HOUR FROM view.createdAt)", "hour")
+      .addSelect("COUNT(*)", "views")
+      .where("view.eventId = :eventId", { eventId })
+      .andWhere("view.createdAt BETWEEN :start AND :end", dateRange)
+      .groupBy("EXTRACT(HOUR FROM view.createdAt)")
+      .orderBy("views", "DESC")
+      .getRawMany()
+
+    // Peak purchase hours
+    const peakPurchaseHours = await this.purchaseLogRepository
+      .createQueryBuilder("purchase")
+      .select("EXTRACT(HOUR FROM purchase.createdAt)", "hour")
+      .addSelect("COUNT(*)", "purchases")
+      .addSelect("SUM(purchase.totalAmount)", "revenue")
+      .where("purchase.eventId = :eventId", { eventId })
+      .andWhere("purchase.createdAt BETWEEN :start AND :end", dateRange)
+      .andWhere("purchase.status = :status", { status: "completed" })
+      .groupBy("EXTRACT(HOUR FROM purchase.createdAt)")
+      .orderBy("purchases", "DESC")
+      .getRawMany()
+
+    // Sales velocity (cumulative over time)
+    const salesVelocity = await this.getSalesVelocity(eventId, dateRange)
+
+    return {
+      peakViewingHours: peakViewingHours.map((p) => ({
+        hour: Number(p.hour),
+        views: Number(p.views),
+      })),
+      peakPurchaseHours: peakPurchaseHours.map((p) => ({
+        hour: Number(p.hour),
+        purchases: Number(p.purchases),
+        revenue: Number(p.revenue),
+      })),
+      salesVelocity,
+    }
+  }
+
+  /**
+   * Get funnel metrics
+   */
+  private async getFunnelMetrics(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<EventAnalyticsDto["funnelMetrics"]> {
+    const totalViews = await this.eventViewRepository.count({
+      where: {
+        eventId,
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+    })
+
+    const ticketViews = await this.eventEngagementRepository.count({
+      where: {
+        eventId,
+        engagementType: EngagementType.TICKET_VIEW,
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+    })
+
+    const purchases = await this.purchaseLogRepository.count({
+      where: {
+        eventId,
+        status: "completed",
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+    })
+
+    const viewToTicketView = totalViews > 0 ? (ticketViews / totalViews) * 100 : 0
+    const ticketViewToPurchase = ticketViews > 0 ? (purchases / ticketViews) * 100 : 0
+    const overallConversion = totalViews > 0 ? (purchases / totalViews) * 100 : 0
+
+    const dropOffPoints = [
+      {
+        stage: "Event Page to Ticket View",
+        dropOffRate: 100 - viewToTicketView,
+        suggestions: [
+          "Improve event description and visuals",
+          "Add social proof and testimonials",
+          "Optimize page loading speed",
+        ],
+      },
+      {
+        stage: "Ticket View to Purchase",
+        dropOffRate: 100 - ticketViewToPurchase,
+        suggestions: [
+          "Simplify checkout process",
+          "Add multiple payment options",
+          "Display security badges",
+          "Offer limited-time discounts",
+        ],
+      },
+    ]
+
+    return {
+      viewToTicketView,
+      ticketViewToPurchase,
+      overallConversion,
+      dropOffPoints,
+    }
+  }
+
+  // Helper methods for detailed breakdowns
+  private async getSalesByDay(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<Array<{ date: string; tickets: number; revenue: number }>> {
+    const sales = await this.purchaseLogRepository
+      .createQueryBuilder("purchase")
+      .select("DATE(purchase.createdAt)", "date")
+      .addSelect("SUM(purchase.quantity)", "tickets")
+      .addSelect("SUM(purchase.totalAmount)", "revenue")
+      .where("purchase.eventId = :eventId", { eventId })
+      .andWhere("purchase.createdAt BETWEEN :start AND :end", dateRange)
+      .andWhere("purchase.status = :status", { status: "completed" })
+      .groupBy("DATE(purchase.createdAt)")
+      .orderBy("date", "ASC")
+      .getRawMany()
+
+    return sales.map((s) => ({
+      date: s.date,
+      tickets: Number(s.tickets),
+      revenue: Number(s.revenue),
+    }))
+  }
+
+  private async getSalesByHour(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<Array<{ hour: number; tickets: number; revenue: number }>> {
+    const sales = await this.purchaseLogRepository
+      .createQueryBuilder("purchase")
+      .select("EXTRACT(HOUR FROM purchase.createdAt)", "hour")
+      .addSelect("SUM(purchase.quantity)", "tickets")
+      .addSelect("SUM(purchase.totalAmount)", "revenue")
+      .where("purchase.eventId = :eventId", { eventId })
+      .andWhere("purchase.createdAt BETWEEN :start AND :end", dateRange)
+      .andWhere("purchase.status = :status", { status: "completed" })
+      .groupBy("EXTRACT(HOUR FROM purchase.createdAt)")
+      .orderBy("hour", "ASC")
+      .getRawMany()
+
+    return sales.map((s) => ({
+      hour: Number(s.hour),
+      tickets: Number(s.tickets),
+      revenue: Number(s.revenue),
+    }))
+  }
+
+  private async getViewsBySource(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<
+    Array<{ source: string; views: number; uniqueVisitors: number; conversions: number; conversionRate: number }>
+  > {
+    const viewsBySource = await this.eventViewRepository
+      .createQueryBuilder("view")
+      .select("view.trafficSource", "source")
+      .addSelect("COUNT(*)", "views")
+      .addSelect("COUNT(DISTINCT COALESCE(view.userId, view.ipAddress))", "uniqueVisitors")
+      .addSelect("SUM(CASE WHEN view.convertedToPurchase THEN 1 ELSE 0 END)", "conversions")
+      .where("view.eventId = :eventId", { eventId })
+      .andWhere("view.createdAt BETWEEN :start AND :end", dateRange)
+      .groupBy("view.trafficSource")
+      .orderBy("views", "DESC")
+      .getRawMany()
+
+    return viewsBySource.map((vs) => ({
+      source: vs.source || "unknown",
+      views: Number(vs.views),
+      uniqueVisitors: Number(vs.uniqueVisitors),
+      conversions: Number(vs.conversions),
+      conversionRate: Number(vs.views) > 0 ? (Number(vs.conversions) / Number(vs.views)) * 100 : 0,
+    }))
+  }
+
+  private async getViewsByDevice(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<Array<{ device: string; views: number; percentage: number }>> {
+    const totalViews = await this.eventViewRepository.count({
+      where: {
+        eventId,
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+    })
+
+    const viewsByDevice = await this.eventViewRepository
+      .createQueryBuilder("view")
+      .select("view.deviceType", "device")
+      .addSelect("COUNT(*)", "views")
+      .where("view.eventId = :eventId", { eventId })
+      .andWhere("view.createdAt BETWEEN :start AND :end", dateRange)
+      .groupBy("view.deviceType")
+      .orderBy("views", "DESC")
+      .getRawMany()
+
+    return viewsByDevice.map((vd) => ({
+      device: vd.device || "unknown",
+      views: Number(vd.views),
+      percentage: totalViews > 0 ? (Number(vd.views) / totalViews) * 100 : 0,
+    }))
+  }
+
+  private async getViewsByCountry(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<Array<{ country: string; views: number; percentage: number }>> {
+    const totalViews = await this.eventViewRepository.count({
+      where: {
+        eventId,
+        createdAt: Between(dateRange.start, dateRange.end),
+      },
+    })
+
+    const viewsByCountry = await this.eventViewRepository
+      .createQueryBuilder("view")
+      .select("view.country", "country")
+      .addSelect("COUNT(*)", "views")
+      .where("view.eventId = :eventId", { eventId })
+      .andWhere("view.createdAt BETWEEN :start AND :end", dateRange)
+      .andWhere("view.country IS NOT NULL")
+      .groupBy("view.country")
+      .orderBy("views", "DESC")
+      .limit(10)
+      .getRawMany()
+
+    return viewsByCountry.map((vc) => ({
+      country: vc.country,
+      views: Number(vc.views),
+      percentage: totalViews > 0 ? (Number(vc.views) / totalViews) * 100 : 0,
+    }))
+  }
+
+  private async getViewsByDay(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+    filters: AnalyticsFilterDto,
+  ): Promise<Array<{ date: string; views: number; uniqueVisitors: number }>> {
+    const viewsByDay = await this.eventViewRepository
+      .createQueryBuilder("view")
+      .select("DATE(view.createdAt)", "date")
+      .addSelect("COUNT(*)", "views")
+      .addSelect("COUNT(DISTINCT COALESCE(view.userId, view.ipAddress))", "uniqueVisitors")
+      .where("view.eventId = :eventId", { eventId })
+      .andWhere("view.createdAt BETWEEN :start AND :end", dateRange)
+      .groupBy("DATE(view.createdAt)")
+      .orderBy("date", "ASC")
+      .getRawMany()
+
+    return viewsByDay.map((vd) => ({
+      date: vd.date,
+      views: Number(vd.views),
+      uniqueVisitors: Number(vd.uniqueVisitors),
+    }))
+  }
+
+  private async getTopCities(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+  ): Promise<Array<{ city: string; visitors: number; purchases: number; revenue: number }>> {
+    // Similar implementation to getTopCountries but for cities
+    return []
+  }
+
+  private async getDeviceBreakdown(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+  ): Promise<Array<{ device: string; visitors: number; purchases: number; conversionRate: number }>> {
+    // Implementation for device breakdown with conversion rates
+    return []
+  }
+
+  private async getSalesVelocity(
+    eventId: string,
+    dateRange: { start: Date; end: Date },
+  ): Promise<Array<{ date: string; cumulativeTickets: number; cumulativeRevenue: number }>> {
+    // Implementation for cumulative sales over time
+    return []
+  }
+
+  private getDateRange(filters: AnalyticsFilterDto): { start: Date; end: Date } {
+    const end = filters.endDate ? new Date(filters.endDate) : new Date()
+    const start = filters.startDate ? new Date(filters.startDate) : new Date(Date.now() - 30 * 24 * 60 * 60 * 1000) // 30 days ago
+
+    return { start, end }
+  }
+}

--- a/src/event-analytics/test/analytics-tracking.service.spec.ts
+++ b/src/event-analytics/test/analytics-tracking.service.spec.ts
@@ -1,0 +1,325 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import type { Repository } from "typeorm"
+import { AnalyticsTrackingService } from "../services/analytics-tracking.service"
+import { EventView } from "../entities/event-view.entity"
+import { PurchaseLog } from "../entities/purchase-log.entity"
+import { EventEngagement, EngagementType } from "../entities/event-engagement.entity"
+import type { TrackViewDto } from "../dto/track-view.dto"
+import type { TrackPurchaseDto } from "../dto/track-purchase.dto"
+import type { TrackEngagementDto } from "../dto/track-engagement.dto"
+import { jest } from "@jest/globals"
+
+describe("AnalyticsTrackingService", () => {
+  let service: AnalyticsTrackingService
+  let eventViewRepository: Repository<EventView>
+  let purchaseLogRepository: Repository<PurchaseLog>
+  let eventEngagementRepository: Repository<EventEngagement>
+
+  const mockEventViewRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+    update: jest.fn(),
+  }
+
+  const mockPurchaseLogRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  }
+
+  const mockEventEngagementRepository = {
+    create: jest.fn(),
+    save: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AnalyticsTrackingService,
+        {
+          provide: getRepositoryToken(EventView),
+          useValue: mockEventViewRepository,
+        },
+        {
+          provide: getRepositoryToken(PurchaseLog),
+          useValue: mockPurchaseLogRepository,
+        },
+        {
+          provide: getRepositoryToken(EventEngagement),
+          useValue: mockEventEngagementRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<AnalyticsTrackingService>(AnalyticsTrackingService)
+    eventViewRepository = module.get<Repository<EventView>>(getRepositoryToken(EventView))
+    purchaseLogRepository = module.get<Repository<PurchaseLog>>(getRepositoryToken(PurchaseLog))
+    eventEngagementRepository = module.get<Repository<EventEngagement>>(getRepositoryToken(EventEngagement))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("trackView", () => {
+    it("should track event view successfully", async () => {
+      const trackViewDto: TrackViewDto = {
+        eventId: "event-123",
+        userId: "user-456",
+        trafficSource: "google",
+        referrerUrl: "https://google.com/search",
+        utmSource: "google",
+        utmMedium: "organic",
+        utmCampaign: "tech-conference",
+        deviceType: "desktop",
+        timeOnPage: 180,
+      }
+
+      const mockEventView = {
+        id: "view-123",
+        ...trackViewDto,
+        ipAddress: "192.168.1.1",
+      }
+
+      mockEventViewRepository.create.mockReturnValue(mockEventView)
+      mockEventViewRepository.save.mockResolvedValue(mockEventView)
+
+      await service.trackView(trackViewDto, "192.168.1.1")
+
+      expect(mockEventViewRepository.create).toHaveBeenCalledWith({
+        ...trackViewDto,
+        ipAddress: "192.168.1.1",
+        trafficSource: "google",
+      })
+      expect(mockEventViewRepository.save).toHaveBeenCalledWith(mockEventView)
+    })
+
+    it("should normalize traffic source from referrer URL", async () => {
+      const trackViewDto: TrackViewDto = {
+        eventId: "event-123",
+        referrerUrl: "https://facebook.com/page",
+      }
+
+      const mockEventView = {
+        id: "view-123",
+        ...trackViewDto,
+        trafficSource: "facebook",
+      }
+
+      mockEventViewRepository.create.mockReturnValue(mockEventView)
+      mockEventViewRepository.save.mockResolvedValue(mockEventView)
+
+      await service.trackView(trackViewDto)
+
+      expect(mockEventViewRepository.create).toHaveBeenCalledWith({
+        ...trackViewDto,
+        trafficSource: "facebook",
+      })
+    })
+
+    it("should default to direct traffic when no referrer", async () => {
+      const trackViewDto: TrackViewDto = {
+        eventId: "event-123",
+        userId: "user-456",
+      }
+
+      const mockEventView = {
+        id: "view-123",
+        ...trackViewDto,
+        trafficSource: "direct",
+      }
+
+      mockEventViewRepository.create.mockReturnValue(mockEventView)
+      mockEventViewRepository.save.mockResolvedValue(mockEventView)
+
+      await service.trackView(trackViewDto)
+
+      expect(mockEventViewRepository.create).toHaveBeenCalledWith({
+        ...trackViewDto,
+        trafficSource: "direct",
+      })
+    })
+  })
+
+  describe("trackPurchase", () => {
+    it("should track purchase successfully", async () => {
+      const trackPurchaseDto: TrackPurchaseDto = {
+        eventId: "event-123",
+        purchaserId: "user-456",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        quantity: 2,
+        unitPrice: 100,
+        totalAmount: 200,
+        status: "completed",
+        trafficSource: "email",
+        paymentMethod: "credit_card",
+        transactionId: "txn-123",
+      }
+
+      const mockPurchaseLog = {
+        id: "purchase-123",
+        ...trackPurchaseDto,
+        completedAt: expect.any(Date),
+      }
+
+      mockPurchaseLogRepository.create.mockReturnValue(mockPurchaseLog)
+      mockPurchaseLogRepository.save.mockResolvedValue(mockPurchaseLog)
+      mockEventViewRepository.update.mockResolvedValue({ affected: 1 })
+
+      await service.trackPurchase(trackPurchaseDto, "192.168.1.1")
+
+      expect(mockPurchaseLogRepository.create).toHaveBeenCalledWith({
+        ...trackPurchaseDto,
+        ipAddress: "192.168.1.1",
+        trafficSource: "email",
+        completedAt: expect.any(Date),
+      })
+      expect(mockPurchaseLogRepository.save).toHaveBeenCalledWith(mockPurchaseLog)
+      expect(mockEventViewRepository.update).toHaveBeenCalled()
+    })
+
+    it("should not set completedAt for failed purchases", async () => {
+      const trackPurchaseDto: TrackPurchaseDto = {
+        eventId: "event-123",
+        purchaserId: "user-456",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        quantity: 1,
+        unitPrice: 100,
+        totalAmount: 100,
+        status: "failed",
+      }
+
+      const mockPurchaseLog = {
+        id: "purchase-123",
+        ...trackPurchaseDto,
+        completedAt: null,
+      }
+
+      mockPurchaseLogRepository.create.mockReturnValue(mockPurchaseLog)
+      mockPurchaseLogRepository.save.mockResolvedValue(mockPurchaseLog)
+
+      await service.trackPurchase(trackPurchaseDto)
+
+      expect(mockPurchaseLogRepository.create).toHaveBeenCalledWith({
+        ...trackPurchaseDto,
+        trafficSource: "direct",
+        completedAt: null,
+      })
+    })
+  })
+
+  describe("trackEngagement", () => {
+    it("should track engagement successfully", async () => {
+      const trackEngagementDto: TrackEngagementDto = {
+        eventId: "event-123",
+        userId: "user-456",
+        engagementType: EngagementType.SHARE,
+        metadata: { platform: "twitter" },
+        trafficSource: "social",
+      }
+
+      const mockEngagement = {
+        id: "engagement-123",
+        ...trackEngagementDto,
+        ipAddress: "192.168.1.1",
+      }
+
+      mockEventEngagementRepository.create.mockReturnValue(mockEngagement)
+      mockEventEngagementRepository.save.mockResolvedValue(mockEngagement)
+
+      await service.trackEngagement(trackEngagementDto, "192.168.1.1")
+
+      expect(mockEventEngagementRepository.create).toHaveBeenCalledWith({
+        ...trackEngagementDto,
+        ipAddress: "192.168.1.1",
+        trafficSource: "social",
+      })
+      expect(mockEventEngagementRepository.save).toHaveBeenCalledWith(mockEngagement)
+    })
+  })
+
+  describe("parseUserAgent", () => {
+    it("should parse Chrome on Windows desktop", () => {
+      const userAgent =
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+
+      const result = service.parseUserAgent(userAgent)
+
+      expect(result.deviceType).toBe("desktop")
+      expect(result.browser).toBe("chrome")
+      expect(result.operatingSystem).toBe("windows")
+    })
+
+    it("should parse Safari on iOS mobile", () => {
+      const userAgent =
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
+
+      const result = service.parseUserAgent(userAgent)
+
+      expect(result.deviceType).toBe("mobile")
+      expect(result.browser).toBe("safari")
+      expect(result.operatingSystem).toBe("ios")
+    })
+
+    it("should parse Firefox on Linux desktop", () => {
+      const userAgent = "Mozilla/5.0 (X11; Linux x86_64; rv:89.0) Gecko/20100101 Firefox/89.0"
+
+      const result = service.parseUserAgent(userAgent)
+
+      expect(result.deviceType).toBe("desktop")
+      expect(result.browser).toBe("firefox")
+      expect(result.operatingSystem).toBe("linux")
+    })
+
+    it("should handle iPad as tablet", () => {
+      const userAgent =
+        "Mozilla/5.0 (iPad; CPU OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1"
+
+      const result = service.parseUserAgent(userAgent)
+
+      expect(result.deviceType).toBe("tablet")
+      expect(result.browser).toBe("safari")
+      expect(result.operatingSystem).toBe("ios")
+    })
+  })
+
+  describe("traffic source normalization", () => {
+    it("should identify social media sources", () => {
+      expect(service["normalizeTrafficSource"](undefined, "https://facebook.com/page")).toBe("facebook")
+      expect(service["normalizeTrafficSource"](undefined, "https://twitter.com/user")).toBe("twitter")
+      expect(service["normalizeTrafficSource"](undefined, "https://linkedin.com/in/user")).toBe("linkedin")
+      expect(service["normalizeTrafficSource"](undefined, "https://instagram.com/user")).toBe("instagram")
+      expect(service["normalizeTrafficSource"](undefined, "https://youtube.com/watch")).toBe("youtube")
+    })
+
+    it("should identify search engines", () => {
+      expect(service["normalizeTrafficSource"](undefined, "https://google.com/search")).toBe("google")
+      expect(service["normalizeTrafficSource"](undefined, "https://bing.com/search")).toBe("bing")
+      expect(service["normalizeTrafficSource"](undefined, "https://yahoo.com/search")).toBe("yahoo")
+      expect(service["normalizeTrafficSource"](undefined, "https://duckduckgo.com/search")).toBe("duckduckgo")
+    })
+
+    it("should identify email sources", () => {
+      expect(service["normalizeTrafficSource"](undefined, "https://gmail.com")).toBe("email")
+      expect(service["normalizeTrafficSource"](undefined, "https://outlook.com")).toBe("email")
+    })
+
+    it("should default to referral for unknown sources", () => {
+      expect(service["normalizeTrafficSource"](undefined, "https://unknown-site.com")).toBe("referral")
+    })
+
+    it("should use provided traffic source when available", () => {
+      expect(service["normalizeTrafficSource"]("paid", "https://google.com")).toBe("paid")
+    })
+
+    it("should default to direct when no referrer", () => {
+      expect(service["normalizeTrafficSource"]()).toBe("direct")
+    })
+  })
+})

--- a/src/event-analytics/test/dto.spec.ts
+++ b/src/event-analytics/test/dto.spec.ts
@@ -1,0 +1,259 @@
+import { validate } from "class-validator"
+import { plainToClass } from "class-transformer"
+import { TrackViewDto } from "../dto/track-view.dto"
+import { TrackPurchaseDto } from "../dto/track-purchase.dto"
+import { TrackEngagementDto } from "../dto/track-engagement.dto"
+import { EngagementType } from "../entities/event-engagement.entity"
+
+describe("Event Analytics DTOs", () => {
+  describe("TrackViewDto", () => {
+    it("should validate valid view tracking data", async () => {
+      const viewData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        userId: "550e8400-e29b-41d4-a716-446655440002",
+        trafficSource: "google",
+        referrerUrl: "https://google.com/search",
+        utmSource: "google",
+        utmMedium: "organic",
+        utmCampaign: "tech-conference-2024",
+        utmTerm: "tech conference",
+        utmContent: "ad-variant-a",
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        deviceType: "desktop",
+        browser: "chrome",
+        operatingSystem: "windows",
+        country: "United States",
+        city: "San Francisco",
+        timeOnPage: 180,
+        convertedToPurchase: true,
+        purchaseId: "550e8400-e29b-41d4-a716-446655440003",
+      }
+
+      const dto = plainToClass(TrackViewDto, viewData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.eventId).toBe("550e8400-e29b-41d4-a716-446655440001")
+      expect(dto.timeOnPage).toBe(180)
+      expect(dto.convertedToPurchase).toBe(true)
+    })
+
+    it("should validate minimal view tracking data", async () => {
+      const viewData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+      }
+
+      const dto = plainToClass(TrackViewDto, viewData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.eventId).toBe("550e8400-e29b-41d4-a716-446655440001")
+    })
+
+    it("should reject invalid UUID for eventId", async () => {
+      const viewData = {
+        eventId: "invalid-uuid",
+      }
+
+      const dto = plainToClass(TrackViewDto, viewData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("eventId")
+    })
+
+    it("should reject time on page exceeding 24 hours", async () => {
+      const viewData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        timeOnPage: 90000, // More than 24 hours (86400 seconds)
+      }
+
+      const dto = plainToClass(TrackViewDto, viewData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("timeOnPage")
+    })
+
+    it("should reject negative time on page", async () => {
+      const viewData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        timeOnPage: -10,
+      }
+
+      const dto = plainToClass(TrackViewDto, viewData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("timeOnPage")
+    })
+  })
+
+  describe("TrackPurchaseDto", () => {
+    it("should validate valid purchase tracking data", async () => {
+      const purchaseData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        purchaserId: "550e8400-e29b-41d4-a716-446655440002",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        quantity: 2,
+        unitPrice: 99.99,
+        totalAmount: 199.98,
+        discountAmount: 20.0,
+        discountCode: "EARLY20",
+        status: "completed",
+        paymentMethod: "credit_card",
+        transactionId: "txn_1234567890",
+        trafficSource: "email",
+        referrerUrl: "https://mailchimp.com",
+        utmSource: "newsletter",
+        utmMedium: "email",
+        utmCampaign: "weekly-digest",
+        deviceType: "desktop",
+        country: "United States",
+        city: "New York",
+      }
+
+      const dto = plainToClass(TrackPurchaseDto, purchaseData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.quantity).toBe(2)
+      expect(dto.unitPrice).toBe(99.99)
+      expect(dto.totalAmount).toBe(199.98)
+      expect(dto.discountAmount).toBe(20.0)
+    })
+
+    it("should reject quantity less than 1", async () => {
+      const purchaseData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        purchaserId: "550e8400-e29b-41d4-a716-446655440002",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        quantity: 0,
+        unitPrice: 99.99,
+        totalAmount: 0,
+        status: "completed",
+      }
+
+      const dto = plainToClass(TrackPurchaseDto, purchaseData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("quantity")
+    })
+
+    it("should reject negative unit price", async () => {
+      const purchaseData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        purchaserId: "550e8400-e29b-41d4-a716-446655440002",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        quantity: 1,
+        unitPrice: -10,
+        totalAmount: -10,
+        status: "completed",
+      }
+
+      const dto = plainToClass(TrackPurchaseDto, purchaseData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(2) // unitPrice and totalAmount
+      expect(errors.some((e) => e.property === "unitPrice")).toBe(true)
+      expect(errors.some((e) => e.property === "totalAmount")).toBe(true)
+    })
+
+    it("should reject negative discount amount", async () => {
+      const purchaseData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        purchaserId: "550e8400-e29b-41d4-a716-446655440002",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        quantity: 1,
+        unitPrice: 100,
+        totalAmount: 100,
+        discountAmount: -5,
+        status: "completed",
+      }
+
+      const dto = plainToClass(TrackPurchaseDto, purchaseData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("discountAmount")
+    })
+  })
+
+  describe("TrackEngagementDto", () => {
+    it("should validate valid engagement tracking data", async () => {
+      const engagementData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        userId: "550e8400-e29b-41d4-a716-446655440002",
+        engagementType: EngagementType.SHARE,
+        metadata: {
+          platform: "twitter",
+          url: "https://twitter.com/share",
+          text: "Check out this amazing event!",
+        },
+        trafficSource: "social",
+        deviceType: "mobile",
+      }
+
+      const dto = plainToClass(TrackEngagementDto, engagementData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.engagementType).toBe(EngagementType.SHARE)
+      expect(dto.metadata).toEqual({
+        platform: "twitter",
+        url: "https://twitter.com/share",
+        text: "Check out this amazing event!",
+      })
+    })
+
+    it("should validate all engagement types", async () => {
+      const engagementTypes = Object.values(EngagementType)
+
+      for (const type of engagementTypes) {
+        const engagementData = {
+          eventId: "550e8400-e29b-41d4-a716-446655440001",
+          engagementType: type,
+        }
+
+        const dto = plainToClass(TrackEngagementDto, engagementData)
+        const errors = await validate(dto)
+
+        expect(errors).toHaveLength(0)
+        expect(dto.engagementType).toBe(type)
+      }
+    })
+
+    it("should reject invalid engagement type", async () => {
+      const engagementData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        engagementType: "invalid_type",
+      }
+
+      const dto = plainToClass(TrackEngagementDto, engagementData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(1)
+      expect(errors[0].property).toBe("engagementType")
+    })
+
+    it("should allow anonymous engagement tracking", async () => {
+      const engagementData = {
+        eventId: "550e8400-e29b-41d4-a716-446655440001",
+        engagementType: EngagementType.PAGE_VIEW,
+        // No userId provided
+      }
+
+      const dto = plainToClass(TrackEngagementDto, engagementData)
+      const errors = await validate(dto)
+
+      expect(errors).toHaveLength(0)
+      expect(dto.userId).toBeUndefined()
+    })
+  })
+})

--- a/src/event-analytics/test/event-analytics.controller.spec.ts
+++ b/src/event-analytics/test/event-analytics.controller.spec.ts
@@ -1,0 +1,266 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import type { Request } from "express"
+import { EventAnalyticsController } from "../controllers/event-analytics.controller"
+import { EventAnalyticsService } from "../services/event-analytics.service"
+import { AnalyticsTrackingService } from "../services/analytics-tracking.service"
+import { EngagementType } from "../entities/event-engagement.entity"
+import type { TrackViewDto } from "../dto/track-view.dto"
+import type { TrackPurchaseDto } from "../dto/track-purchase.dto"
+import type { TrackEngagementDto } from "../dto/track-engagement.dto"
+import type { AnalyticsFilterDto } from "../dto/analytics-response.dto"
+import { jest } from "@jest/globals"
+
+describe("EventAnalyticsController", () => {
+  let controller: EventAnalyticsController
+  let eventAnalyticsService: EventAnalyticsService
+  let analyticsTrackingService: AnalyticsTrackingService
+
+  const mockEventAnalyticsService = {
+    getEventAnalytics: jest.fn(),
+  }
+
+  const mockAnalyticsTrackingService = {
+    trackView: jest.fn(),
+    trackPurchase: jest.fn(),
+    trackEngagement: jest.fn(),
+    parseUserAgent: jest.fn(),
+    getLocationFromIP: jest.fn(),
+  }
+
+  const mockRequest = {
+    ip: "192.168.1.1",
+    connection: { remoteAddress: "192.168.1.1" },
+    headers: {
+      "user-agent":
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+    },
+  } as unknown as Request
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [EventAnalyticsController],
+      providers: [
+        {
+          provide: EventAnalyticsService,
+          useValue: mockEventAnalyticsService,
+        },
+        {
+          provide: AnalyticsTrackingService,
+          useValue: mockAnalyticsTrackingService,
+        },
+      ],
+    }).compile()
+
+    controller = module.get<EventAnalyticsController>(EventAnalyticsController)
+    eventAnalyticsService = module.get<EventAnalyticsService>(EventAnalyticsService)
+    analyticsTrackingService = module.get<AnalyticsTrackingService>(AnalyticsTrackingService)
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(controller).toBeDefined()
+  })
+
+  describe("getEventAnalytics", () => {
+    it("should return event analytics", async () => {
+      const eventId = "event-123"
+      const organizerId = "organizer-456"
+      const filters: AnalyticsFilterDto = {
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
+        trafficSource: "google",
+      }
+
+      const mockAnalytics = {
+        eventId,
+        eventName: "Test Event",
+        salesMetrics: {
+          totalTicketsSold: 100,
+          totalRevenue: 10000,
+        },
+        trafficMetrics: {
+          totalViews: 1000,
+          uniqueVisitors: 800,
+        },
+      }
+
+      mockEventAnalyticsService.getEventAnalytics.mockResolvedValue(mockAnalytics)
+
+      const result = await controller.getEventAnalytics(eventId, organizerId, filters)
+
+      expect(result).toEqual(mockAnalytics)
+      expect(mockEventAnalyticsService.getEventAnalytics).toHaveBeenCalledWith(eventId, organizerId, filters)
+    })
+  })
+
+  describe("trackView", () => {
+    it("should track view with parsed user agent", async () => {
+      const eventId = "event-123"
+      const trackViewDto: TrackViewDto = {
+        eventId,
+        userId: "user-456",
+        trafficSource: "google",
+        timeOnPage: 180,
+      }
+
+      mockAnalyticsTrackingService.parseUserAgent.mockReturnValue({
+        deviceType: "desktop",
+        browser: "chrome",
+        operatingSystem: "windows",
+      })
+
+      mockAnalyticsTrackingService.getLocationFromIP.mockResolvedValue({
+        country: "United States",
+        city: "San Francisco",
+      })
+
+      const result = await controller.trackView(eventId, trackViewDto, mockRequest)
+
+      expect(result).toEqual({
+        success: true,
+        message: "View tracked successfully",
+      })
+
+      expect(mockAnalyticsTrackingService.parseUserAgent).toHaveBeenCalledWith(mockRequest.headers["user-agent"])
+      expect(mockAnalyticsTrackingService.getLocationFromIP).toHaveBeenCalledWith("192.168.1.1")
+      expect(mockAnalyticsTrackingService.trackView).toHaveBeenCalledWith(
+        {
+          ...trackViewDto,
+          eventId,
+          userAgent: mockRequest.headers["user-agent"],
+          deviceType: "desktop",
+          browser: "chrome",
+          operatingSystem: "windows",
+          country: "United States",
+          city: "San Francisco",
+        },
+        "192.168.1.1",
+      )
+    })
+
+    it("should track view without parsing when device info provided", async () => {
+      const eventId = "event-123"
+      const trackViewDto: TrackViewDto = {
+        eventId,
+        userId: "user-456",
+        deviceType: "mobile",
+        browser: "safari",
+        operatingSystem: "ios",
+        country: "Canada",
+        city: "Toronto",
+      }
+
+      const result = await controller.trackView(eventId, trackViewDto, mockRequest)
+
+      expect(result.success).toBe(true)
+      expect(mockAnalyticsTrackingService.parseUserAgent).not.toHaveBeenCalled()
+      expect(mockAnalyticsTrackingService.getLocationFromIP).not.toHaveBeenCalled()
+      expect(mockAnalyticsTrackingService.trackView).toHaveBeenCalledWith(
+        {
+          ...trackViewDto,
+          eventId,
+          userAgent: mockRequest.headers["user-agent"],
+        },
+        "192.168.1.1",
+      )
+    })
+  })
+
+  describe("trackPurchase", () => {
+    it("should track purchase successfully", async () => {
+      const eventId = "event-123"
+      const trackPurchaseDto: TrackPurchaseDto = {
+        eventId,
+        purchaserId: "user-456",
+        purchaserName: "John Doe",
+        purchaserEmail: "john@example.com",
+        quantity: 2,
+        unitPrice: 100,
+        totalAmount: 200,
+        status: "completed",
+        paymentMethod: "credit_card",
+        transactionId: "txn-123",
+      }
+
+      const result = await controller.trackPurchase(eventId, trackPurchaseDto, mockRequest)
+
+      expect(result).toEqual({
+        success: true,
+        message: "Purchase tracked successfully",
+      })
+
+      expect(mockAnalyticsTrackingService.trackPurchase).toHaveBeenCalledWith(
+        {
+          ...trackPurchaseDto,
+          eventId,
+        },
+        "192.168.1.1",
+      )
+    })
+  })
+
+  describe("trackEngagement", () => {
+    it("should track engagement successfully", async () => {
+      const eventId = "event-123"
+      const trackEngagementDto: TrackEngagementDto = {
+        eventId,
+        userId: "user-456",
+        engagementType: EngagementType.SHARE,
+        metadata: {
+          platform: "twitter",
+          url: "https://twitter.com/share",
+        },
+        trafficSource: "social",
+      }
+
+      const result = await controller.trackEngagement(eventId, trackEngagementDto, mockRequest)
+
+      expect(result).toEqual({
+        success: true,
+        message: "Engagement tracked successfully",
+      })
+
+      expect(mockAnalyticsTrackingService.trackEngagement).toHaveBeenCalledWith(
+        {
+          ...trackEngagementDto,
+          eventId,
+        },
+        "192.168.1.1",
+      )
+    })
+  })
+
+  describe("IP address handling", () => {
+    it("should use req.ip when available", async () => {
+      const eventId = "event-123"
+      const trackViewDto: TrackViewDto = { eventId }
+
+      await controller.trackView(eventId, trackViewDto, mockRequest)
+
+      expect(mockAnalyticsTrackingService.trackView).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId }),
+        "192.168.1.1",
+      )
+    })
+
+    it("should fallback to connection.remoteAddress", async () => {
+      const eventId = "event-123"
+      const trackViewDto: TrackViewDto = { eventId }
+      const requestWithoutIP = {
+        ip: undefined,
+        connection: { remoteAddress: "10.0.0.1" },
+        headers: {},
+      } as unknown as Request
+
+      await controller.trackView(eventId, trackViewDto, requestWithoutIP)
+
+      expect(mockAnalyticsTrackingService.trackView).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId }),
+        "10.0.0.1",
+      )
+    })
+  })
+})

--- a/src/event-analytics/test/event-analytics.service.spec.ts
+++ b/src/event-analytics/test/event-analytics.service.spec.ts
@@ -1,0 +1,328 @@
+import { Test, type TestingModule } from "@nestjs/testing"
+import { getRepositoryToken } from "@nestjs/typeorm"
+import { ForbiddenException } from "@nestjs/common"
+import type { Repository } from "typeorm"
+import { EventAnalyticsService } from "../services/event-analytics.service"
+import { EventView } from "../entities/event-view.entity"
+import { PurchaseLog } from "../entities/purchase-log.entity"
+import { EventEngagement } from "../entities/event-engagement.entity"
+import { Event } from "../../ticketing/entities/event.entity"
+import { Refund } from "../../refunds/entities/refund.entity"
+import type { AnalyticsFilterDto } from "../dto/analytics-response.dto"
+import { jest } from "@jest/globals"
+
+describe("EventAnalyticsService", () => {
+  let service: EventAnalyticsService
+  let eventRepository: Repository<Event>
+  let eventViewRepository: Repository<EventView>
+  let purchaseLogRepository: Repository<PurchaseLog>
+  let eventEngagementRepository: Repository<EventEngagement>
+  let refundRepository: Repository<Refund>
+
+  const mockEventRepository = {
+    findOne: jest.fn(),
+  }
+
+  const mockEventViewRepository = {
+    createQueryBuilder: jest.fn(),
+    count: jest.fn(),
+    find: jest.fn(),
+  }
+
+  const mockPurchaseLogRepository = {
+    createQueryBuilder: jest.fn(),
+    find: jest.fn(),
+  }
+
+  const mockEventEngagementRepository = {
+    find: jest.fn(),
+    count: jest.fn(),
+  }
+
+  const mockRefundRepository = {
+    find: jest.fn(),
+  }
+
+  const mockQueryBuilder = {
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    groupBy: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    getMany: jest.fn(),
+    getRawMany: jest.fn(),
+  }
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        EventAnalyticsService,
+        {
+          provide: getRepositoryToken(Event),
+          useValue: mockEventRepository,
+        },
+        {
+          provide: getRepositoryToken(EventView),
+          useValue: mockEventViewRepository,
+        },
+        {
+          provide: getRepositoryToken(PurchaseLog),
+          useValue: mockPurchaseLogRepository,
+        },
+        {
+          provide: getRepositoryToken(EventEngagement),
+          useValue: mockEventEngagementRepository,
+        },
+        {
+          provide: getRepositoryToken(Refund),
+          useValue: mockRefundRepository,
+        },
+      ],
+    }).compile()
+
+    service = module.get<EventAnalyticsService>(EventAnalyticsService)
+    eventRepository = module.get<Repository<Event>>(getRepositoryToken(Event))
+    eventViewRepository = module.get<Repository<EventView>>(getRepositoryToken(EventView))
+    purchaseLogRepository = module.get<Repository<PurchaseLog>>(getRepositoryToken(PurchaseLog))
+    eventEngagementRepository = module.get<Repository<EventEngagement>>(getRepositoryToken(EventEngagement))
+    refundRepository = module.get<Repository<Refund>>(getRepositoryToken(Refund))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should be defined", () => {
+    expect(service).toBeDefined()
+  })
+
+  describe("getEventAnalytics", () => {
+    const mockEvent = {
+      id: "event-123",
+      name: "Test Event",
+      startDate: new Date("2024-06-15"),
+      ticketPrice: 100,
+      maxCapacity: 500,
+      organizerId: "organizer-123",
+    }
+
+    const filters: AnalyticsFilterDto = {
+      startDate: "2024-01-01",
+      endDate: "2024-12-31",
+    }
+
+    beforeEach(() => {
+      mockEventRepository.findOne.mockResolvedValue(mockEvent)
+      mockPurchaseLogRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockEventViewRepository.createQueryBuilder.mockReturnValue(mockQueryBuilder)
+      mockEventEngagementRepository.find.mockResolvedValue([])
+      mockRefundRepository.find.mockResolvedValue([])
+      mockEventViewRepository.count.mockResolvedValue(100)
+      mockEventEngagementRepository.count.mockResolvedValue(10)
+
+      // Mock query builder responses
+      mockQueryBuilder.getMany.mockResolvedValue([])
+      mockQueryBuilder.getRawMany.mockResolvedValue([])
+    })
+
+    it("should return comprehensive analytics for authorized organizer", async () => {
+      const result = await service.getEventAnalytics("event-123", "organizer-123", filters)
+
+      expect(result).toBeDefined()
+      expect(result.eventId).toBe("event-123")
+      expect(result.eventName).toBe("Test Event")
+      expect(result.salesMetrics).toBeDefined()
+      expect(result.trafficMetrics).toBeDefined()
+      expect(result.engagementMetrics).toBeDefined()
+      expect(result.campaignMetrics).toBeDefined()
+      expect(result.demographicMetrics).toBeDefined()
+      expect(result.timeAnalysis).toBeDefined()
+      expect(result.funnelMetrics).toBeDefined()
+    })
+
+    it("should throw ForbiddenException for unauthorized organizer", async () => {
+      mockEventRepository.findOne.mockResolvedValue(null)
+
+      await expect(service.getEventAnalytics("event-123", "wrong-organizer", filters)).rejects.toThrow(
+        ForbiddenException,
+      )
+    })
+
+    it("should apply traffic source filter", async () => {
+      const filtersWithSource = { ...filters, trafficSource: "google" }
+
+      await service.getEventAnalytics("event-123", "organizer-123", filtersWithSource)
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("purchase.trafficSource = :trafficSource", {
+        trafficSource: "google",
+      })
+    })
+
+    it("should exclude refunded purchases by default", async () => {
+      await service.getEventAnalytics("event-123", "organizer-123", filters)
+
+      expect(mockQueryBuilder.andWhere).toHaveBeenCalledWith("purchase.status != :refundedStatus", {
+        refundedStatus: "refunded",
+      })
+    })
+
+    it("should include refunded purchases when specified", async () => {
+      const filtersWithRefunded = { ...filters, includeRefunded: true }
+
+      await service.getEventAnalytics("event-123", "organizer-123", filtersWithRefunded)
+
+      // Should not add the refunded status filter
+      expect(mockQueryBuilder.andWhere).not.toHaveBeenCalledWith("purchase.status != :refundedStatus", {
+        refundedStatus: "refunded",
+      })
+    })
+  })
+
+  describe("getSalesMetrics", () => {
+    it("should calculate sales metrics correctly", async () => {
+      const mockPurchases = [
+        {
+          quantity: 2,
+          totalAmount: 200,
+          discountAmount: 20,
+          status: "completed",
+        },
+        {
+          quantity: 1,
+          totalAmount: 100,
+          discountAmount: 0,
+          status: "completed",
+        },
+        {
+          quantity: 1,
+          totalAmount: 100,
+          discountAmount: 0,
+          status: "failed",
+        },
+      ]
+
+      const mockRefunds = [
+        {
+          refundAmount: 50,
+          status: "processed",
+        },
+      ]
+
+      mockQueryBuilder.getMany.mockResolvedValue(mockPurchases)
+      mockRefundRepository.find.mockResolvedValue(mockRefunds)
+      mockEventViewRepository.count.mockResolvedValue(1000)
+
+      const result = await service["getSalesMetrics"](
+        "event-123",
+        { start: new Date("2024-01-01"), end: new Date("2024-12-31") },
+        {},
+      )
+
+      expect(result.totalTicketsSold).toBe(3) // 2 + 1 from completed purchases
+      expect(result.grossRevenue).toBe(300) // 200 + 100 from completed purchases
+      expect(result.netRevenue).toBe(250) // 300 - 50 refund
+      expect(result.discountAmount).toBe(20) // 20 + 0 from completed purchases
+      expect(result.averageOrderValue).toBe(150) // 300 / 2 completed purchases
+      expect(result.conversionRate).toBe(0.2) // 2 completed purchases / 1000 views * 100
+    })
+  })
+
+  describe("getTrafficMetrics", () => {
+    it("should calculate traffic metrics correctly", async () => {
+      const mockViews = [
+        {
+          userId: "user-1",
+          ipAddress: "192.168.1.1",
+          timeOnPage: 120,
+        },
+        {
+          userId: "user-2",
+          ipAddress: "192.168.1.2",
+          timeOnPage: 60,
+        },
+        {
+          userId: "user-1", // Same user, different session
+          ipAddress: "192.168.1.1",
+          timeOnPage: 20, // Bounce
+        },
+      ]
+
+      mockQueryBuilder.getMany.mockResolvedValue(mockViews)
+
+      const result = await service["getTrafficMetrics"](
+        "event-123",
+        { start: new Date("2024-01-01"), end: new Date("2024-12-31") },
+        {},
+      )
+
+      expect(result.totalViews).toBe(3)
+      expect(result.uniqueVisitors).toBe(2) // user-1 and user-2
+      expect(result.averageTimeOnPage).toBe(66.67) // (120 + 60 + 20) / 3
+      expect(result.bounceRate).toBe(33.33) // 1 bounce out of 3 views * 100
+    })
+  })
+
+  describe("getEngagementMetrics", () => {
+    it("should calculate engagement metrics correctly", async () => {
+      const mockEngagements = [
+        { engagementType: "share" },
+        { engagementType: "favorite" },
+        { engagementType: "share" },
+        { engagementType: "newsletter_signup" },
+        { engagementType: "calendar_add" },
+      ]
+
+      mockEventEngagementRepository.find.mockResolvedValue(mockEngagements)
+      mockEventViewRepository.count.mockResolvedValue(100)
+
+      const result = await service["getEngagementMetrics"](
+        "event-123",
+        { start: new Date("2024-01-01"), end: new Date("2024-12-31") },
+        {},
+      )
+
+      expect(result.totalEngagements).toBe(5)
+      expect(result.engagementRate).toBe(5) // 5 engagements / 100 views * 100
+      expect(result.socialShares).toBe(2)
+      expect(result.favorites).toBe(1)
+      expect(result.newsletterSignups).toBe(1)
+      expect(result.calendarAdds).toBe(1)
+    })
+  })
+
+  describe("date range handling", () => {
+    it("should use provided date range", () => {
+      const filters: AnalyticsFilterDto = {
+        startDate: "2024-06-01",
+        endDate: "2024-06-30",
+      }
+
+      const result = service["getDateRange"](filters)
+
+      expect(result.start).toEqual(new Date("2024-06-01"))
+      expect(result.end).toEqual(new Date("2024-06-30"))
+    })
+
+    it("should default to last 30 days when no dates provided", () => {
+      const filters: AnalyticsFilterDto = {}
+      const result = service["getDateRange"](filters)
+
+      expect(result.end).toBeInstanceOf(Date)
+      expect(result.start).toBeInstanceOf(Date)
+      expect(result.end.getTime() - result.start.getTime()).toBeCloseTo(30 * 24 * 60 * 60 * 1000, -1000) // ~30 days
+    })
+
+    it("should use current date as end when only start date provided", () => {
+      const filters: AnalyticsFilterDto = {
+        startDate: "2024-06-01",
+      }
+
+      const result = service["getDateRange"](filters)
+
+      expect(result.start).toEqual(new Date("2024-06-01"))
+      expect(result.end).toBeInstanceOf(Date)
+    })
+  })
+})


### PR DESCRIPTION
This PR implements the `GET /events/:id/analytics` endpoint to provide event organizers with key performance metrics, including ticket sales, revenue, traffic sources, and event views. It also adds logic to track and aggregate data from purchase logs and view activity. Traffic source data is captured from the frontend when available.

closes #219 