### PR TITLE
feat(events): enforce event lifecycle and validate status transitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3673,7 +3673,7 @@
       "version": "1.11.24",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.24.tgz",
       "integrity": "sha512-MaQEIpfcEMzx3VWWopbofKJvaraqmL6HbLlw2bFZ7qYqYw3rkhM0cQVEgyzbHtTWwCwPMFZSC2DUbhlZgrMfLg==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3715,7 +3715,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3732,7 +3731,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3749,7 +3747,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3766,7 +3763,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3783,7 +3779,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3800,7 +3795,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3817,7 +3811,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3834,7 +3827,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3851,7 +3843,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3868,7 +3859,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3882,7 +3872,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
@@ -3898,7 +3888,7 @@
       "version": "0.1.21",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.21.tgz",
       "integrity": "sha512-2YEtj5HJVbKivud9N4bpPBAyZhj4S2Ipe5LkUG94alTpr7in/GU/EARgPAd3BwU+YOmFVJC2+kjqhGRi3r0ZpQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/src/events/dto/change-event-status.dto.ts
+++ b/src/events/dto/change-event-status.dto.ts
@@ -1,0 +1,7 @@
+import { IsEnum } from 'class-validator';
+import { EventStatus } from "../../common/enums/event-status.enum";
+
+export class ChangeEventStatusDto {
+  @IsEnum(EventStatus)
+  status: EventStatus;
+}

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -31,6 +31,7 @@ import { Roles } from "security/decorators/roles.decorator";
 import { UserRole } from "src/common/enums/users-roles.enum";
 import { Event } from "./entities/event.entity";
 import { EventStatus } from "../common/enums/event-status.enum";
+import { ChangeEventStatusDto } from "./dto/change-event-status.dto";
 
 @ApiTags("Events")
 @ApiBearerAuth()
@@ -378,4 +379,13 @@ export class EventsController {
   ) {
     return this.eventsService.postpone(id, postponementDetails);
   }
+
+  @Patch(':id/status')
+changeStatus(
+  @Param('id') id: string,
+  @Body() dto: ChangeEventStatusDto,
+) {
+  return this.eventsService.changeStatus(id, dto.status, dto);
+}
+
 }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -12,6 +12,7 @@ import * as fuzzball from "fuzzball";
 import { CategoryService } from "src/category/category.service";
 import { UpdateEventDto } from "./dto/update-event.dto";
 import { EventStatus } from "src/common/enums/event-status.enum";
+import { applyEventStatusChange } from "./lifecycle/event.lifecycle";
 
 @Injectable()
 export class EventsService {
@@ -268,4 +269,17 @@ export class EventsService {
 
     return this.eventRepository.save(event);
   }
+
+  async changeStatus(
+  id: string,
+  nextStatus: EventStatus,
+  metadata?: any,
+): Promise<Event> {
+  const event = await this.getEventById(id);
+
+  applyEventStatusChange(event, nextStatus, metadata);
+
+  return this.eventRepository.save(event);
+}
+
 }

--- a/src/events/lifecycle/event.lifecycle.ts
+++ b/src/events/lifecycle/event.lifecycle.ts
@@ -1,0 +1,48 @@
+import { BadRequestException } from '@nestjs/common';
+import { EventStatus } from '../../common/enums/event-status.enum';
+import { EVENT_STATUS_TRANSITIONS } from './event.transitions';
+import { validateForPublish } from './event.validators';
+import { Event } from '../entities/event.entity';
+
+export function applyEventStatusChange(
+  event: Event,
+  nextStatus: EventStatus,
+  metadata?: {
+    cancellationReason?: string;
+    newStartDate?: Date;
+    newEndDate?: Date;
+  },
+) {
+  const allowed = EVENT_STATUS_TRANSITIONS[event.status];
+  if (!allowed.includes(nextStatus)) {
+    throw new BadRequestException(
+      `Invalid transition from ${event.status} to ${nextStatus}`,
+    );
+  }
+
+  if (nextStatus === EventStatus.PUBLISHED) {
+    validateForPublish(event);
+  }
+
+  if (
+    nextStatus === EventStatus.CANCELLED &&
+    !metadata?.cancellationReason
+  ) {
+    throw new BadRequestException(
+      'Cancellation reason is required',
+    );
+  }
+
+  if (nextStatus === EventStatus.POSTPONED) {
+    if (!metadata?.newStartDate || !metadata?.newEndDate) {
+      throw new BadRequestException(
+        'New dates are required for postponement',
+      );
+    }
+
+    event.eventDate = metadata.newStartDate;
+    event.eventClosingDate = metadata.newEndDate;
+  }
+
+  event.status = nextStatus;
+}

--- a/src/events/lifecycle/event.transitions.ts
+++ b/src/events/lifecycle/event.transitions.ts
@@ -1,0 +1,19 @@
+import { EventStatus } from '../../common/enums/event-status.enum';
+
+export const EVENT_STATUS_TRANSITIONS: Record<EventStatus, EventStatus[]> = {
+  [EventStatus.DRAFT]: [
+    EventStatus.PUBLISHED,
+    EventStatus.CANCELLED,
+  ],
+  [EventStatus.PUBLISHED]: [
+    EventStatus.POSTPONED,
+    EventStatus.COMPLETED,
+    EventStatus.CANCELLED,
+  ],
+  [EventStatus.POSTPONED]: [
+    EventStatus.PUBLISHED,
+    EventStatus.CANCELLED,
+  ],
+  [EventStatus.COMPLETED]: [],
+  [EventStatus.CANCELLED]: [],
+};

--- a/src/events/lifecycle/event.validators.ts
+++ b/src/events/lifecycle/event.validators.ts
@@ -1,0 +1,28 @@
+import { BadRequestException } from '@nestjs/common';
+import { Event } from '../entities/event.entity';
+
+export function validateForPublish(event: Event) {
+  if (event.eventDate >= event.eventClosingDate) {
+    throw new BadRequestException(
+      'Event date must be before closing date',
+    );
+  }
+
+  if (event.capacity < 1) {
+    throw new BadRequestException(
+      'Event capacity must be greater than zero',
+    );
+  }
+
+  if (event.eventComingSoon) {
+    throw new BadRequestException(
+      'Event marked as coming soon cannot be published',
+    );
+  }
+
+  if (event.eventDate < new Date()) {
+    throw new BadRequestException(
+      'Cannot publish an event in the past',
+    );
+  }
+}


### PR DESCRIPTION
This PR implements a clear and validated event lifecycle for events in the backend.

What was done
- Introduced explicit event status transitions (Draft, Published, Cancelled, Postponed, Completed)
- Centralized event state validation in the EventsService
- Prevented invalid state transitions (e.g. cancelling a completed event)
- Ensured default event status is Draft on creation
- Added a dedicated endpoint for changing event status
 Why
The UI exposes Create Event and Manage Event flows that depend on predictable event states.
This change ensures backend behavior matches the UI flow and prevents invalid business actions.

Acceptance criteria
- Event lifecycle transitions are explicit and validated ✅
- Invalid state transitions are rejected ✅
- Business rules live in the service/domain layer ✅

closes #392 