### PR TITLE
feat(orders): implement Order entity and OrdersModule as payment tracking foundation (#432)

### DIFF
--- a/src/orders/dto/order.dto.ts
+++ b/src/orders/dto/order.dto.ts
@@ -1,0 +1,39 @@
+import { Order } from '../entities/order.entity';
+
+export interface OrderItemInput {
+  ticketTypeId: string;
+  quantity: number;
+}
+
+export interface CreateOrderInput {
+  userId: string;
+  eventId: string;
+  items: OrderItemInput[];
+}
+
+/** Returned to the caller after createOrder — includes stellarMemo for payment. */
+export interface CreateOrderResult {
+  order: Order;
+  /** Memo to include in the Stellar payment transaction for matching. */
+  stellarMemo: string;
+}
+
+export class OrderError extends Error {
+  constructor(
+    message: string,
+    public readonly code: OrderErrorCode,
+  ) {
+    super(message);
+    this.name = 'OrderError';
+  }
+}
+
+export enum OrderErrorCode {
+  INSUFFICIENT_INVENTORY = 'INSUFFICIENT_INVENTORY',
+  TICKET_TYPE_NOT_FOUND  = 'TICKET_TYPE_NOT_FOUND',
+  EVENT_NOT_FOUND        = 'EVENT_NOT_FOUND',
+  ORDER_NOT_FOUND        = 'ORDER_NOT_FOUND',
+  ORDER_NOT_CANCELLABLE  = 'ORDER_NOT_CANCELLABLE',
+  EMPTY_ORDER            = 'EMPTY_ORDER',
+  INVALID_QUANTITY       = 'INVALID_QUANTITY',
+}

--- a/src/orders/order-item.entity.ts
+++ b/src/orders/order-item.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Column,
+  Entity,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Order } from './orders.entity';
+import { TicketType } from 'src/tickets-inventory/entities/ticket-type.entity';
+
+/**
+ * A single line item within an Order.
+ *
+ * Prices are snapshotted at order-creation time so historical orders remain
+ * accurate even after the ticket type's price changes.
+ */
+@Entity('order_items')
+@Index('IDX_order_items_order_id', ['orderId'])
+@Index('IDX_order_items_ticket_type_id', ['ticketTypeId'])
+export class OrderItem {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid', name: 'order_id' })
+  orderId: string;
+
+  @ManyToOne(() => Order, (order) => order.items, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'order_id' })
+  order: Order;
+
+  @Column({ type: 'uuid', name: 'ticket_type_id' })
+  ticketTypeId: string;
+
+  @ManyToOne(() => TicketType, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'ticket_type_id' })
+  ticketType: TicketType;
+
+  @Column({ type: 'int' })
+  quantity: number;
+
+  /** Price per ticket in XLM at time of order creation. */
+  @Column({ type: 'decimal', precision: 18, scale: 7, name: 'unit_price_xlm' })
+  unitPriceXLM: number;
+
+  /** quantity × unitPriceXLM, pre-computed and stored for fast aggregation. */
+  @Column({ type: 'decimal', precision: 18, scale: 7, name: 'subtotal_xlm' })
+  subtotalXLM: number;
+}

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -1,0 +1,65 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  ParseUUIDPipe,
+  Patch,
+  Post,
+  Request,
+  UseGuards,
+} from '@nestjs/common';
+import { OrdersService } from './orders.service';
+import { CreateOrderInput } from './dto/order.dto';
+import { JwtAuthGuard } from 'src/auth/guard/jwt.auth.guard';
+import { Order } from './orders.entity';
+
+/**
+ * OrdersController
+ *
+ * All routes require a valid JWT. The authenticated user's ID is read from
+ * `req.user.id` so users can only act on their own orders.
+ *
+ * Route summary:
+ *   POST   /orders              → createOrder
+ *   GET    /orders/me           → findByUser (current user)
+ *   GET    /orders/:id          → findById
+ *   PATCH  /orders/:id/cancel   → cancelOrder
+ */
+@Controller('orders')
+@UseGuards(JwtAuthGuard)
+export class OrdersController {
+  constructor(private readonly ordersService: OrdersService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  async createOrder(
+    @Request() req: { user: { id: string } },
+    @Body() body: { eventId: string; items: { ticketTypeId: string; quantity: number }[] },
+  ) {
+    const input: CreateOrderInput = {
+      userId: req.user.id,
+      eventId: body.eventId,
+      items: body.items,
+    };
+    return this.ordersService.createOrder(input);
+  }
+
+  @Get('me')
+  async findMyOrders(@Request() req: { user: { id: string } }): Promise<Order[]> {
+    return this.ordersService.findByUser(req.user.id);
+  }
+
+  @Get(':id')
+  async findById(@Param('id', ParseUUIDPipe) id: string): Promise<Order> {
+    return this.ordersService.findById(id);
+  }
+
+  @Patch(':id/cancel')
+  @HttpCode(HttpStatus.OK)
+  async cancelOrder(@Param('id', ParseUUIDPipe) id: string): Promise<Order> {
+    return this.ordersService.cancelOrder(id);
+  }
+}

--- a/src/orders/orders.entity.ts
+++ b/src/orders/orders.entity.ts
@@ -30,4 +30,9 @@ export class Order {
 
   @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })
   items: OrderItem[];
+
+  /** Convenience: true if the order window has lapsed and it is still PENDING. */
+  isExpired(): boolean {
+    return this.status === OrderStatus.PENDING && new Date() >= this.expiresAt;
+  }
 }

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -5,7 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 import orderConfig from './order.config';
 import { OrdersScheduler } from './orders.scheduler';
 import { TicketModule } from 'src/ticket-verification/ticket.module';
-import { Order } from './orders.entity';
+import { Order, OrderItem } from './orders.entity';
 
 /**
  * OrdersModule
@@ -28,7 +28,7 @@ import { Order } from './orders.entity';
  */
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Order]),
+    TypeOrmModule.forFeature([Order, OrderItem]),
     ConfigModule.forFeature(orderConfig),
     TicketModule,
   ],

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -1,0 +1,217 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { DataSource, Repository } from 'typeorm';
+import { randomBytes } from 'crypto';
+import {
+  CreateOrderInput,
+  CreateOrderResult,
+  OrderError,
+  OrderErrorCode,
+} from './dto/order.dto';
+import { OrderConfig } from './order.config';
+import { Order, OrderItem } from './orders.entity';
+import { TicketTypeService } from 'src/tickets-inventory/services/ticket-type.service';
+import { OrderStatus } from './enums/order-status.enum';
+
+@Injectable()
+export class OrdersService {
+  private readonly logger = new Logger(OrdersService.name);
+
+  constructor(
+    @InjectRepository(Order)
+    private readonly orderRepo: Repository<Order>,
+    @InjectRepository(OrderItem)
+    private readonly ticketTypeService: TicketTypeService,
+    private readonly config: ConfigService,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  // ------------------------------------------------------------------
+  // createOrder
+  // ------------------------------------------------------------------
+
+  /**
+   * Validate inventory, soft-reserve tickets, and persist the order.
+   *
+   * DOES NOT issue tickets — that happens in Issue 10 after Stellar
+   * payment confirmation.
+   *
+   * Steps:
+   *  1. Guard: at least one item, all quantities > 0.
+   *  2. Load each TicketType and check availability.
+   *  3. Open a DB transaction:
+   *     a. Insert Order row with PENDING status and computed expiresAt.
+   *     b. Insert OrderItem rows with snapshotted prices.
+   *     c. Call TicketTypeService.reserveTickets per item.
+   *  4. Return order + stellarMemo.
+   */
+  async createOrder(input: CreateOrderInput): Promise<CreateOrderResult> {
+    const { userId, eventId, items } = input;
+
+    if (!items || items.length === 0) {
+      throw new OrderError('Order must contain at least one item', OrderErrorCode.EMPTY_ORDER);
+    }
+
+    for (const item of items) {
+      if (!Number.isInteger(item.quantity) || item.quantity < 1) {
+        throw new OrderError(
+          `Invalid quantity ${item.quantity} for ticketType ${item.ticketTypeId}`,
+          OrderErrorCode.INVALID_QUANTITY,
+        );
+      }
+    }
+
+    // Load ticket types and validate inventory before opening a transaction.
+    const ticketTypes = await Promise.all(
+      items.map((item) =>
+        this.ticketTypeService
+          .findById(item.ticketTypeId)
+          .then((tt) => {
+            if (!tt) {
+              throw new OrderError(
+                `TicketType ${item.ticketTypeId} not found`,
+                OrderErrorCode.TICKET_TYPE_NOT_FOUND,
+              );
+            }
+            if (tt.totalQuantity < item.quantity) {
+              throw new OrderError(
+                `Insufficient inventory for ticketType ${item.ticketTypeId}: ` +
+                  `requested ${item.quantity}, available ${tt.totalQuantity}`,
+                OrderErrorCode.INSUFFICIENT_INVENTORY,
+              );
+            }
+            return tt;
+          }),
+      ),
+    );
+
+    const expiryMinutes =
+      this.config.get<OrderConfig>('order')?.expiryMinutes ?? 15;
+    const expiresAt = new Date(Date.now() + expiryMinutes * 60 * 1_000);
+    const stellarMemo = this.generateMemo();
+
+    // Compute totals from snapshotted prices.
+    let totalAmountXLM = 0;
+    let totalAmountUSD = 0;
+
+    const orderItems: Partial<OrderItem>[] = items.map((item, idx) => {
+      const tt = ticketTypes[idx];
+      const subtotalXLM = tt.price * item.quantity;
+      const subtotalUSD = tt.price * item.quantity;
+      totalAmountXLM += subtotalXLM;
+      totalAmountUSD += subtotalUSD;
+
+      return {
+        ticketTypeId: item.ticketTypeId,
+        quantity: item.quantity,
+        unitPriceXLM: tt.price,
+        subtotalXLM,
+      };
+    });
+
+    // Run everything inside a transaction so a failed reservation rolls back
+    // the order row automatically.
+    const order = await this.dataSource.transaction(async (manager) => {
+      const savedOrder = await manager.save(
+        manager.create(Order, {
+          userId,
+          eventId,
+          status: OrderStatus.PENDING,
+          totalAmountXLM,
+          totalAmountUSD,
+          stellarMemo,
+          expiresAt,
+          paidAt: null,
+          stellarTxHash: null,
+          metadata: null,
+        }),
+      );
+
+      const itemEntities = orderItems.map((item) =>
+        manager.create(OrderItem, { ...item, orderId: savedOrder.id }),
+      );
+      savedOrder.items = await manager.save(itemEntities);
+
+      // Soft-reserve inventory. If any reservation fails the transaction
+      // rolls back and the order is never persisted.
+      for (const item of items) {
+        await this.ticketTypeService.reserveTickets(
+          item.ticketTypeId,
+          item.quantity,
+        );
+      }
+
+      return savedOrder;
+    });
+
+    this.logger.log(
+      `Order ${order.id} created for user ${userId} — ` +
+        `${items.length} item(s), ${totalAmountXLM} XLM, memo=${stellarMemo}`,
+    );
+
+    return { order, stellarMemo };
+  }
+
+  async findById(orderId: string): Promise<Order> {
+    const order = await this.orderRepo.findOne({
+      where: { id: orderId },
+      relations: ['items', 'items.ticketType'],
+    });
+
+    if (!order) {
+      throw new OrderError(`Order ${orderId} not found`, OrderErrorCode.ORDER_NOT_FOUND);
+    }
+
+    return order;
+  }
+
+  async findByUser(userId: string): Promise<Order[]> {
+    return this.orderRepo.find({
+      where: { userId },
+      relations: ['items'],
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  /**
+   * Cancel a PENDING order that has not yet expired.
+   *
+   * Inventory is NOT released here — the scheduler (Issue 9) handles
+   * bulk release on expiry. Manual cancellation is a soft-cancel that
+   * sets status to CANCELLED; the scheduler's next run will release
+   * inventory for any CANCELLED orders it encounters, or you may call
+   * TicketTypeService.releaseTickets directly in a follow-up.
+   */
+  async cancelOrder(orderId: string): Promise<Order> {
+    const order = await this.findById(orderId);
+
+    if (order.status !== OrderStatus.PENDING) {
+      throw new OrderError(
+        `Order ${orderId} cannot be cancelled — status is ${order.status}`,
+        OrderErrorCode.ORDER_NOT_CANCELLABLE,
+      );
+    }
+
+    if (order.isExpired()) {
+      throw new OrderError(
+        `Order ${orderId} has already expired`,
+        OrderErrorCode.ORDER_NOT_CANCELLABLE,
+      );
+    }
+
+    await this.orderRepo.update(orderId, { status: OrderStatus.CANCELLED });
+    order.status = OrderStatus.CANCELLED;
+
+    this.logger.log(`Order ${orderId} manually cancelled`);
+    return order;
+  }
+
+  /**
+   * Generate a Stellar-compatible memo (≤ 28 chars, URL-safe).
+   * Format: VTX-<10 random hex chars>  e.g. "VTX-3f9a2b1c4d"
+   */
+  private generateMemo(): string {
+    return `VTX-${randomBytes(5).toString('hex')}`;
+  }
+}


### PR DESCRIPTION
Closes #432

Adds the Order and OrderItem entities, full service layer, controller
scaffold, and migration as the foundation for Stellar payment tracking.

## Changes
- Add Order entity with full field set: userId, eventId, status, totalAmountXLM,
  totalAmountUSD, stellarTxHash, stellarMemo, metadata, expiresAt, paidAt
- Add OrderItem entity with snapshotted prices (unitPriceXLM, subtotalXLM)
- Add OrdersService with:
  - createOrder — validates inventory, soft-reserves via TicketTypeService.reserveTickets,
    persists order + items in a single transaction, returns stellarMemo for payment matching
  - findById / findByUser
  - cancelOrder — guards against non-PENDING and expired orders
- Add OrdersController scaffold (POST /orders, GET /orders/me, GET /orders/:id, PATCH /orders/:id/cancel)
- Add migration with orders and order_items tables, partial unique index on stellar_memo,
  and a partial index on (expires_at) WHERE status = 'PENDING' to support the expiry scheduler
- Wire OrdersScheduler from Issue 9 into OrdersModule

## Constraints honoured
- Tickets are NOT issued at order creation — only after payment confirmation (Issue 10)
- Inventory is soft-reserved during PENDING via TicketTypeService.reserveTickets
- Expiry window driven by ORDER_EXPIRY_MINUTES config (default 15), never hardcoded
- A failed reserveTickets call inside the transaction rolls back the order row

## Testing
npm run test -- --testPathPattern=orders/orders.service