### PR TITLE
Add contact message domain and persistence

### DIFF
--- a/src/contact/contact.controller.ts
+++ b/src/contact/contact.controller.ts
@@ -1,4 +1,6 @@
-import { Controller } from '@nestjs/common';
+import { Controller, Body, Post } from '@nestjs/common';
+import { ContactService } from './contact.service';
+import { CreateContactMessageDto } from './dto/create-contact-message.dto';
 
 /**
  * Contact Controller for VeriTix
@@ -27,6 +29,13 @@ import { Controller } from '@nestjs/common';
  */
 @Controller('contact')
 export class ContactController {
+  constructor(private readonly contactService: ContactService) {}
+
   // Endpoint implementations will be added in future issues
   // No business logic in controllers - per architectural requirements
+  @Post()
+  async submit(@Body() dto: CreateContactMessageDto) {
+    await this.contactService.create(dto);
+    return { success: true };
+  }
 }

--- a/src/contact/contact.module.ts
+++ b/src/contact/contact.module.ts
@@ -1,6 +1,8 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContactService } from './contact.service';
 import { ContactController } from './contact.controller';
+import { ContactMessage } from './entities/contact-message.entity';
 
 /**
  * Contact Module for VeriTix
@@ -38,6 +40,7 @@ import { ContactController } from './contact.controller';
  * ```
  */
 @Module({
+  imports: [TypeOrmModule.forFeature([ContactMessage])],
   controllers: [ContactController],
   providers: [ContactService],
   exports: [ContactService],

--- a/src/contact/contact.service.ts
+++ b/src/contact/contact.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 import {
   ContactInquiry,
   ContactSummary,
@@ -7,6 +9,8 @@ import {
   UpdateContactData,
   ContactFilterOptions,
 } from './interfaces/contact.interface';
+import { CreateContactMessageDto } from './dto/create-contact-message.dto';
+import { ContactMessage } from './entities/contact-message.entity';
 
 /**
  * Contact Service for VeriTix
@@ -20,6 +24,16 @@ import {
  */
 @Injectable()
 export class ContactService {
+  constructor(
+    @InjectRepository(ContactMessage)
+    private readonly contactRepo: Repository<ContactMessage>,
+  ) {}
+
+  async create(dto: CreateContactMessageDto): Promise<ContactMessage> {
+    const message = this.contactRepo.create(dto);
+    return this.contactRepo.save(message);
+  }
+
   /**
    * Submits a new contact inquiry.
    * @param _data - The contact submission data

--- a/src/contact/dto/create-contact-message.dto.ts
+++ b/src/contact/dto/create-contact-message.dto.ts
@@ -1,0 +1,22 @@
+import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+export class CreateContactMessageDto {
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(100)
+  name: string;
+
+  @IsEmail()
+  @MaxLength(255)
+  email: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(150)
+  subject: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(5000)
+  message: string;
+}

--- a/src/contact/entities/contact-message.entity.ts
+++ b/src/contact/entities/contact-message.entity.ts
@@ -1,0 +1,27 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+} from 'typeorm';
+
+@Entity('contact_messages')
+export class ContactMessage {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ length: 100 })
+  name: string;
+
+  @Column({ length: 255 })
+  email: string;
+
+  @Column({ length: 150 })
+  subject: string;
+
+  @Column({ type: 'text' })
+  message: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,18 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    }),
+  );
+
   await app.listen(process.env.PORT ?? 3000);
 }
 void bootstrap();


### PR DESCRIPTION
### Description

Implements the Contact message feature to allow the backend to accept and store messages submitted from the public Contact page.

Key changes:

- [x] Added ContactMessage entity/model
- [x] Persisted name, email, subject, message, and timestamp
- [x] Introduced DTOs with input validation
- [x] Added public endpoint to submit contact messages
- [x] No external integrations or email sending

### Sample request
```json
{
  "name": "Jane Doe",
  "email": "jane@example.com",
  "subject": "Partnership inquiry",
  "message": "I'd like to learn more about Veritix."
}
```

### Sample response
```json
{ "success": true }
```

Closes #397