### PR TITLE
Implement ticket verification endpoints and add unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3010,7 +3010,7 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.10.tgz",
       "integrity": "sha512-udNofxftduMUEv7nqahl2nvodCiCDQ4Ge0ebzsEm6P8s0RC2tBM0Hqx0nNF5J/6t9uagFJyWIDjXy3IIWMHDJw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3052,7 +3052,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3069,7 +3068,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3086,7 +3084,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3103,7 +3100,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3120,7 +3116,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3137,7 +3132,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3154,7 +3148,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3171,7 +3164,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3188,7 +3180,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3205,7 +3196,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3219,14 +3209,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"

--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
       "json",
       "ts"
     ],
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "rootDir": "src",
     "testRegex": ".*\\.spec\\.ts$",
     "transform": {

--- a/src/verification/dto/index.ts
+++ b/src/verification/dto/index.ts
@@ -1,4 +1,10 @@
-export { VerifyTicketDto, BulkVerifyTicketsDto, VerificationQueryDto, ManualVerificationDto } from './verification-operations.dto';
+export {
+  VerifyTicketDto,
+  CheckInDto,
+  BulkVerifyTicketsDto,
+  VerificationQueryDto,
+  ManualVerificationDto,
+} from './verification-operations.dto';
 export { 
   VerificationResponseDto, 
   VerifiedTicketInfoDto, 

--- a/src/verification/dto/verification-operations.dto.ts
+++ b/src/verification/dto/verification-operations.dto.ts
@@ -39,6 +39,16 @@ export class VerifyTicketDto {
   longitude?: string;
 }
 
+export class CheckInDto {
+  @IsString()
+  @Length(1, 100)
+  ticketCode: string;
+
+  @IsOptional()
+  @IsUUID()
+  verifierId?: string;
+}
+
 export class BulkVerifyTicketsDto {
   @IsString()
   @Length(1, 100, { each: true })

--- a/src/verification/verification-log.repository.ts
+++ b/src/verification/verification-log.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { VerificationStatus } from './interfaces/verification.interface';
+import { VerificationLog } from './entities/verification-log.entity';
 
 export interface CreateLogDto {
   ticketId: string | null;

--- a/src/verification/verification.controller.spec.ts
+++ b/src/verification/verification.controller.spec.ts
@@ -1,0 +1,196 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UnprocessableEntityException } from '@nestjs/common';
+import { VerificationController } from './verification.controller';
+import { VerificationService } from './verification.service';
+import { VerificationStatus } from './interfaces/verification.interface';
+import { JwtAuthGuard } from '../auth/guard/jwt.auth.guard';
+import { RolesGuard } from '../auth/guard/roles.guard';
+
+const validResult = {
+  status: VerificationStatus.VALID,
+  isValid: true,
+  message: 'Ticket is valid. Entry permitted.',
+  verifiedAt: new Date(),
+  verifiedBy: 'verifier-1',
+};
+
+const invalidResult = {
+  status: VerificationStatus.ALREADY_USED,
+  isValid: false,
+  message: 'Ticket has already been used. Entry denied.',
+  verifiedAt: new Date(),
+  verifiedBy: 'verifier-1',
+};
+
+const mockUser = {
+  id: 'user-uuid',
+  email: 'organizer@test.com',
+  fullName: 'Test Organizer',
+  role: 'ORGANIZER',
+} as any;
+
+describe('VerificationController', () => {
+  let controller: VerificationController;
+  let verificationService: VerificationService;
+
+  const mockVerifyTicket = jest.fn();
+  const mockCheckIn = jest.fn();
+  const mockPeek = jest.fn();
+  const mockGetLogsForEvent = jest.fn();
+  const mockGetStatsForEvent = jest.fn();
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [VerificationController],
+      providers: [
+        {
+          provide: VerificationService,
+          useValue: {
+            verifyTicket: mockVerifyTicket,
+            checkIn: mockCheckIn,
+            peek: mockPeek,
+            getLogsForEvent: mockGetLogsForEvent,
+            getStatsForEvent: mockGetStatsForEvent,
+          },
+        },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue({ canActivate: () => true })
+      .overrideGuard(RolesGuard)
+      .useValue({ canActivate: () => true })
+      .compile();
+
+    controller = module.get<VerificationController>(VerificationController);
+    verificationService = module.get<VerificationService>(VerificationService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('POST /verification/verify', () => {
+    it('returns 200 and result when ticket is valid', async () => {
+      mockVerifyTicket.mockResolvedValue(validResult);
+      const dto = { ticketCode: 'QR123', markAsUsed: false };
+      const result = await controller.verify(dto, mockUser);
+      expect(result).toEqual(validResult);
+      expect(mockVerifyTicket).toHaveBeenCalledWith({
+        ticketCode: 'QR123',
+        eventId: undefined,
+        verifierId: 'user-uuid',
+        markAsUsed: false,
+      });
+    });
+
+    it('throws UnprocessableEntityException (422) when ticket is invalid', async () => {
+      mockVerifyTicket.mockResolvedValue(invalidResult);
+      const dto = { ticketCode: 'QR456', markAsUsed: false };
+      await expect(controller.verify(dto, mockUser)).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+      await expect(controller.verify(dto, mockUser)).rejects.toMatchObject({
+        response: invalidResult,
+      });
+    });
+
+    it('passes verifierId from body when provided', async () => {
+      mockVerifyTicket.mockResolvedValue(validResult);
+      const dto = {
+        ticketCode: 'QR789',
+        verifierId: 'custom-verifier-id',
+        markAsUsed: true,
+      };
+      await controller.verify(dto, mockUser);
+      expect(mockVerifyTicket).toHaveBeenCalledWith({
+        ticketCode: 'QR789',
+        eventId: undefined,
+        verifierId: 'custom-verifier-id',
+        markAsUsed: true,
+      });
+    });
+  });
+
+  describe('POST /verification/check-in', () => {
+    it('returns 200 and result when check-in is valid', async () => {
+      mockCheckIn.mockResolvedValue(validResult);
+      const dto = { ticketCode: 'QR123' };
+      const result = await controller.checkIn(dto, mockUser);
+      expect(result).toEqual(validResult);
+      expect(mockCheckIn).toHaveBeenCalledWith('QR123', 'user-uuid');
+    });
+
+    it('throws UnprocessableEntityException (422) when check-in is invalid', async () => {
+      mockCheckIn.mockResolvedValue(invalidResult);
+      const dto = { ticketCode: 'QR456' };
+      await expect(controller.checkIn(dto, mockUser)).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+      await expect(controller.checkIn(dto, mockUser)).rejects.toMatchObject({
+        response: invalidResult,
+      });
+    });
+
+    it('passes verifierId from body when provided', async () => {
+      mockCheckIn.mockResolvedValue(validResult);
+      const dto = { ticketCode: 'QR789', verifierId: 'staff-id' };
+      await controller.checkIn(dto, mockUser);
+      expect(mockCheckIn).toHaveBeenCalledWith('QR789', 'staff-id');
+    });
+  });
+
+  describe('GET /verification/peek/:ticketCode', () => {
+    it('returns 200 and result when ticket is valid', async () => {
+      mockPeek.mockResolvedValue(validResult);
+      const result = await controller.peek('QR-PEEK');
+      expect(result).toEqual(validResult);
+      expect(mockPeek).toHaveBeenCalledWith('QR-PEEK');
+    });
+
+    it('throws UnprocessableEntityException (422) when ticket is invalid', async () => {
+      mockPeek.mockResolvedValue(invalidResult);
+      await expect(controller.peek('QR-BAD')).rejects.toThrow(
+        UnprocessableEntityException,
+      );
+      await expect(controller.peek('QR-BAD')).rejects.toMatchObject({
+        response: invalidResult,
+      });
+    });
+  });
+
+  describe('GET /verification/stats/:eventId', () => {
+    it('returns 200 with stats object', async () => {
+      const stats = {
+        eventId: 'event-uuid',
+        totalTickets: 100,
+        verifiedCount: 25,
+        remainingCount: 75,
+        verificationRate: 25,
+        calculatedAt: new Date(),
+      };
+      mockGetStatsForEvent.mockResolvedValue(stats);
+      const result = await controller.getStats('event-uuid');
+      expect(result).toEqual(stats);
+      expect(mockGetStatsForEvent).toHaveBeenCalledWith('event-uuid');
+    });
+  });
+
+  describe('GET /verification/logs/:eventId', () => {
+    it('returns 200 with logs array', async () => {
+      const logs = [
+        {
+          id: 'log-1',
+          ticketCode: 'QR1',
+          eventId: 'event-uuid',
+          status: VerificationStatus.VALID,
+          verifiedAt: new Date(),
+        },
+      ];
+      mockGetLogsForEvent.mockResolvedValue(logs);
+      const result = await controller.getLogs('event-uuid');
+      expect(result).toEqual(logs);
+      expect(mockGetLogsForEvent).toHaveBeenCalledWith('event-uuid');
+    });
+  });
+});

--- a/src/verification/verification.controller.ts
+++ b/src/verification/verification.controller.ts
@@ -1,24 +1,96 @@
-import { Controller } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Get,
+  Body,
+  Param,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  UnprocessableEntityException,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import { VerificationService } from './verification.service';
+import { VerifyTicketDto, CheckInDto } from './dto';
+import { JwtAuthGuard } from '../auth/guard/jwt.auth.guard';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { CurrentUser } from '../auth/decorators/current.user.decorators';
+import { UserRole } from '../auth/common/enum/user-role-enum';
+import { User } from '../auth/entities/user.entity';
+import type { VerificationResult, VerificationStats } from './interfaces/verification.interface';
+import type { VerificationLog } from './interfaces/verification.interface';
 
 /**
  * Verification Controller for VeriTix
  *
- * This controller handles ticket verification HTTP endpoints.
- * Currently a placeholder as per architectural requirements
- * (no business logic in controllers).
- *
- * Future endpoints to be implemented:
- * - POST /verification/verify - Verify a ticket code
- * - POST /verification/check-in - Verify and mark ticket as used
- * - GET /verification/peek/:ticketCode - Check ticket without marking as used
- * - GET /verification/stats/:eventId - Get verification stats for event
- * - GET /verification/logs/:eventId - Get verification logs for event
- *
- * Note: Endpoint implementations will be added when the
- * verification features are implemented.
+ * Handles ticket verification HTTP endpoints. All business logic is delegated
+ * to VerificationService. Returns 200 for valid/success, 422 for invalid ticket states.
  */
 @Controller('verification')
 export class VerificationController {
-  // Endpoint implementations will be added in future issues
-  // No business logic in controllers - per architectural requirements
+  constructor(private readonly verificationService: VerificationService) {}
+
+  @Post('verify')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ORGANIZER, UserRole.ADMIN)
+  async verify(
+    @Body() dto: VerifyTicketDto,
+    @CurrentUser() user: User,
+  ): Promise<VerificationResult> {
+    const result = await this.verificationService.verifyTicket({
+      ticketCode: dto.ticketCode,
+      eventId: dto.eventId,
+      verifierId: dto.verifierId ?? user.id,
+      markAsUsed: dto.markAsUsed ?? false,
+    });
+    if (!result.isValid) {
+      throw new UnprocessableEntityException(result);
+    }
+    return result;
+  }
+
+  @Post('check-in')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ORGANIZER, UserRole.ADMIN)
+  async checkIn(
+    @Body() dto: CheckInDto,
+    @CurrentUser() user: User,
+  ): Promise<VerificationResult> {
+    const result = await this.verificationService.checkIn(
+      dto.ticketCode,
+      dto.verifierId ?? user.id,
+    );
+    if (!result.isValid) {
+      throw new UnprocessableEntityException(result);
+    }
+    return result;
+  }
+
+  @Get('peek/:ticketCode')
+  async peek(@Param('ticketCode') ticketCode: string): Promise<VerificationResult> {
+    const result = await this.verificationService.peek(ticketCode);
+    if (!result.isValid) {
+      throw new UnprocessableEntityException(result);
+    }
+    return result;
+  }
+
+  @Get('stats/:eventId')
+  @UseGuards(JwtAuthGuard)
+  async getStats(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+  ): Promise<VerificationStats> {
+    return this.verificationService.getStatsForEvent(eventId);
+  }
+
+  @Get('logs/:eventId')
+  @UseGuards(JwtAuthGuard)
+  async getLogs(
+    @Param('eventId', ParseUUIDPipe) eventId: string,
+  ): Promise<VerificationLog[]> {
+    return this.verificationService.getLogsForEvent(eventId);
+  }
 }

--- a/src/verification/verification.module.ts
+++ b/src/verification/verification.module.ts
@@ -2,8 +2,11 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { VerificationService } from './verification.service';
 import { VerificationController } from './verification.controller';
-import { VerificationLog } from './verification-log.entity';
+import { VerificationLog } from './entities/verification-log.entity';
 import { VerificationLogRepository } from './verification-log.repository';
+import { TicketsModule } from '../tickets-inventory/tickets.module';
+import { EventsModule } from '../events/events.module';
+import { AuthModule } from '../auth/auth.module';
 
 /**
  * Verification Module for VeriTix
@@ -39,7 +42,13 @@ import { VerificationLogRepository } from './verification-log.repository';
  * ```
  */
 @Module({
-  controllers: [TypeOrmModule.forFeature([VerificationLog]), VerificationController],
+  imports: [
+    TypeOrmModule.forFeature([VerificationLog]),
+    TicketsModule,
+    EventsModule,
+    AuthModule,
+  ],
+  controllers: [VerificationController],
   providers: [VerificationService, VerificationLogRepository],
   exports: [VerificationService, VerificationLogRepository],
 })


### PR DESCRIPTION
## Summary

- implemented five endpoints (verify, check-in, peek, stats, logs) with correct guards, roles, and 200/422 behavior.
- add eleven controller tests for all five endpoints with mocked service and overridden guards.
- added moduleNameMapper for src/* so tests resolve absolute imports.

Closes #434 