### PR TITLE
feat(auth): wire up email service in AuthService (#439)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.0.0",
+        "@nestjs/swagger": "^11.2.6",
         "@nestjs/throttler": "^6.4.0",
         "@nestjs/typeorm": "^11.0.0",
         "@sendgrid/mail": "^8.1.6",
@@ -242,6 +243,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1982,6 +1984,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.16.0.tgz",
+      "integrity": "sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.1.1.tgz",
@@ -2368,6 +2376,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/common/-/common-11.1.12.tgz",
       "integrity": "sha512-v6U3O01YohHO+IE3EIFXuRuu3VJILWzyMmSYZXpyBbnp0hk0mFyHxK2w3dF4I5WnbwiRbWlEXdeXFvPQ7qaZzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "file-type": "21.3.0",
         "iterare": "1.2.1",
@@ -2415,6 +2424,7 @@
       "integrity": "sha512-97DzTYMf5RtGAVvX1cjwpKRiCUpkeQ9CCzSAenqkAhOmNVVFaApbhuw+xrDt13rsCa2hHVOYPrV4dBgOYMJjsA==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@nuxt/opencollective": "0.4.1",
         "fast-safe-stringify": "2.1.1",
@@ -2498,6 +2508,7 @@
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.12.tgz",
       "integrity": "sha512-GYK/vHI0SGz5m8mxr7v3Urx8b9t78Cf/dj5aJMZlGd9/1D9OI1hAl00BaphjEXINUJ/BQLxIlF2zUjrYsd6enQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cors": "2.8.5",
         "express": "5.2.1",
@@ -2638,6 +2649,45 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.6.tgz",
+      "integrity": "sha512-oiXOxMQqDFyv1AKAqFzSo6JPvMEs4uA36Eyz/s2aloZLxUjcLfUMELSLSNQunr61xCPTpwEOShfmO7NIufKXdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.16.0",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.1",
+        "lodash": "4.17.23",
+        "path-to-regexp": "8.3.0",
+        "swagger-ui-dist": "5.31.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0 || ^9.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@nestjs/swagger/node_modules/lodash": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.1.12",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.1.12.tgz",
@@ -2777,6 +2827,13 @@
         "node": ">=14"
       }
     },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/@sendgrid/client": {
       "version": "8.1.6",
       "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-8.1.6.tgz",
@@ -2888,6 +2945,7 @@
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -2960,6 +3018,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -3483,6 +3542,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.7.tgz",
       "integrity": "sha512-MciR4AKGHWl7xwxkBa6xUGxQJ4VBOmPTF7sL+iGzuahOFaO0jHCsuEfS80pan1ef4gWId1oWOweIhrDEYLuaOw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3653,6 +3713,7 @@
       "integrity": "sha512-nm3cvFN9SqZGXjmw5bZ6cGmvJSyJPn0wU9gHAZZHDnZl2wF9PhHv78Xf06E0MaNk4zLVHL8hb2/c32XvyJOLQg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.1",
         "@typescript-eslint/types": "8.53.1",
@@ -4443,6 +4504,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4492,6 +4554,7 @@
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -4688,7 +4751,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -5058,6 +5120,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5167,6 +5230,7 @@
       "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-7.2.8.tgz",
       "integrity": "sha512-0HDaDLBBY/maa/LmUVAr70XUOwsiQD+jyzCBjmUErYZUKdMS9dT59PqW59PpVqfGM7ve6H0J6307JTpkCYefHQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.3.3",
         "keyv": "^5.5.5"
@@ -5339,6 +5403,7 @@
       "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -5386,13 +5451,15 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
       "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-validator": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/class-validator/-/class-validator-0.14.3.tgz",
       "integrity": "sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/validator": "^13.15.3",
         "libphonenumber-js": "^1.11.1",
@@ -6165,6 +6232,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7804,6 +7872,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -8483,7 +8552,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -8614,6 +8682,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
       "integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -9479,6 +9548,7 @@
       "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
       "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "passport-strategy": "1.x.x",
         "pause": "0.0.1",
@@ -9610,6 +9680,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
       "integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.10.1",
         "pg-pool": "^3.11.0",
@@ -9877,6 +9948,7 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -10110,7 +10182,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
       "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -10295,6 +10368,7 @@
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10969,6 +11043,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.31.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.31.0.tgz",
+      "integrity": "sha512-zSUTIck02fSga6rc0RZP3b7J7wgHXwLea8ZjgLA3Vgnb8QeOl3Wou2/j5QkzSGeoz6HusP/coYuJl33aQxQZpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -11065,6 +11148,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11423,6 +11507,7 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11583,6 +11668,7 @@
       "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
       "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sqltools/formatter": "^1.2.5",
         "ansis": "^4.2.0",
@@ -11788,6 +11874,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12056,6 +12143,7 @@
       "integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -12125,6 +12213,7 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.0.0",
+    "@nestjs/swagger": "^11.2.6",
     "@nestjs/throttler": "^6.4.0",
     "@nestjs/typeorm": "^11.0.0",
     "@sendgrid/mail": "^8.1.6",

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,18 +1,193 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { AuthService } from './auth.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { User } from './entities/user.entity';
+import { UserHelper } from './helper/user-helper';
+import { JwtHelper } from './helper/jwt-helper';
+import { Repository } from 'typeorm';
+import { CreateUserDto } from './dto/create-user.dto';
+import { UserMessages } from './helper/user-messages';
+import { SendPasswordResetOtpDto } from './dto/send-password-reset-otp.dto';
+import { ResendOtpDto } from './dto/resend-otp.dto';
+import { sendEmail } from '../config/email/email.service';
+
+jest.mock('../config/email/email.service', () => ({
+  sendEmail: jest.fn(),
+}));
 
 describe('AuthService', () => {
   let service: AuthService;
+  let userRepository: Repository<User>;
+  let userHelper: UserHelper;
+
+  const mockUserRepository = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    findOneBy: jest.fn(),
+  };
+
+  const mockUserHelper = {
+    isValidPassword: jest.fn(),
+    hashPassword: jest.fn(),
+    generateVerificationCode: jest.fn(),
+    formatUserResponse: jest.fn(),
+    verifyPassword: jest.fn(),
+  };
+
+  const mockJwtHelper = {
+    generateTokens: jest.fn(),
+    validateRefreshToken: jest.fn(),
+    generateAccessToken: jest.fn(),
+  };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [AuthService],
+      providers: [
+        AuthService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: mockUserRepository,
+        },
+        {
+          provide: UserHelper,
+          useValue: mockUserHelper,
+        },
+        {
+          provide: JwtHelper,
+          useValue: mockJwtHelper,
+        },
+      ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
+    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
+    userHelper = module.get<UserHelper>(UserHelper);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('createUser', () => {
+    it('should create a user and send a verification email', async () => {
+      const createUserDto: CreateUserDto = {
+        email: 'test@example.com',
+        fullName: 'Test User',
+        password: 'Password123',
+      };
+      const verificationCode = '1234';
+
+      mockUserRepository.findOne.mockResolvedValue(null);
+      mockUserHelper.isValidPassword.mockReturnValue(true);
+      mockUserHelper.hashPassword.mockResolvedValue('hashedPassword');
+      mockUserHelper.generateVerificationCode.mockReturnValue(verificationCode);
+      mockUserRepository.create.mockReturnValue(createUserDto);
+      mockUserRepository.save.mockResolvedValue(createUserDto);
+
+      const result = await service.createUser(createUserDto);
+
+      expect(result).toEqual({ message: UserMessages.USER_CREATED_SUCCESSFULLY });
+      expect(sendEmail).toHaveBeenCalledWith(
+        createUserDto.email,
+        'Verify Your Account',
+        'verification-email',
+        {
+          fullName: createUserDto.fullName,
+          otp1: '1',
+          otp2: '2',
+          otp3: '3',
+          otp4: '4',
+        },
+      );
+    });
+  });
+
+  describe('resendVerificationOtp', () => {
+    it('should resend verification OTP and send an email', async () => {
+      const email = 'test@example.com';
+      const user = { email, fullName: 'Test User' };
+      const verificationCode = '5678';
+
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserHelper.generateVerificationCode.mockReturnValue(verificationCode);
+      mockUserRepository.save.mockResolvedValue(user);
+
+      const result = await service.resendVerificationOtp(email);
+
+      expect(result).toEqual({ message: UserMessages.OTP_SENT });
+      expect(sendEmail).toHaveBeenCalledWith(
+        email,
+        'Verify Your Account',
+        'verification-email',
+        {
+          fullName: user.fullName,
+          otp1: '5',
+          otp2: '6',
+          otp3: '7',
+          otp4: '8',
+        },
+      );
+    });
+  });
+
+  describe('requestResetPasswordOtp', () => {
+    it('should request reset password OTP and send an email', async () => {
+      const dto: SendPasswordResetOtpDto = { email: 'test@example.com' };
+      const user = { email: dto.email, fullName: 'Test User' };
+      const otp = '9012';
+
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserHelper.generateVerificationCode.mockReturnValue(otp);
+      mockUserRepository.save.mockResolvedValue(user);
+
+      const result = await service.requestResetPasswordOtp(dto);
+
+      expect(result).toEqual({ message: UserMessages.OTP_SENT });
+      expect(sendEmail).toHaveBeenCalledWith(
+        dto.email,
+        'Password Reset OTP',
+        'reset-password-email',
+        {
+          fullName: user.fullName,
+          otp1: '9',
+          otp2: '0',
+          otp3: '1',
+          otp4: '2',
+        },
+      );
+    });
+  });
+
+  describe('resendResetPasswordVerificationOtp', () => {
+    it('should resend reset password OTP and send an email', async () => {
+      const dto: ResendOtpDto = { email: 'test@example.com' };
+      const user = { email: dto.email, fullName: 'Test User' };
+      const otp = '3456';
+
+      mockUserRepository.findOne.mockResolvedValue(user);
+      mockUserHelper.generateVerificationCode.mockReturnValue(otp);
+      mockUserRepository.save.mockResolvedValue(user);
+
+      const result = await service.resendResetPasswordVerificationOtp(dto);
+
+      expect(result).toEqual({ message: UserMessages.OTP_SENT });
+      expect(sendEmail).toHaveBeenCalledWith(
+        dto.email,
+        'Password Reset OTP',
+        'reset-password-email',
+        {
+          fullName: user.fullName,
+          otp1: '3',
+          otp2: '4',
+          otp3: '5',
+          otp4: '6',
+        },
+      );
+    });
   });
 });

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -20,6 +20,7 @@ import { VerifyOtpDto } from './dto/verify-otp.dto';
 import { SendPasswordResetOtpDto } from './dto/send-password-reset-otp.dto';
 import { ResendOtpDto } from './dto/resend-otp.dto';
 import { ResetPasswordDto } from './dto/reset-password.dto';
+import { sendEmail } from '../config/email/email.service';
 
 @Injectable()
 export class AuthService {
@@ -60,11 +61,18 @@ export class AuthService {
       isVerified: false,
     });
     await this.userRepository.save(newUser);
-    // await this.emailService.sendVerificationEmail(
-    //   createUserDto.email,
-    //   verificationCode,
-    //   createUserDto.fullName,
-    // );
+    await sendEmail(
+      createUserDto.email,
+      'Verify Your Account',
+      'verification-email',
+      {
+        fullName: createUserDto.fullName,
+        otp1: verificationCode[0],
+        otp2: verificationCode[1],
+        otp3: verificationCode[2],
+        otp4: verificationCode[3],
+      },
+    );
 
     return {
       message: UserMessages.USER_CREATED_SUCCESSFULLY,
@@ -161,11 +169,13 @@ export class AuthService {
       user.verificationCodeExpiresAt = moment().add(10, 'minutes').toDate();
       await this.userRepository.save(user);
 
-      // await this.emailService.sendVerificationEmail(
-      //   user.email,
-      //   verificationCode,
-      //   user.fullName,
-      // );
+      await sendEmail(user.email, 'Verify Your Account', 'verification-email', {
+        fullName: user.fullName,
+        otp1: verificationCode[0],
+        otp2: verificationCode[1],
+        otp3: verificationCode[2],
+        otp4: verificationCode[3],
+      });
 
       return { message: UserMessages.OTP_SENT };
     } catch (error) {
@@ -247,11 +257,13 @@ export class AuthService {
     user.passwordResetCodeExpiresAt = moment().add(10, 'minutes').toDate();
     await this.userRepository.save(user);
 
-    // await this.emailService.sendPasswordResetEmail(
-    //   user.email,
-    //   otp,
-    //   user.fullName,
-    // );
+    await sendEmail(user.email, 'Password Reset OTP', 'reset-password-email', {
+      fullName: user.fullName,
+      otp1: otp[0],
+      otp2: otp[1],
+      otp3: otp[2],
+      otp4: otp[3],
+    });
 
     return { message: UserMessages.OTP_SENT };
   }
@@ -275,11 +287,13 @@ export class AuthService {
       user.passwordResetCodeExpiresAt = moment().add(10, 'minutes').toDate();
       await this.userRepository.save(user);
 
-      // await this.emailService.sendPasswordResetEmail(
-      //   user.email,
-      //   otp,
-      //   user.fullName,
-      // );
+      await sendEmail(user.email, 'Password Reset OTP', 'reset-password-email', {
+        fullName: user.fullName,
+        otp1: otp[0],
+        otp2: otp[1],
+        otp3: otp[2],
+        otp4: otp[3],
+      });
 
       return { message: UserMessages.OTP_SENT };
     } catch (error) {


### PR DESCRIPTION
## Overview
This PR connects the email-sending calls in `AuthService` that were previously commented out. It enables sending verification emails (on sign-up and resend) and password reset emails.

## Related Issue
Closes #439

## Changes

### Auth Component
- **[MODIFY]** `src/auth/auth.service.ts`
  - Imported `sendEmail` from `src/config/email/email.service.ts`.
  - Uncommented and completed the four email call sites:
    - `createUser`: Sends verification email after saving a new user.
    - `resendVerificationOtp`: Sends verification email.
    - `requestResetPasswordOtp`: Sends password-reset email.
    - `resendResetPasswordVerificationOtp`: Sends password-reset email.
  - Implemented logic to split the 4-digit OTP into individual characters (`otp1`, `otp2`, `otp3`, `otp4`) to match the requirements of the HTML templates.

### Testing
- **[MODIFY]** `src/auth/auth.service.spec.ts`
  - Added unit tests to mock `sendEmail` and assert it is called with the correct arguments (email, subject, template name, and placeholders).
  - Verified that all 5 tests pass successfully.

---

## Verification Results

### 1. Automated Unit Tests
All tests in `AuthService` passed successfully.
**Screenshot of test results:**
<img width="876" height="420" alt="image" src="https://github.com/user-attachments/assets/5f5de0b3-80cb-465e-816f-6db0e161eac6" />


### 2. Mock Mode Verification
Confirmed that the email service correctly falls back to mock mode when `SENDGRID_API_KEY` is not set. 
**Screenshot of mock mode output:**
<img width="624" height="241" alt="image" src="https://github.com/user-attachments/assets/08311c6d-2d07-4676-8817-a76850c6d771" />


---

## How to Test

### 1. Run Unit Tests
Verify the business logic with the existing test suite:
```bash
npm run test -- src/auth/auth.service.spec.ts
```

### 2. Verify Mock Mode (Manual Smoke Test)
Since the email service supports a mock mode, you can verify it without a SendGrid API key by creating a temporary file `src/config/email/smoke-test.ts` with the following content:

```typescript
import { sendEmail } from './email.service';

async function testMockMode() {
  // Clear env vars to force mock mode
  process.env.SENDGRID_API_KEY = '';
  process.env.SENDGRID_SENDER = '';
  
  console.log('--- Email Mock Mode Test ---');
  const result = await sendEmail(
    'test@example.com',
    'Verify Your Account',
    'verification-email',
    {
      fullName: 'Test User',
      otp1: '1',
      otp2: '2',
      otp3: '3',
      otp4: '4',
    }
  );
  
  console.log('\nResult:', JSON.stringify(result, null, 2));
}

testMockMode();
```

Then run it using `ts-node`:
```bash
npx ts-node src/config/email/smoke-test.ts
```
