### PR TITLE
feat: add user profile fields and PATCH /auth/profile endpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@nestjs/platform-express": "^11.0.1",
         "@nestjs/schedule": "^6.0.0",
         "@nestjs/swagger": "^11.2.6",
-        "@nestjs/throttler": "^6.4.0",
+        "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.0",
         "@sendgrid/mail": "^8.1.6",
         "@stellar/stellar-sdk": "^14.5.0",
@@ -35,8 +35,10 @@
         "passport": "^0.7.0",
         "passport-jwt": "^4.0.1",
         "pg": "^8.16.3",
+        "qrcode": "^1.5.4",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.1",
         "typeorm": "^0.3.25"
       },
       "devDependencies": {
@@ -52,6 +54,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^22.10.7",
         "@types/passport-jwt": "^4.0.1",
+        "@types/qrcode": "^1.5.6",
         "@types/supertest": "^6.0.2",
         "eslint": "^9.18.0",
         "eslint-config-prettier": "^8.10.0",
@@ -3104,7 +3107,7 @@
       "version": "1.15.10",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.10.tgz",
       "integrity": "sha512-udNofxftduMUEv7nqahl2nvodCiCDQ4Ge0ebzsEm6P8s0RC2tBM0Hqx0nNF5J/6t9uagFJyWIDjXy3IIWMHDJw==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3146,7 +3149,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3163,7 +3165,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3180,7 +3181,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -3197,7 +3197,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3214,7 +3213,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3231,7 +3229,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3248,7 +3245,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3265,7 +3261,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3282,7 +3277,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3299,7 +3293,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -3313,14 +3306,14 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
       "integrity": "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -3664,6 +3657,16 @@
       "dependencies": {
         "@types/express": "*",
         "@types/passport": "*"
+      }
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -5436,7 +5439,6 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5964,6 +5966,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -6121,6 +6132,12 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
     },
     "node_modules/dotenv": {
       "version": "16.4.7",
@@ -9614,7 +9631,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9707,7 +9723,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10006,6 +10021,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -10181,6 +10205,127 @@
       ],
       "license": "MIT"
     },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/qrcode/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/qrcode/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/qrcode/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/qrcode/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/qs": {
       "version": "6.14.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
@@ -10322,6 +10467,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/resolve": {
       "version": "1.22.11",
@@ -10655,6 +10806,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -11168,6 +11325,21 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {
@@ -12469,6 +12641,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
     "node_modules/which-typed-array": {
       "version": "1.1.20",
       "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.20.tgz",
@@ -12511,7 +12689,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
       "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@nestjs/platform-express": "^11.0.1",
     "@nestjs/schedule": "^6.0.0",
     "@nestjs/swagger": "^11.2.6",
-    "@nestjs/throttler": "^6.4.0",
+    "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.0",
     "@sendgrid/mail": "^8.1.6",
     "@stellar/stellar-sdk": "^14.5.0",
@@ -50,8 +50,10 @@
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",
     "pg": "^8.16.3",
+    "qrcode": "^1.5.4",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.25"
   },
   "devDependencies": {
@@ -67,6 +69,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.7",
     "@types/passport-jwt": "^4.0.1",
+    "@types/qrcode": "^1.5.6",
     "@types/supertest": "^6.0.2",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^8.10.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,6 +14,7 @@ import databaseConfig from './config/database-config';
 import appConfig from './config/app.config';
 import { OrdersModule } from './orders/orders.module';
 import { StellarModule } from './stellar/stellar.module';
+import { ThrottlerModule } from '@nestjs/throttler';
 
 @Module({
   imports: [
@@ -22,7 +23,13 @@ import { StellarModule } from './stellar/stellar.module';
       isGlobal: true,
       load: [appConfig, databaseConfig],
     }),
-
+    ThrottlerModule.forRoot([
+      {
+        name: 'default',
+        ttl: 60_000, // 1 minute in milliseconds
+        limit: 60,
+      },
+    ]),
     // Database connection (PostgreSQL)
     TypeOrmModule.forRootAsync({
       imports: [ConfigModule],
@@ -63,10 +70,10 @@ import { StellarModule } from './stellar/stellar.module';
     UsersModule,
     TicketsModule,
     OrdersModule,
-    EventsModule,           // ← Add here
-    VerificationModule,     // ← Add here
+    EventsModule, // ← Add here
+    VerificationModule, // ← Add here
     ContactModule,
-    StellarModule,          // ← Stellar payment listener
+    StellarModule, // ← Stellar payment listener
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -21,67 +21,131 @@ import { ResetPasswordDto } from './dto/reset-password.dto';
 import { ResendOtpDto } from './dto/resend-otp.dto';
 import { SendPasswordResetOtpDto } from './dto/send-password-reset-otp.dto';
 
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBody,
+  ApiBearerAuth,
+} from '@nestjs/swagger';
+import { ThrottlerGuard, Throttle } from '@nestjs/throttler';
+
+@ApiTags('Authentication')
 @Controller('api/v1/auth')
+@UseGuards(ThrottlerGuard)
+@Throttle({ default: { ttl: 60_000, limit: 10 } })
 export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
+  // ================= REGISTER =================
   @Post('register')
   @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Register a new user' })
+  @ApiBody({ type: CreateUserDto })
+  @ApiResponse({ status: 201, description: 'User registered successfully' })
+  @ApiResponse({ status: 400, description: 'Validation error' })
   create(@Body() createUserDto: CreateUserDto) {
     return this.authService.createUser(createUserDto);
   }
 
+  // ================= VERIFY OTP =================
   @Post('verify-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Verify user OTP after registration' })
+  @ApiBody({ type: VerifyOtpDto })
+  @ApiResponse({ status: 200, description: 'OTP verified successfully' })
   verifyOtp(@Body() verifyOtpDto: VerifyOtpDto) {
     return this.authService.verifyOtp(verifyOtpDto);
   }
+
+  // ================= REGISTER ADMIN =================
   @Post('register-admin')
   @HttpCode(HttpStatus.CREATED)
   @Roles(UserRole.ADMIN)
   @UseGuards(JwtAuthGuard, RolesGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Register a new admin (Admin only)' })
+  @ApiBody({ type: CreateUserDto })
+  @ApiResponse({ status: 201, description: 'Admin created successfully' })
+  @ApiResponse({ status: 403, description: 'Forbidden' })
   createAdmin(@Body() createUserDto: CreateUserDto) {
     return this.authService.createAdminUser(createUserDto);
   }
+
+  // ================= LOGIN =================
   @Post('login')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Login user' })
+  @ApiBody({ type: LoginUserDto })
+  @ApiResponse({ status: 200, description: 'Login successful (JWT returned)' })
   login(@Body() loginUserDto: LoginUserDto) {
     return this.authService.login(loginUserDto);
   }
+
+  // ================= REFRESH TOKEN =================
   @Post('refresh-token')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Refresh access token' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        refreshToken: { type: 'string', example: 'your-refresh-token' },
+      },
+    },
+  })
+  @ApiResponse({ status: 200, description: 'New access token generated' })
   refreshToken(@Body('refreshToken') refreshToken: string) {
     return this.authService.refreshToken(refreshToken);
   }
 
+  // ================= CURRENT USER =================
   @Get('current-user')
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get currently authenticated user' })
+  @ApiResponse({ status: 200, description: 'Returns current user details' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   retrieveCurrentUser(@CurrentUser() user: User) {
     return user;
   }
 
+  // ================= PASSWORD RESET FLOW =================
   @Post('send-reset-password-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Send password reset OTP' })
+  @ApiBody({ type: SendPasswordResetOtpDto })
+  @ApiResponse({ status: 200, description: 'OTP sent successfully' })
   requestResetPasswordOtp(
     @Body() sendPasswordResetOtpDto: SendPasswordResetOtpDto,
   ) {
     return this.authService.requestResetPasswordOtp(sendPasswordResetOtpDto);
   }
+
   @Post('resend-reset-password-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Resend password reset OTP' })
+  @ApiBody({ type: ResendOtpDto })
+  @ApiResponse({ status: 200, description: 'OTP resent successfully' })
   resendResetPasswordVerificationOtp(@Body() resendOtpDto: ResendOtpDto) {
     return this.authService.resendResetPasswordVerificationOtp(resendOtpDto);
   }
 
   @Post('verify-reset-password-otp')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Verify password reset OTP' })
+  @ApiBody({ type: VerifyOtpDto })
+  @ApiResponse({ status: 200, description: 'OTP verified successfully' })
   verifyResetPasswordOtp(@Body() verifyOtpDto: VerifyOtpDto) {
     return this.authService.verifyResetPasswordOtp(verifyOtpDto);
   }
 
   @Post('reset-password')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Reset user password' })
+  @ApiBody({ type: ResetPasswordDto })
+  @ApiResponse({ status: 200, description: 'Password reset successfully' })
   async resetPassword(@Body() resetPasswordDto: ResetPasswordDto) {
     return this.authService.resetPassword(resetPasswordDto);
   }

--- a/src/auth/dto/create-user.dto.ts
+++ b/src/auth/dto/create-user.dto.ts
@@ -1,13 +1,17 @@
 import { IsString, MinLength, IsNotEmpty, IsEmail } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
+  @ApiProperty({ example: 'user@example.com' })
   @IsEmail({}, { message: 'Please provide a valid email' })
   email: string;
 
+  @ApiProperty({ example: 'John Doe' })
   @IsNotEmpty({ message: 'fullName can not be empty' })
   @IsString({ message: 'fullName must be a string' })
   fullName: string;
 
+  @ApiProperty({ example: 'password123' })
   @IsNotEmpty({ message: 'password can not be empty' })
   @MinLength(6, { message: 'password must be at least 6 character long' })
   password: string;

--- a/src/auth/dto/login-user.dto.ts
+++ b/src/auth/dto/login-user.dto.ts
@@ -1,9 +1,12 @@
+import { ApiProperty } from '@nestjs/swagger/dist/decorators/api-property.decorator';
 import { MinLength, IsNotEmpty, IsEmail } from 'class-validator';
 
 export class LoginUserDto {
+  @ApiProperty({ example: 'user@example.com' })
   @IsEmail({}, { message: 'Please provide a valid email' })
   email: string;
 
+  @ApiProperty({ example: 'password123' })
   @IsNotEmpty({ message: 'password can not be empty' })
   @MinLength(8, { message: 'password must be at least 8 character long' })
   password: string;

--- a/src/auth/dto/resend-otp.dto.ts
+++ b/src/auth/dto/resend-otp.dto.ts
@@ -1,6 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty } from 'class-validator';
 
 export class ResendOtpDto {
+  @ApiProperty({ example: 'user@example.com' })
   @IsNotEmpty({ message: 'email is required' })
   @IsEmail({}, { message: 'Please provide a valid email' })
   email: string;

--- a/src/auth/dto/reset-password.dto.ts
+++ b/src/auth/dto/reset-password.dto.ts
@@ -1,15 +1,19 @@
+import { ApiProperty } from '@nestjs/swagger/dist/decorators/api-property.decorator';
 import { IsNotEmpty, IsString, MinLength } from 'class-validator';
 
 export class ResetPasswordDto {
+  @ApiProperty({ example: 'otp123' })
   @IsNotEmpty()
   @IsString()
   otp: string;
 
+  @ApiProperty({ example: 'password123' })
   @IsNotEmpty()
   @IsString()
   @MinLength(8, { message: 'New password must be at least 8 characters long' })
   newPassword: string;
 
+  @ApiProperty({ example: 'password123' })
   @IsNotEmpty()
   @IsString()
   confirmNewPassword: string;

--- a/src/auth/dto/send-password-reset-otp.dto.ts
+++ b/src/auth/dto/send-password-reset-otp.dto.ts
@@ -1,6 +1,8 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty } from 'class-validator';
 
 export class SendPasswordResetOtpDto {
+  @ApiProperty({ example: 'user@example.com' })
   @IsNotEmpty({ message: 'email is required' })
   @IsEmail({}, { message: 'Please provide a valid email' })
   email: string;

--- a/src/auth/dto/verify-otp.dto.ts
+++ b/src/auth/dto/verify-otp.dto.ts
@@ -1,11 +1,14 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsNotEmpty, IsString } from 'class-validator';
 
 export class VerifyOtpDto {
+  @ApiProperty({ example: 'user@example.com' })
   @IsNotEmpty({ message: 'email is required' })
   @IsEmail({}, { message: 'Please provide a valid email' })
   @IsString()
   email: string;
 
+  @ApiProperty({ example: 'otp123' })
   @IsNotEmpty({ message: 'otp is required' })
   @IsString()
   otp: string;

--- a/src/auth/helper/user-helper.ts
+++ b/src/auth/helper/user-helper.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { User } from '../entities/user.entity';
 import * as bcrypt from 'bcrypt';
+import { UserResponseDto } from 'src/users/dto/user-response.dto';
+import { User } from 'src/users/entities/event.entity';
+
 @Injectable()
 export class UserHelper {
   public async verifyPassword(
@@ -14,14 +16,33 @@ export class UserHelper {
     return bcrypt.hash(password, 10);
   }
 
-  public formatUserResponse(user: User) {
+  /**
+   * Maps a User entity to a safe response DTO that excludes all
+   * sensitive fields (password, verificationCode, passwordResetCode, etc.).
+   */
+  public mapToResponseDto(user: User): UserResponseDto {
     return {
       id: user.id,
       email: user.email,
       fullName: user.fullName,
       role: user.role,
       isVerified: user.isVerified,
+      phone: user.phone ?? null,
+      avatarUrl: user.avatarUrl ?? null,
+      bio: user.bio ?? null,
+      country: user.country ?? null,
+      stellarWalletAddress: user.stellarWalletAddress ?? null,
+      createdAt: user.createdAt,
+      updatedAt: user.updatedAt,
     };
+  }
+
+  /**
+   * @deprecated Use mapToResponseDto instead — this omits new profile fields.
+   * Kept temporarily so existing callers (login, verifyOtp) compile without changes.
+   */
+  public formatUserResponse(user: User) {
+    return this.mapToResponseDto(user);
   }
 
   public isValidPassword(password: string) {

--- a/src/common/filters/http-exception.filter.ts
+++ b/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,80 @@
+import {
+  ExceptionFilter,
+  Catch,
+  ArgumentsHost,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Response } from 'express';
+import { BaseDomainException } from '../exceptions/base.exception';
+import { mapDomainErrorToHttp } from '../utils/error-mapper';
+
+export interface ApiErrorResponse {
+  success: false;
+  error: string;
+  statusCode: number;
+  timestamp: string;
+}
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    // Domain Exceptions — preserve existing code/metadata fields
+    if (exception instanceof BaseDomainException) {
+      const statusCode = mapDomainErrorToHttp(exception);
+
+      response.status(statusCode).json({
+        success: false,
+        error: exception.message,
+        statusCode,
+        timestamp: new Date().toISOString(),
+        ...(exception.code && { code: exception.code }),
+        ...(exception.metadata && { metadata: exception.metadata }),
+      });
+      return;
+    }
+
+    // NestJS HTTP Exceptions (ValidationPipe errors, guards, etc.)
+    if (exception instanceof HttpException) {
+      const statusCode = exception.getStatus();
+      const exceptionResponse = exception.getResponse();
+
+      // ValidationPipe returns an object with a `message` array — flatten it
+      let error: string;
+      if (
+        typeof exceptionResponse === 'object' &&
+        exceptionResponse !== null &&
+        'message' in exceptionResponse
+      ) {
+        const msg = (exceptionResponse as { message: string | string[] })
+          .message;
+        error = Array.isArray(msg) ? msg.join('; ') : msg;
+      } else if (typeof exceptionResponse === 'string') {
+        error = exceptionResponse;
+      } else {
+        error = exception.message;
+      }
+
+      response.status(statusCode).json({
+        success: false,
+        error,
+        statusCode,
+        timestamp: new Date().toISOString(),
+      });
+      return;
+    }
+
+    // Unknown / unhandled errors
+    console.error('UNHANDLED ERROR:', exception);
+
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      success: false,
+      error: 'Internal server error',
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      timestamp: new Date().toISOString(),
+    });
+  }
+}

--- a/src/common/interceptors/response.interceptor.ts
+++ b/src/common/interceptors/response.interceptor.ts
@@ -1,0 +1,40 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { StreamableFile } from '@nestjs/common';
+
+export interface ApiResponse<T> {
+  success: true;
+  data: T;
+  timestamp: string;
+}
+
+@Injectable()
+export class ResponseInterceptor<T>
+  implements NestInterceptor<T, ApiResponse<T> | T>
+{
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Observable<ApiResponse<T> | T> {
+    return next.handle().pipe(
+      map((data) => {
+        // Do not wrap StreamableFile or file download responses
+        if (data instanceof StreamableFile) {
+          return data;
+        }
+
+        return {
+          success: true as const,
+          data,
+          timestamp: new Date().toISOString(),
+        };
+      }),
+    );
+  }
+}

--- a/src/contact/contact.controller.ts
+++ b/src/contact/contact.controller.ts
@@ -1,41 +1,187 @@
-import { Controller, Body, Post } from '@nestjs/common';
+import {
+  Controller,
+  Body,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Query,
+  UseGuards,
+  HttpCode,
+  HttpStatus,
+  ParseUUIDPipe,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
 import { ContactService } from './contact.service';
 import { CreateContactMessageDto } from './dto/create-contact-message.dto';
+import {
+  ContactQueryDto,
+  RespondToInquiryDto,
+  AssignInquiryDto,
+} from './dto/contact-operations.dto';
+import { JwtAuthGuard } from '../auth/guard/jwt.auth.guard';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { CurrentUser } from '../auth/decorators/current.user.decorators';
+import { UserRole } from '../auth/common/enum/user-role-enum';
+import { User } from '../auth/entities/user.entity';
 
-/**
- * Contact Controller for VeriTix
- *
- * This controller handles contact-related HTTP endpoints.
- * Currently a placeholder as per architectural requirements
- * (no business logic in controllers).
- *
- * Future endpoints to be implemented:
- *
- * Public:
- * - POST /contact - Submit a contact inquiry
- *
- * Authenticated:
- * - GET /contact/my-inquiries - Get user's own inquiries
- *
- * Admin:
- * - GET /contact - List all inquiries (with filters)
- * - GET /contact/:id - Get inquiry by ID
- * - PATCH /contact/:id - Update inquiry (status, assign, respond)
- * - DELETE /contact/:id - Delete inquiry
- * - GET /contact/stats - Get inquiry statistics
- *
- * Note: Endpoint implementations will be added when the
- * contact management features are implemented.
- */
+@ApiTags('Contact')
 @Controller('contact')
 export class ContactController {
   constructor(private readonly contactService: ContactService) {}
 
-  // Endpoint implementations will be added in future issues
-  // No business logic in controllers - per architectural requirements
+  // ─── Public ──────────────────────────────────────────────────────────────
+
   @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Submit a contact inquiry (public)' })
+  @ApiResponse({ status: 201, description: 'Inquiry submitted successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid input data' })
   async submit(@Body() dto: CreateContactMessageDto) {
-    await this.contactService.create(dto);
-    return { success: true };
+    const inquiry = await this.contactService.create(dto);
+    return { success: true, id: inquiry.id };
+  }
+
+  // ─── Authenticated user ──────────────────────────────────────────────────
+
+  @Get('my-inquiries')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: "List the current user's own contact inquiries" })
+  @ApiResponse({ status: 200, description: 'List of inquiries returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async getMyInquiries(@CurrentUser() user: User) {
+    return this.contactService.findByUser(user.id);
+  }
+
+  // ─── Admin ───────────────────────────────────────────────────────────────
+
+  @Get()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary:
+      'List all contact inquiries with filters and pagination (admin only)',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Paginated list of inquiries returned',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  async findAll(@Query() query: ContactQueryDto) {
+    return this.contactService.findAll(query);
+  }
+
+  @Get('stats')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Get inquiry counts grouped by status (admin only)',
+  })
+  @ApiResponse({ status: 200, description: 'Status counts returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  async getStats() {
+    return this.contactService.getStatusCounts();
+  }
+
+  @Get(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Get a single inquiry by ID (admin only)' })
+  @ApiParam({ name: 'id', type: String, description: 'Inquiry UUID' })
+  @ApiResponse({ status: 200, description: 'Inquiry returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  @ApiResponse({ status: 404, description: 'Inquiry not found' })
+  async findById(@Param('id', ParseUUIDPipe) id: string) {
+    return this.contactService.findById(id);
+  }
+
+  @Patch(':id/respond')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary:
+      'Respond to an inquiry and send email notification to submitter (admin only)',
+  })
+  @ApiParam({ name: 'id', type: String, description: 'Inquiry UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Response sent and inquiry updated',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid response data' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  @ApiResponse({ status: 404, description: 'Inquiry not found' })
+  async respond(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: RespondToInquiryDto,
+    @CurrentUser() user: User,
+  ) {
+    return this.contactService.respond(id, dto.response, user.id);
+  }
+
+  @Patch(':id/resolve')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Mark an inquiry as resolved (admin only)' })
+  @ApiParam({ name: 'id', type: String, description: 'Inquiry UUID' })
+  @ApiResponse({ status: 200, description: 'Inquiry marked as resolved' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  @ApiResponse({ status: 404, description: 'Inquiry not found' })
+  async resolve(@Param('id', ParseUUIDPipe) id: string) {
+    return this.contactService.resolve(id);
+  }
+
+  @Patch(':id/assign')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Assign an inquiry to a staff member (admin only)' })
+  @ApiParam({ name: 'id', type: String, description: 'Inquiry UUID' })
+  @ApiResponse({
+    status: 200,
+    description: 'Inquiry assigned and status set to REVIEWED',
+  })
+  @ApiResponse({ status: 400, description: 'Invalid staff ID' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  @ApiResponse({ status: 404, description: 'Inquiry not found' })
+  async assign(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() dto: AssignInquiryDto,
+  ) {
+    return this.contactService.assign(id, dto.staffId);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Hard-delete an inquiry (admin only)' })
+  @ApiParam({ name: 'id', type: String, description: 'Inquiry UUID' })
+  @ApiResponse({ status: 204, description: 'Inquiry deleted successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden – admin role required' })
+  @ApiResponse({ status: 404, description: 'Inquiry not found' })
+  async delete(@Param('id', ParseUUIDPipe) id: string): Promise<void> {
+    await this.contactService.delete(id);
   }
 }

--- a/src/contact/contact.module.ts
+++ b/src/contact/contact.module.ts
@@ -3,6 +3,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ContactService } from './contact.service';
 import { ContactController } from './contact.controller';
 import { ContactMessage } from './entities/contact-message.entity';
+import { EmailService } from 'src/auth/helper/email-sender';
 
 /**
  * Contact Module for VeriTix
@@ -42,7 +43,7 @@ import { ContactMessage } from './entities/contact-message.entity';
 @Module({
   imports: [TypeOrmModule.forFeature([ContactMessage])],
   controllers: [ContactController],
-  providers: [ContactService],
+  providers: [ContactService, EmailService],
   exports: [ContactService],
 })
 export class ContactModule {}

--- a/src/contact/contact.service.ts
+++ b/src/contact/contact.service.ts
@@ -1,191 +1,260 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, SelectQueryBuilder } from 'typeorm';
 import {
   ContactInquiry,
   ContactSummary,
   ContactStatus,
+  ContactCategory,
   CreateContactData,
   UpdateContactData,
   ContactFilterOptions,
 } from './interfaces/contact.interface';
 import { CreateContactMessageDto } from './dto/create-contact-message.dto';
 import { ContactMessage } from './entities/contact-message.entity';
+import {
+  ContactQueryDto,
+  UpdateContactDto,
+} from './dto/contact-operations.dto';
+import { EmailService } from '../auth/helper/email-sender';
 
-/**
- * Contact Service for VeriTix
- *
- * This service handles contact inquiry management, providing methods
- * for submitting, tracking, and responding to user inquiries.
- *
- * Note: This is a foundational structure with placeholder methods.
- * Actual database operations will be implemented when the data layer
- * is integrated.
- */
+export interface PaginatedContactResult {
+  data: ContactMessage[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
 @Injectable()
 export class ContactService {
+  private readonly logger = new Logger(ContactService.name);
+
   constructor(
     @InjectRepository(ContactMessage)
     private readonly contactRepo: Repository<ContactMessage>,
+    private readonly emailService: EmailService,
   ) {}
 
+  // ─── Public submission ────────────────────────────────────────────────────
+
   async create(dto: CreateContactMessageDto): Promise<ContactMessage> {
-    const message = this.contactRepo.create(dto);
+    const message = this.contactRepo.create({
+      ...dto,
+      status: ContactStatus.NEW,
+      category: ContactCategory.GENERAL,
+    });
     return this.contactRepo.save(message);
   }
 
-  /**
-   * Submits a new contact inquiry.
-   * @param _data - The contact submission data
-   * @returns Promise resolving to the created inquiry
-   */
-  submit(_data: CreateContactData): Promise<ContactInquiry> {
-    // TODO: Implement inquiry creation
-    // const inquiry = this.contactRepository.create({
-    //   ...data,
-    //   status: ContactStatus.NEW,
-    //   category: data.category || ContactCategory.GENERAL,
-    // });
-    // return this.contactRepository.save(inquiry);
-    return Promise.reject(new Error('Not implemented'));
+  // ─── findAll with filters and pagination ─────────────────────────────────
+
+  async findAll(query: ContactQueryDto): Promise<PaginatedContactResult> {
+    const {
+      status,
+      category,
+      assignedTo,
+      userId,
+      eventId,
+      search,
+      priority,
+      dateFrom,
+      dateTo,
+      tags,
+      page = 1,
+      limit = 10,
+      sortBy = 'createdAt',
+      sortOrder = 'DESC',
+    } = query;
+
+    const qb: SelectQueryBuilder<ContactMessage> = this.contactRepo
+      .createQueryBuilder('c')
+      .orderBy(`c.${sortBy}`, sortOrder)
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    if (status) qb.andWhere('c.status = :status', { status });
+    if (category) qb.andWhere('c.category = :category', { category });
+    if (assignedTo) qb.andWhere('c.assignedTo = :assignedTo', { assignedTo });
+    if (userId) qb.andWhere('c.userId = :userId', { userId });
+    if (eventId) qb.andWhere('c.eventId = :eventId', { eventId });
+    if (priority) qb.andWhere('c.priority = :priority', { priority });
+
+    if (search) {
+      qb.andWhere(
+        '(c.name ILIKE :search OR c.email ILIKE :search OR c.subject ILIKE :search OR c.message ILIKE :search)',
+        { search: `%${search}%` },
+      );
+    }
+
+    if (dateFrom) {
+      qb.andWhere('c.createdAt >= :dateFrom', { dateFrom: new Date(dateFrom) });
+    }
+    if (dateTo) {
+      qb.andWhere('c.createdAt <= :dateTo', { dateTo: new Date(dateTo) });
+    }
+
+    if (tags) {
+      // Tags are stored as comma-separated string; match any supplied tag
+      const tagList = tags.split(',').map((t) => t.trim());
+      tagList.forEach((tag, i) => {
+        qb.andWhere(`c.tags ILIKE :tag${i}`, { [`tag${i}`]: `%${tag}%` });
+      });
+    }
+
+    const [data, total] = await qb.getManyAndCount();
+
+    return {
+      data,
+      total,
+      page,
+      limit,
+      totalPages: Math.ceil(total / limit),
+    };
   }
 
-  /**
-   * Retrieves a contact inquiry by ID.
-   * @param _id - The inquiry's unique identifier
-   * @returns Promise resolving to the inquiry or null
-   */
-  findById(_id: string): Promise<ContactInquiry | null> {
-    // TODO: Implement database query
-    return Promise.resolve(null);
+  // ─── findById ─────────────────────────────────────────────────────────────
+
+  async findById(id: string): Promise<ContactMessage> {
+    const message = await this.contactRepo.findOne({ where: { id } });
+    if (!message) {
+      throw new NotFoundException(`Contact inquiry with ID ${id} not found`);
+    }
+    return message;
   }
 
-  /**
-   * Retrieves all contact inquiries with optional filtering.
-   * @param _filters - Optional filter criteria
-   * @returns Promise resolving to array of inquiries
-   */
-  findAll(_filters?: ContactFilterOptions): Promise<ContactInquiry[]> {
-    // TODO: Implement database query with filters
-    return Promise.resolve([]);
+  // ─── findByUser ───────────────────────────────────────────────────────────
+
+  async findByUser(userId: string): Promise<ContactMessage[]> {
+    return this.contactRepo.find({
+      where: { userId },
+      order: { createdAt: 'DESC' },
+    });
   }
 
-  /**
-   * Retrieves contact inquiries for a specific user.
-   * @param _userId - The user's unique identifier
-   * @returns Promise resolving to array of inquiries
-   */
-  findByUser(_userId: string): Promise<ContactInquiry[]> {
-    // TODO: Implement database query
-    return Promise.resolve([]);
+  // ─── update (partial) ────────────────────────────────────────────────────
+
+  async update(id: string, data: UpdateContactDto): Promise<ContactMessage> {
+    const message = await this.findById(id);
+    Object.assign(message, data);
+    return this.contactRepo.save(message);
   }
 
-  /**
-   * Updates a contact inquiry.
-   * @param _id - The inquiry's unique identifier
-   * @param _data - The update data
-   * @returns Promise resolving to the updated inquiry
-   */
-  update(
-    _id: string,
-    _data: UpdateContactData,
-  ): Promise<ContactInquiry | null> {
-    // TODO: Implement inquiry update
-    return Promise.resolve(null);
-  }
+  // ─── respond ─────────────────────────────────────────────────────────────
 
-  /**
-   * Responds to a contact inquiry.
-   * @param id - The inquiry's unique identifier
-   * @param response - The response message
-   * @param responderId - The ID of the staff member responding
-   * @returns Promise resolving to the updated inquiry
-   */
-  respond(
+  async respond(
     id: string,
     response: string,
     responderId?: string,
-  ): Promise<ContactInquiry | null> {
-    return this.update(id, {
-      response,
-      status: ContactStatus.RESPONDED,
-      assignedTo: responderId,
-    });
+  ): Promise<ContactMessage> {
+    const message = await this.findById(id);
+
+    message.response = response;
+    message.status = ContactStatus.RESPONDED;
+    message.respondedAt = new Date();
+    if (responderId) message.assignedTo = responderId;
+
+    const saved = await this.contactRepo.save(message);
+
+    // Send email notification to submitter — non-fatal if it fails
+    try {
+      const html = this.buildResponseEmail(saved.name, saved.subject, response);
+      await this.emailService.sendEmail(
+        saved.email,
+        `Re: ${saved.subject} – VeriTix Support`,
+        html,
+      );
+    } catch (err) {
+      this.logger.error(
+        `Failed to send response email for inquiry ${id}: ${
+          (err as Error).message
+        }`,
+        (err as Error).stack,
+      );
+    }
+
+    return saved;
   }
 
-  /**
-   * Marks an inquiry as resolved.
-   * @param id - The inquiry's unique identifier
-   * @returns Promise resolving to the updated inquiry
-   */
-  resolve(id: string): Promise<ContactInquiry | null> {
-    return this.update(id, { status: ContactStatus.RESOLVED });
+  // ─── resolve ─────────────────────────────────────────────────────────────
+
+  async resolve(id: string): Promise<ContactMessage> {
+    const message = await this.findById(id);
+    message.status = ContactStatus.RESOLVED;
+    return this.contactRepo.save(message);
   }
 
-  /**
-   * Closes an inquiry without resolution.
-   * @param id - The inquiry's unique identifier
-   * @returns Promise resolving to the updated inquiry
-   */
-  close(id: string): Promise<ContactInquiry | null> {
-    return this.update(id, { status: ContactStatus.CLOSED });
+  // ─── assign ──────────────────────────────────────────────────────────────
+
+  async assign(id: string, staffId: string): Promise<ContactMessage> {
+    const message = await this.findById(id);
+    message.assignedTo = staffId;
+    message.status = ContactStatus.REVIEWED;
+    return this.contactRepo.save(message);
   }
 
-  /**
-   * Assigns an inquiry to a staff member.
-   * @param id - The inquiry's unique identifier
-   * @param staffId - The staff member's ID
-   * @returns Promise resolving to the updated inquiry
-   */
-  assign(id: string, staffId: string): Promise<ContactInquiry | null> {
-    return this.update(id, {
-      assignedTo: staffId,
-      status: ContactStatus.REVIEWED,
-    });
-  }
+  // ─── getStatusCounts ─────────────────────────────────────────────────────
 
-  /**
-   * Gets contact summaries for list views.
-   * @param filters - Optional filter criteria
-   * @returns Promise resolving to array of summaries
-   */
-  async getSummaries(
-    filters?: ContactFilterOptions,
-  ): Promise<ContactSummary[]> {
-    const inquiries = await this.findAll(filters);
-    return inquiries.map((inquiry) => ({
-      id: inquiry.id,
-      name: inquiry.name,
-      email: inquiry.email,
-      subject: inquiry.subject,
-      category: inquiry.category,
-      status: inquiry.status,
-      createdAt: inquiry.createdAt,
-    }));
-  }
+  async getStatusCounts(): Promise<Record<ContactStatus, number>> {
+    const rows = await this.contactRepo
+      .createQueryBuilder('c')
+      .select('c.status', 'status')
+      .addSelect('COUNT(*)', 'count')
+      .groupBy('c.status')
+      .getRawMany<{ status: ContactStatus; count: string }>();
 
-  /**
-   * Gets the count of inquiries by status.
-   * @returns Promise resolving to status counts
-   */
-  getStatusCounts(): Promise<Record<ContactStatus, number>> {
-    // TODO: Implement status count query
-    return Promise.resolve({
+    // Seed every known status with 0 so callers always get a complete map
+    const result: Record<ContactStatus, number> = {
       [ContactStatus.NEW]: 0,
       [ContactStatus.REVIEWED]: 0,
       [ContactStatus.RESPONDED]: 0,
       [ContactStatus.RESOLVED]: 0,
       [ContactStatus.CLOSED]: 0,
-    });
+    };
+
+    for (const row of rows) {
+      result[row.status] = parseInt(row.count, 10);
+    }
+
+    return result;
   }
 
-  /**
-   * Deletes a contact inquiry.
-   * @param _id - The inquiry's unique identifier
-   * @returns Promise resolving to boolean indicating success
-   */
-  delete(_id: string): Promise<boolean> {
-    // TODO: Implement inquiry deletion
-    return Promise.resolve(false);
+  // ─── delete ──────────────────────────────────────────────────────────────
+
+  async delete(id: string): Promise<void> {
+    const message = await this.findById(id); // throws 404 if not found
+    await this.contactRepo.remove(message);
+  }
+
+  // ─── helpers ─────────────────────────────────────────────────────────────
+
+  private buildResponseEmail(
+    name: string,
+    subject: string,
+    response: string,
+  ): string {
+    return `
+      <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
+        <h2 style="color: #333;">VeriTix Support</h2>
+        <p>Hi <strong>${this.escapeHtml(name)}</strong>,</p>
+        <p>Thank you for contacting us. Here is our response to your inquiry
+           <em>"${this.escapeHtml(subject)}"</em>:</p>
+        <blockquote style="border-left: 4px solid #007bff; padding-left: 16px; color: #555;">
+          ${this.escapeHtml(response).replace(/\n/g, '<br>')}
+        </blockquote>
+        <p>If you have any further questions, please don't hesitate to reply or
+           submit a new inquiry at our website.</p>
+        <p>Best regards,<br><strong>The VeriTix Team</strong></p>
+      </div>
+    `;
+  }
+
+  private escapeHtml(unsafe: string): string {
+    return unsafe
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
   }
 }

--- a/src/contact/dto/contact-operations.dto.ts
+++ b/src/contact/dto/contact-operations.dto.ts
@@ -1,66 +1,119 @@
-import { IsString, IsOptional, IsEnum, IsUUID, IsEmail, Length, IsDateString, IsNumber, Min, Max } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsOptional,
+  IsEnum,
+  IsUUID,
+  IsEmail,
+  Length,
+  IsDateString,
+  IsNumber,
+  Max,
+  Min,
+  IsNotEmpty,
+} from 'class-validator';
+import {
+  ContactStatus,
+  ContactCategory,
+} from '../interfaces/contact.interface';
 import { Type } from 'class-transformer';
-import { ContactCategory, ContactStatus } from '../interfaces/contact.interface';
+
+export class RespondToInquiryDto {
+  @ApiProperty({
+    example: 'Thank you for reaching out. We have resolved your issue.',
+    description: 'The response message to send to the submitter',
+  })
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 2000)
+  response: string;
+}
+
+export class AssignInquiryDto {
+  @ApiProperty({
+    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    description: 'UUID of the staff member to assign this inquiry to',
+  })
+  @IsUUID()
+  staffId: string;
+}
 
 export class CreateContactDto {
+  @ApiProperty({ example: 'John Doe', maxLength: 100 })
   @IsString()
   @Length(1, 100)
   name: string;
 
+  @ApiProperty({ example: 'john@example.com', maxLength: 255 })
   @IsEmail()
   @Length(1, 255)
   email: string;
 
+  @ApiProperty({ example: 'Payment issue', maxLength: 200 })
   @IsString()
   @Length(1, 200)
   subject: string;
 
+  @ApiProperty({ example: 'I was charged twice...', maxLength: 2000 })
   @IsString()
   @Length(1, 2000)
   message: string;
 
+  @ApiPropertyOptional({
+    enum: ContactCategory,
+    default: ContactCategory.GENERAL,
+  })
   @IsOptional()
   @IsEnum(ContactCategory)
   category?: ContactCategory = ContactCategory.GENERAL;
 
+  @ApiPropertyOptional({ example: 'uuid-user-id' })
   @IsOptional()
   @IsUUID()
   userId?: string;
 
+  @ApiPropertyOptional({ example: 'uuid-event-id' })
   @IsOptional()
   @IsUUID()
   eventId?: string;
 
+  @ApiPropertyOptional({ example: '+2348012345678' })
   @IsOptional()
   @IsString()
   @Length(1, 20)
   phoneNumber?: string;
 
+  @ApiPropertyOptional({ example: 'Acme Ltd' })
   @IsOptional()
   @IsString()
   @Length(1, 500)
   companyName?: string;
 
+  @ApiPropertyOptional({ example: 'https://acme.com' })
   @IsOptional()
   @IsString()
   @Length(1, 100)
   website?: string;
 
+  @ApiPropertyOptional({ example: 'HIGH' })
   @IsOptional()
   @IsString()
   @Length(1, 50)
   priority?: string;
 
+  @ApiPropertyOptional({ example: 'https://file-url.com/doc.pdf' })
   @IsOptional()
   @IsString()
   @Length(1, 1000)
   attachmentUrls?: string;
 
+  @ApiPropertyOptional({ example: 'Mozilla/5.0...' })
   @IsOptional()
   @IsString()
   @Length(1, 500)
   userAgent?: string;
 
+  @ApiPropertyOptional({ example: '192.168.1.1' })
   @IsOptional()
   @IsString()
   @Length(1, 100)
@@ -68,37 +121,54 @@ export class CreateContactDto {
 }
 
 export class UpdateContactDto {
+  @ApiPropertyOptional({ enum: ContactStatus, example: ContactStatus.REVIEWED })
   @IsOptional()
   @IsEnum(ContactStatus)
   status?: ContactStatus;
 
+  @ApiPropertyOptional({
+    example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+    description: 'UUID of the assigned staff member',
+  })
   @IsOptional()
   @IsUUID()
   assignedTo?: string;
 
+  @ApiPropertyOptional({ example: 'Looking into this now.', maxLength: 2000 })
   @IsOptional()
   @IsString()
   @Length(1, 2000)
   response?: string;
 
+  @ApiPropertyOptional({
+    enum: ContactCategory,
+    example: ContactCategory.SUPPORT,
+  })
   @IsOptional()
   @IsEnum(ContactCategory)
   category?: ContactCategory;
 
+  @ApiPropertyOptional({ example: 'high', maxLength: 100 })
   @IsOptional()
   @IsString()
   @Length(1, 100)
   priority?: string;
 
+  @ApiPropertyOptional({
+    example: 'Needs escalation to billing team.',
+    maxLength: 1000,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 1000)
   internalNotes?: string;
 
+  @ApiPropertyOptional({ example: '2025-03-01T09:00:00.000Z' })
   @IsOptional()
   @IsDateString()
   followUpDate?: string;
 
+  @ApiPropertyOptional({ example: 'billing,urgent', maxLength: 100 })
   @IsOptional()
   @IsString()
   @Length(1, 100)
@@ -106,55 +176,73 @@ export class UpdateContactDto {
 }
 
 export class ContactQueryDto {
+  @ApiPropertyOptional({ enum: ContactStatus, example: ContactStatus.NEW })
   @IsOptional()
   @IsEnum(ContactStatus)
   status?: ContactStatus;
 
+  @ApiPropertyOptional({
+    enum: ContactCategory,
+    example: ContactCategory.SUPPORT,
+  })
   @IsOptional()
   @IsEnum(ContactCategory)
   category?: ContactCategory;
 
+  @ApiPropertyOptional({ example: 'f47ac10b-58cc-4372-a567-0e02b2c3d479' })
   @IsOptional()
   @IsUUID()
   assignedTo?: string;
 
+  @ApiPropertyOptional({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
   @IsOptional()
   @IsUUID()
   userId?: string;
 
+  @ApiPropertyOptional({ example: 'b2c3d4e5-f6a7-8901-bcde-f12345678901' })
   @IsOptional()
   @IsUUID()
   eventId?: string;
 
+  @ApiPropertyOptional({
+    example: 'ticket refund',
+    description: 'Full-text search across name, email, subject, and message',
+  })
   @IsOptional()
   @IsString()
   @Length(1, 100)
   search?: string;
 
+  @ApiPropertyOptional({ example: 'high' })
   @IsOptional()
   @IsString()
   @Length(1, 100)
   priority?: string;
 
+  @ApiPropertyOptional({ example: '2025-01-01T00:00:00.000Z' })
   @IsOptional()
   @IsString()
   dateFrom?: string;
 
+  @ApiPropertyOptional({ example: '2025-12-31T23:59:59.000Z' })
   @IsOptional()
   @IsString()
   dateTo?: string;
 
+  @ApiPropertyOptional({ example: 'billing,urgent' })
   @IsOptional()
   @IsString()
   @Length(1, 100)
   tags?: string;
 
+  @ApiPropertyOptional({ example: 1, minimum: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({ example: 10, minimum: 1, maximum: 100, default: 10 })
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
@@ -162,38 +250,57 @@ export class ContactQueryDto {
   @Max(100)
   limit?: number = 10;
 
+  @ApiPropertyOptional({
+    example: 'createdAt',
+    enum: ['createdAt', 'updatedAt', 'respondedAt', 'priority'],
+    default: 'createdAt',
+  })
   @IsOptional()
   @IsEnum(['createdAt', 'updatedAt', 'respondedAt', 'priority'])
   sortBy?: string = 'createdAt';
 
+  @ApiPropertyOptional({
+    example: 'DESC',
+    enum: ['ASC', 'DESC'],
+    default: 'DESC',
+  })
   @IsOptional()
   @IsEnum(['ASC', 'DESC'])
   sortOrder?: 'ASC' | 'DESC' = 'DESC';
 }
 
 export class BulkContactUpdateDto {
-  @IsString()
+  @ApiProperty({
+    type: [String],
+    example: ['uuid1', 'uuid2'],
+  })
+  @IsString({ each: true })
   @Length(1, 100, { each: true })
   contactIds: string[];
 
+  @ApiPropertyOptional({ enum: ContactStatus })
   @IsOptional()
   @IsEnum(ContactStatus)
   status?: ContactStatus;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsUUID()
   assignedTo?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   @Length(1, 2000)
   response?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   @Length(1, 100)
   priority?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
   @Length(1, 1000)

--- a/src/contact/dto/contact-response.dto.ts
+++ b/src/contact/dto/contact-response.dto.ts
@@ -1,6 +1,18 @@
-import { IsString, IsOptional, IsEnum, IsUUID, IsEmail, IsNumber, IsDateString } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsEnum,
+  IsUUID,
+  IsEmail,
+  IsNumber,
+  IsDateString,
+} from 'class-validator';
 import { Type } from 'class-transformer';
-import { ContactCategory, ContactStatus } from '../interfaces/contact.interface';
+import {
+  ContactCategory,
+  ContactStatus,
+} from '../interfaces/contact.interface';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class ContactResponseDto {
   id: string;
@@ -59,27 +71,32 @@ export class ContactResponseDto {
 }
 
 export class ContactSummaryDto {
+  @ApiProperty()
   id: string;
 
+  @ApiProperty()
   name: string;
 
+  @ApiProperty()
   email: string;
 
+  @ApiProperty()
   subject: string;
 
-  category: ContactCategory;
+  @ApiProperty()
+  category: string;
 
-  status: ContactStatus;
+  @ApiProperty()
+  status: string;
 
+  @ApiProperty({ required: false })
   priority?: string;
 
+  @ApiProperty()
   createdAt: Date;
 
+  @ApiProperty({ required: false })
   respondedAt?: Date;
-
-  assignedTo?: string;
-
-  assignedStaffName?: string;
 }
 
 export class UserSummaryDto {

--- a/src/contact/dto/create-contact-message.dto.ts
+++ b/src/contact/dto/create-contact-message.dto.ts
@@ -1,20 +1,37 @@
 import { IsEmail, IsNotEmpty, IsString, MaxLength } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateContactMessageDto {
+  @ApiProperty({
+    example: 'John Doe',
+    maxLength: 100,
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(100)
   name: string;
 
+  @ApiProperty({
+    example: 'john@example.com',
+    maxLength: 255,
+  })
   @IsEmail()
   @MaxLength(255)
   email: string;
 
+  @ApiProperty({
+    example: 'Issue with ticket purchase',
+    maxLength: 150,
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(150)
   subject: string;
 
+  @ApiProperty({
+    example: 'I am unable to complete my ticket purchase...',
+    maxLength: 5000,
+  })
   @IsString()
   @IsNotEmpty()
   @MaxLength(5000)

--- a/src/contact/entities/contact-message.entity.ts
+++ b/src/contact/entities/contact-message.entity.ts
@@ -3,9 +3,18 @@ import {
   PrimaryGeneratedColumn,
   Column,
   CreateDateColumn,
+  UpdateDateColumn,
+  Index,
 } from 'typeorm';
+import {
+  ContactCategory,
+  ContactStatus,
+} from '../interfaces/contact.interface';
 
 @Entity('contact_messages')
+@Index(['status'])
+@Index(['category'])
+@Index(['userId'])
 export class ContactMessage {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -22,6 +31,94 @@ export class ContactMessage {
   @Column({ type: 'text' })
   message: string;
 
+  @Column({
+    type: 'enum',
+    enum: ContactCategory,
+    default: ContactCategory.GENERAL,
+    comment: 'Inquiry category',
+  })
+  category: ContactCategory;
+
+  @Column({
+    type: 'enum',
+    enum: ContactStatus,
+    default: ContactStatus.NEW,
+    comment: 'Current workflow status',
+  })
+  status: ContactStatus;
+
+  @Column({
+    type: 'uuid',
+    nullable: true,
+    comment: 'Authenticated user who submitted the inquiry',
+  })
+  userId: string | null;
+
+  @Column({
+    type: 'uuid',
+    nullable: true,
+    comment: 'Related event, if applicable',
+  })
+  eventId: string | null;
+
+  @Column({
+    type: 'uuid',
+    nullable: true,
+    comment: 'Staff member assigned to this inquiry',
+  })
+  assignedTo: string | null;
+
+  @Column({
+    type: 'text',
+    nullable: true,
+    comment: 'Staff response to the inquiry',
+  })
+  response: string | null;
+
+  @Column({
+    type: 'timestamp',
+    nullable: true,
+    comment: 'When a response was sent',
+  })
+  respondedAt: Date | null;
+
+  @Column({ length: 20, nullable: true })
+  phoneNumber: string | null;
+
+  @Column({ length: 200, nullable: true })
+  companyName: string | null;
+
+  @Column({ length: 100, nullable: true })
+  website: string | null;
+
+  @Column({ length: 50, nullable: true, default: 'normal' })
+  priority: string | null;
+
+  @Column({
+    type: 'text',
+    nullable: true,
+    comment: 'JSON array of attachment URLs',
+  })
+  attachmentUrls: string | null;
+
+  @Column({ type: 'text', nullable: true })
+  userAgent: string | null;
+
+  @Column({ length: 100, nullable: true })
+  ipAddress: string | null;
+
+  @Column({ type: 'text', nullable: true, comment: 'Internal staff notes' })
+  internalNotes: string | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  followUpDate: Date | null;
+
+  @Column({ length: 500, nullable: true, comment: 'Comma-separated tags' })
+  tags: string | null;
+
   @CreateDateColumn()
   createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
 }

--- a/src/events/dto/change-event-status.dto.ts
+++ b/src/events/dto/change-event-status.dto.ts
@@ -1,15 +1,19 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { IsEnum, IsOptional, IsString, Length } from 'class-validator';
 import { EventStatus } from '../../enums/event-status.enum';
 
 export class ChangeEventStatusDto {
+  @ApiProperty({ enum: EventStatus })
   @IsEnum(EventStatus)
   status: EventStatus;
 
+  @ApiPropertyOptional({ example: 'Event postponed due to weather' })
   @IsOptional()
   @IsString()
   @Length(1, 500)
   reason?: string;
 
+  @ApiPropertyOptional({ example: 'admin-user-id' })
   @IsOptional()
   @IsString()
   @Length(1, 100)

--- a/src/events/dto/create-event.dto.ts
+++ b/src/events/dto/create-event.dto.ts
@@ -1,84 +1,63 @@
-import { IsString, IsDateString, IsNumber, IsOptional, IsEnum, IsUrl, IsArray, Min, Max, Length, Matches, IsBoolean } from 'class-validator';
-import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsEnum,
+  IsUrl,
+  IsArray,
+  Min,
+  Max,
+  Length,
+  Matches,
+  IsBoolean,
+} from 'class-validator';
 import { EventStatus } from '../../enums/event-status.enum';
 
 export class CreateEventDto {
+  @ApiProperty({ example: 'Tech Conference 2026' })
   @IsString()
   @Length(1, 200)
   title: string;
 
+  @ApiProperty({ example: 'Annual technology conference' })
   @IsString()
   @Length(1, 2000)
   description: string;
 
+  @ApiProperty({ example: '2026-06-15T10:00:00Z' })
   @IsDateString()
   eventDate: string;
 
+  @ApiProperty({ example: '2026-06-14T23:59:59Z' })
   @IsDateString()
   eventClosingDate: string;
 
+  @ApiProperty({ example: 500 })
   @IsNumber()
   @Min(1)
   @Max(1000000)
   capacity: number;
 
+  @ApiPropertyOptional({ example: 'Eko Convention Center' })
   @IsOptional()
   @IsString()
-  @Length(1, 500)
   venue?: string;
 
-  @IsOptional()
-  @IsString()
-  @Length(1, 1000)
-  address?: string;
-
-  @IsOptional()
-  @IsString()
-  @Length(1, 100)
-  city?: string;
-
-  @IsOptional()
-  @IsString()
-  @Length(2, 2)
-  @Matches(/^[A-Z]{2}$/)
-  countryCode?: string;
-
-  @IsOptional()
-  @IsUrl()
-  imageUrl?: string;
-
+  @ApiPropertyOptional({ example: ['tech', 'conference'], type: [String] })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   tags?: string[];
 
+  @ApiPropertyOptional({ enum: EventStatus })
   @IsOptional()
   @IsEnum(EventStatus)
   status?: EventStatus;
 
-  @IsOptional()
-  @IsBoolean()
-  isVirtual?: boolean;
-
-  @IsOptional()
-  @IsUrl()
-  streamingUrl?: string;
-
-  @IsOptional()
-  @IsNumber()
-  @Min(0)
-  @Max(999999)
-  minTicketPrice?: number;
-
-  @IsOptional()
-  @IsNumber()
-  @Min(0)
-  @Max(999999)
-  maxTicketPrice?: number;
-
+  @ApiPropertyOptional({ example: 'NGN' })
   @IsOptional()
   @IsString()
-  @Length(3, 3)
-  @Matches(/^[A-Z]{3}$/)
   currency?: string;
 }

--- a/src/events/dto/event-query.dto.ts
+++ b/src/events/dto/event-query.dto.ts
@@ -1,62 +1,51 @@
-import { IsString, IsNumber, IsOptional, IsEnum, Min, Max, Length, IsBoolean, IsDateString, IsArray } from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsOptional,
+  IsEnum,
+  IsString,
+  IsNumber,
+  Min,
+  Max,
+  IsBoolean,
+  IsArray,
+} from 'class-validator';
 import { Type } from 'class-transformer';
 import { EventStatus } from '../../enums/event-status.enum';
 
 export class EventQueryDto {
+  @ApiPropertyOptional({ example: 'conference' })
   @IsOptional()
   @IsString()
-  @Length(1, 100)
   search?: string;
 
+  @ApiPropertyOptional({ enum: EventStatus })
   @IsOptional()
   @IsEnum(EventStatus)
   status?: EventStatus;
 
+  @ApiPropertyOptional({ example: 'Lagos' })
   @IsOptional()
   @IsString()
-  @Length(1, 100)
   city?: string;
 
+  @ApiPropertyOptional({ example: 'NG' })
   @IsOptional()
   @IsString()
-  @Length(2, 2)
   countryCode?: string;
 
+  @ApiPropertyOptional({ example: true })
   @IsOptional()
   @IsBoolean()
   isVirtual?: boolean;
 
-  @IsOptional()
-  @IsDateString()
-  dateFrom?: string;
-
-  @IsOptional()
-  @IsDateString()
-  dateTo?: string;
-
-  @IsOptional()
-  @IsNumber()
-  @Min(0)
-  @Max(1000)
-  minTicketPrice?: number;
-
-  @IsOptional()
-  @IsNumber()
-  @Min(0)
-  @Max(1000)
-  maxTicketPrice?: number;
-
-  @IsOptional()
-  @IsArray()
-  @IsString({ each: true })
-  tags?: string[];
-
+  @ApiPropertyOptional({ example: 1, default: 1 })
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
   @Min(1)
   page?: number = 1;
 
+  @ApiPropertyOptional({ example: 10, default: 10 })
   @IsOptional()
   @Type(() => Number)
   @IsNumber()
@@ -64,11 +53,14 @@ export class EventQueryDto {
   @Max(100)
   limit?: number = 10;
 
+  @ApiPropertyOptional({
+    enum: ['createdAt', 'eventDate', 'title', 'capacity'],
+    default: 'eventDate',
+  })
   @IsOptional()
-  @IsEnum(['createdAt', 'eventDate', 'title', 'capacity'])
   sortBy?: string = 'eventDate';
 
+  @ApiPropertyOptional({ enum: ['ASC', 'DESC'], default: 'ASC' })
   @IsOptional()
-  @IsEnum(['ASC', 'DESC'])
   sortOrder?: 'ASC' | 'DESC' = 'ASC';
 }

--- a/src/events/dto/event-response.dto.ts
+++ b/src/events/dto/event-response.dto.ts
@@ -1,68 +1,47 @@
-import { IsString, IsNumber, IsOptional, IsEnum, Min, Max, Length, IsBoolean, IsArray } from 'class-validator';
-import { Type } from 'class-transformer';
-
-export class EventResponseDto {
-  id: string;
-
-  title: string;
-
-  description: string;
-
-  eventDate: Date;
-
-  eventClosingDate: Date;
-
-  capacity: number;
-
-  status: string;
-
-  isArchived: boolean;
-
-  venue?: string;
-
-  address?: string;
-
-  city?: string;
-
-  countryCode?: string;
-
-  imageUrl?: string;
-
-  tags?: string[];
-
-  isVirtual?: boolean;
-
-  streamingUrl?: string;
-
-  minTicketPrice?: number;
-
-  maxTicketPrice?: number;
-
-  currency?: string;
-
-  createdAt: Date;
-
-  updatedAt: Date;
-
-  totalTicketsSold?: number;
-
-  availableTickets?: number;
-
-  ticketTypes?: TicketTypeSummaryDto[];
-}
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class TicketTypeSummaryDto {
-  id: string;
+  @ApiProperty() id: string;
+  @ApiProperty() name: string;
+  @ApiProperty() price: number;
+  @ApiProperty() currency: string;
+  @ApiProperty() availableQuantity: number;
+  @ApiProperty() isActive: boolean;
+}
 
-  name: string;
+export class EventResponseDto {
+  @ApiProperty() id: string;
+  @ApiProperty() title: string;
+  @ApiProperty() description: string;
+  @ApiProperty() eventDate: Date;
+  @ApiProperty() eventClosingDate: Date;
+  @ApiProperty() capacity: number;
+  @ApiProperty() status: string;
+  @ApiProperty() isArchived: boolean;
 
-  price: number;
+  @ApiPropertyOptional() venue?: string;
+  @ApiPropertyOptional() address?: string;
+  @ApiPropertyOptional() city?: string;
+  @ApiPropertyOptional() countryCode?: string;
+  @ApiPropertyOptional() imageUrl?: string;
 
-  currency: string;
+  @ApiPropertyOptional({ type: [String] })
+  tags?: string[];
 
-  availableQuantity: number;
+  @ApiPropertyOptional() isVirtual?: boolean;
+  @ApiPropertyOptional() streamingUrl?: string;
+  @ApiPropertyOptional() minTicketPrice?: number;
+  @ApiPropertyOptional() maxTicketPrice?: number;
+  @ApiPropertyOptional() currency?: string;
 
-  isActive: boolean;
+  @ApiProperty() createdAt: Date;
+  @ApiProperty() updatedAt: Date;
+
+  @ApiPropertyOptional() totalTicketsSold?: number;
+  @ApiPropertyOptional() availableTickets?: number;
+
+  @ApiPropertyOptional({ type: [TicketTypeSummaryDto] })
+  ticketTypes?: TicketTypeSummaryDto[];
 }
 
 export class EventSummaryDto {

--- a/src/events/dto/update-event.dto.ts
+++ b/src/events/dto/update-event.dto.ts
@@ -1,86 +1,125 @@
-import { IsString, IsDateString, IsNumber, IsOptional, IsEnum, IsUrl, IsArray, Min, Max, Length, Matches, IsBoolean } from 'class-validator';
-import { Type } from 'class-transformer';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  IsString,
+  IsDateString,
+  IsNumber,
+  IsOptional,
+  IsEnum,
+  IsUrl,
+  IsArray,
+  Min,
+  Max,
+  Length,
+  Matches,
+  IsBoolean,
+} from 'class-validator';
 import { EventStatus } from '../../enums/event-status.enum';
 
 export class UpdateEventDto {
+  @ApiPropertyOptional({ example: 'Tech Conference 2026', maxLength: 200 })
   @IsOptional()
   @IsString()
   @Length(1, 200)
   title?: string;
 
+  @ApiPropertyOptional({
+    example: 'Annual technology conference',
+    maxLength: 2000,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 2000)
   description?: string;
 
+  @ApiPropertyOptional({ example: '2026-06-15T10:00:00Z' })
   @IsOptional()
   @IsDateString()
   eventDate?: string;
 
+  @ApiPropertyOptional({ example: '2026-06-14T23:59:59Z' })
   @IsOptional()
   @IsDateString()
   eventClosingDate?: string;
 
+  @ApiPropertyOptional({ example: 500, minimum: 1, maximum: 1000000 })
   @IsOptional()
   @IsNumber()
   @Min(1)
   @Max(1000000)
   capacity?: number;
 
+  @ApiPropertyOptional({ example: 'Eko Convention Center' })
   @IsOptional()
   @IsString()
   @Length(1, 500)
   venue?: string;
 
+  @ApiPropertyOptional({ example: 'Plot 123, Victoria Island' })
   @IsOptional()
   @IsString()
   @Length(1, 1000)
   address?: string;
 
+  @ApiPropertyOptional({ example: 'Lagos' })
   @IsOptional()
   @IsString()
   @Length(1, 100)
   city?: string;
 
+  @ApiPropertyOptional({
+    example: 'NG',
+    description: 'ISO 2-letter country code',
+  })
   @IsOptional()
   @IsString()
   @Length(2, 2)
   @Matches(/^[A-Z]{2}$/)
   countryCode?: string;
 
+  @ApiPropertyOptional({ example: 'https://example.com/image.jpg' })
   @IsOptional()
   @IsUrl()
   imageUrl?: string;
 
+  @ApiPropertyOptional({ type: [String], example: ['tech', 'conference'] })
   @IsOptional()
   @IsArray()
   @IsString({ each: true })
   tags?: string[];
 
+  @ApiPropertyOptional({ enum: EventStatus })
   @IsOptional()
   @IsEnum(EventStatus)
   status?: EventStatus;
 
+  @ApiPropertyOptional({ example: false })
   @IsOptional()
   @IsBoolean()
   isVirtual?: boolean;
 
+  @ApiPropertyOptional({ example: 'https://zoom.us/j/123456789' })
   @IsOptional()
   @IsUrl()
   streamingUrl?: string;
 
+  @ApiPropertyOptional({ example: 100 })
   @IsOptional()
   @IsNumber()
   @Min(0)
   @Max(999999)
   minTicketPrice?: number;
 
+  @ApiPropertyOptional({ example: 500 })
   @IsOptional()
   @IsNumber()
   @Min(0)
   @Max(999999)
   maxTicketPrice?: number;
 
+  @ApiPropertyOptional({
+    example: 'NGN',
+    description: 'ISO 3-letter currency code',
+  })
   @IsOptional()
   @IsString()
   @Length(3, 3)

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,9 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
 import { GlobalExceptionFilter } from './common/filters/global-exception.filter';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { ResponseInterceptor } from './common/interceptors/response.interceptor';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
@@ -13,8 +16,22 @@ async function bootstrap() {
       transform: true,
     }),
   );
-    app.useGlobalFilters(new GlobalExceptionFilter());
+  app.useGlobalFilters(new GlobalExceptionFilter());
 
+  app.useGlobalInterceptors(new ResponseInterceptor());
+
+  // Format all errors consistently: { success, error, statusCode, timestamp }
+  app.useGlobalFilters(new HttpExceptionFilter());
+
+  const config = new DocumentBuilder()
+    .setTitle('My API')
+    .setDescription('API documentation')
+    .setVersion('1.0')
+    .addBearerAuth()
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
 
   await app.listen(process.env.PORT ?? 3000);
 }

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -11,6 +11,14 @@ import {
   Post,
   UseGuards,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiBody,
+} from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { OrdersService } from './orders.service';
 import { CreateOrderInput } from './dto/order.dto';
@@ -23,18 +31,8 @@ import { User } from 'src/auth/entities/user.entity';
 import { Order } from './orders.entity';
 import { StellarConfig } from 'src/stellar/stellar.config';
 
-/**
- * OrdersController
- *
- * All routes require a valid JWT. The authenticated user's ID is read from
- * the CurrentUser decorator so users can only act on their own orders.
- *
- * Route summary:
- *   POST   /orders       → createOrder (SUBSCRIBER role required)
- *   GET    /orders/my    → findMyOrders (current user)
- *   GET    /orders/:id   → findById (owner or ADMIN only)
- *   DELETE /orders/:id   → cancelOrder (owner or ADMIN only)
- */
+@ApiTags('Orders')
+@ApiBearerAuth('JWT-auth')
 @Controller('orders')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class OrdersController {
@@ -46,9 +44,55 @@ export class OrdersController {
   @Post()
   @Roles(UserRole.SUBSCRIBER)
   @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Create a new ticket order (subscriber only)' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      required: ['eventId', 'items'],
+      properties: {
+        eventId: {
+          type: 'string',
+          format: 'uuid',
+          example: 'b2c3d4e5-f6a7-8901-bcde-f12345678901',
+        },
+        items: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              ticketTypeId: {
+                type: 'string',
+                format: 'uuid',
+                example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+              },
+              quantity: { type: 'number', example: 2 },
+            },
+          },
+        },
+      },
+    },
+  })
+  @ApiResponse({
+    status: 201,
+    description:
+      'Order created. Returns order details with Stellar payment instructions.',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid input or insufficient ticket inventory',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden – subscriber role required',
+  })
   async createOrder(
     @CurrentUser() user: User,
-    @Body() body: { eventId: string; items: { ticketTypeId: string; quantity: number }[] },
+    @Body()
+    body: {
+      eventId: string;
+      items: { ticketTypeId: string; quantity: number }[];
+    },
   ) {
     const input: CreateOrderInput = {
       userId: user.id,
@@ -56,9 +100,9 @@ export class OrdersController {
       items: body.items,
     };
     const result = await this.ordersService.createOrder(input);
-    
+
     const stellarConfig = this.configService.get<StellarConfig>('stellar');
-    
+
     return {
       ...result.order,
       destinationAddress: stellarConfig?.platformAddress,
@@ -68,36 +112,68 @@ export class OrdersController {
   }
 
   @Get('my')
+  @ApiOperation({ summary: "List the current user's orders" })
+  @ApiResponse({
+    status: 200,
+    description: 'List of orders for the authenticated user',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
   async findMyOrders(@CurrentUser() user: User): Promise<Order[]> {
     return this.ordersService.findByUser(user.id);
   }
 
   @Get(':id')
+  @ApiOperation({ summary: 'Get a specific order by ID (owner or admin only)' })
+  @ApiParam({ name: 'id', type: String, description: 'Order UUID' })
+  @ApiResponse({ status: 200, description: 'Order returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden – can only view your own orders',
+  })
+  @ApiResponse({ status: 404, description: 'Order not found' })
   async findById(
     @CurrentUser() user: User,
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<Order> {
     const order = await this.ordersService.findById(id);
-    
+
     if (order.userId !== user.id && user.role !== UserRole.ADMIN) {
-      throw new ForbiddenException('You do not have permission to view this order');
+      throw new ForbiddenException(
+        'You do not have permission to view this order',
+      );
     }
-    
+
     return order;
   }
 
   @Delete(':id')
   @HttpCode(HttpStatus.OK)
+  @ApiOperation({ summary: 'Cancel an order (owner or admin only)' })
+  @ApiParam({ name: 'id', type: String, description: 'Order UUID' })
+  @ApiResponse({ status: 200, description: 'Order cancelled successfully' })
+  @ApiResponse({
+    status: 400,
+    description: 'Order cannot be cancelled in its current state',
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden – can only cancel your own orders',
+  })
+  @ApiResponse({ status: 404, description: 'Order not found' })
   async cancelOrder(
     @CurrentUser() user: User,
     @Param('id', ParseUUIDPipe) id: string,
   ): Promise<Order> {
     const order = await this.ordersService.findById(id);
-    
+
     if (order.userId !== user.id && user.role !== UserRole.ADMIN) {
-      throw new ForbiddenException('You do not have permission to cancel this order');
+      throw new ForbiddenException(
+        'You do not have permission to cancel this order',
+      );
     }
-    
+
     return this.ordersService.cancelOrder(id);
   }
 }

--- a/src/tickets-inventory/dto/ticket.response.dto.ts
+++ b/src/tickets-inventory/dto/ticket.response.dto.ts
@@ -1,17 +1,63 @@
+import { ApiProperty } from '@nestjs/swagger';
 import { TicketStatus } from '../entities/ticket.entity';
 
 export class TicketResponseDto {
+  @ApiProperty({ example: 'c3d4e5f6-a7b8-9012-cdef-123456789012' })
   id: string;
+
+  @ApiProperty({
+    example: 'TKT-QR-ABC123XYZ',
+    description: 'Unique QR code value for scanning at the event',
+  })
   qrCode: string;
+
+  @ApiProperty({
+    example: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA...',
+    description:
+      'Base64 PNG data URI of the QR code image. Render directly in an <img> src attribute. ' +
+      'Null if QR generation failed at issuance.',
+    nullable: true,
+  })
+  qrCodeImage: string | null;
+
+  @ApiProperty({ enum: TicketStatus, example: TicketStatus.ISSUED })
   status: TicketStatus;
+
+  @ApiProperty({ example: 'ORD-2025-00123', nullable: true })
   orderReference: string | null;
+
+  @ApiProperty({ example: 'attendee@example.com', nullable: true })
   attendeeEmail: string | null;
+
+  @ApiProperty({ example: 'Alice Johnson', nullable: true })
   attendeeName: string | null;
+
+  @ApiProperty({ example: '{"seat":"A12"}', nullable: true })
   metadata: string | null;
+
+  @ApiProperty({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
   ticketTypeId: string;
+
+  @ApiProperty({ example: 'b2c3d4e5-f6a7-8901-bcde-f12345678901' })
   eventId: string;
+
+  @ApiProperty({
+    example: '2025-09-15T10:32:00.000Z',
+    nullable: true,
+    description: 'Timestamp when the ticket was scanned at entry',
+  })
   scannedAt: Date | null;
+
+  @ApiProperty({
+    example: null,
+    nullable: true,
+    description: 'Timestamp when a refund was processed',
+  })
   refundedAt: Date | null;
+
+  @ApiProperty({ example: '2025-07-20T09:00:00.000Z' })
   createdAt: Date;
+
+  @ApiProperty({ example: '2025-09-15T10:32:00.000Z' })
   updatedAt: Date;
 }

--- a/src/tickets-inventory/entities/ticket.entity.ts
+++ b/src/tickets-inventory/entities/ticket.entity.ts
@@ -34,6 +34,15 @@ export class Ticket {
   qrCode: string;
 
   @Column({
+    type: 'text',
+    nullable: true,
+    comment:
+      'Base64 PNG data URI of the QR code image (data:image/png;base64,...). ' +
+      'Generated at issuance; null if generation failed.',
+  })
+  qrCodeImage: string | null;
+
+  @Column({
     type: 'enum',
     enum: TicketStatus,
     default: TicketStatus.ISSUED,

--- a/src/tickets-inventory/qr.service.ts
+++ b/src/tickets-inventory/qr.service.ts
@@ -1,0 +1,40 @@
+import { Injectable, Logger } from '@nestjs/common';
+import * as QRCode from 'qrcode';
+
+@Injectable()
+export class QRService {
+  private readonly logger = new Logger(QRService.name);
+
+  /**
+   * Generate a QR code as a base64 PNG data URI.
+   * Encodes only the raw ticket UUID — not a URL — to keep it
+   * portable across scanner apps.
+   *
+   * @param ticketCode  The raw UUID stored in Ticket.qrCode
+   * @returns           A data URI: "data:image/png;base64,..."
+   */
+  async generateQRDataURI(ticketCode: string): Promise<string> {
+    return QRCode.toDataURL(ticketCode, {
+      type: 'image/png',
+      errorCorrectionLevel: 'M',
+      margin: 2,
+      width: 300,
+    });
+  }
+
+  /**
+   * Generate a QR code as a raw PNG Buffer.
+   * Useful for embedding directly in email attachments (CID inline images).
+   *
+   * @param ticketCode  The raw UUID stored in Ticket.qrCode
+   * @returns           Raw PNG bytes as a Buffer
+   */
+  async generateQRBuffer(ticketCode: string): Promise<Buffer> {
+    return QRCode.toBuffer(ticketCode, {
+      type: 'png',
+      errorCorrectionLevel: 'M',
+      margin: 2,
+      width: 300,
+    });
+  }
+}

--- a/src/tickets-inventory/tickets.module.ts
+++ b/src/tickets-inventory/tickets.module.ts
@@ -8,11 +8,15 @@ import { TicketTypeController } from './controllers/ticket-type.controller';
 import { TicketController } from './controllers/ticket.controller';
 import { StellarModule } from '../stellar/stellar.module';
 import { Order } from '../orders/orders.entity';
+import { QRService } from './qr.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([TicketType, Ticket, Order]), StellarModule],
+  imports: [
+    TypeOrmModule.forFeature([TicketType, Ticket, Order]),
+    StellarModule,
+  ],
   controllers: [TicketTypeController, TicketController],
-  providers: [TicketTypeService, TicketService],
-  exports: [TicketTypeService, TicketService],
+  providers: [TicketTypeService, TicketService, QRService],
+  exports: [TicketTypeService, TicketService, QRService],
 })
-export class TicketsModule { }
+export class TicketsModule {}

--- a/src/users/dto/user-profile.dto.ts
+++ b/src/users/dto/user-profile.dto.ts
@@ -1,0 +1,65 @@
+import {
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
+  Matches,
+  Length,
+} from 'class-validator';
+import { ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateProfileDto {
+  @ApiPropertyOptional({
+    example: '+2348012345678',
+    description: 'User phone number',
+    maxLength: 30,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(30)
+  phone?: string;
+
+  @ApiPropertyOptional({
+    example: 'https://example.com/avatar.jpg',
+    description: 'URL of the user avatar image',
+  })
+  @IsOptional()
+  @IsUrl({}, { message: 'avatarUrl must be a valid URL' })
+  avatarUrl?: string;
+
+  @ApiPropertyOptional({
+    example: 'Blockchain enthusiast and event organizer based in Lagos.',
+    description: 'Short user biography (max 500 characters)',
+    maxLength: 500,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(500, { message: 'bio must not exceed 500 characters' })
+  bio?: string;
+
+  @ApiPropertyOptional({
+    example: 'Nigeria',
+    description: 'Country of residence',
+    maxLength: 100,
+  })
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  country?: string;
+
+  @ApiPropertyOptional({
+    example: 'GBXXX...56CHARSTELLARADDRESS',
+    description:
+      'Stellar public key for ticket refunds. Must start with G and be exactly 56 characters.',
+  })
+  @IsOptional()
+  @IsString()
+  @Length(56, 56, {
+    message: 'stellarWalletAddress must be exactly 56 characters',
+  })
+  @Matches(/^G[A-Z2-7]{55}$/, {
+    message:
+      'stellarWalletAddress must be a valid Stellar public key (starts with G, 56 alphanumeric characters)',
+  })
+  stellarWalletAddress?: string;
+}

--- a/src/users/dto/user-response.dto.ts
+++ b/src/users/dto/user-response.dto.ts
@@ -1,0 +1,58 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { UserRole } from 'src/auth/common/enum/user-role-enum';
+
+/**
+ * Safe user representation returned from all public-facing endpoints.
+ * Deliberately excludes: password, verificationCode, passwordResetCode,
+ * verificationCodeExpiresAt, passwordResetCodeExpiresAt.
+ */
+export class UserResponseDto {
+  @ApiProperty({ example: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890' })
+  id: string;
+
+  @ApiProperty({ example: 'alice@example.com' })
+  email: string;
+
+  @ApiProperty({ example: 'Alice Johnson' })
+  fullName: string;
+
+  @ApiProperty({ enum: UserRole, example: UserRole.SUBSCRIBER })
+  role: UserRole;
+
+  @ApiProperty({
+    example: true,
+    description: 'Whether the email has been verified',
+  })
+  isVerified: boolean;
+
+  @ApiPropertyOptional({ example: '+2348012345678', nullable: true })
+  phone: string | null;
+
+  @ApiPropertyOptional({
+    example: 'https://example.com/avatar.jpg',
+    nullable: true,
+  })
+  avatarUrl: string | null;
+
+  @ApiPropertyOptional({
+    example: 'Blockchain enthusiast based in Lagos.',
+    nullable: true,
+  })
+  bio: string | null;
+
+  @ApiPropertyOptional({ example: 'Nigeria', nullable: true })
+  country: string | null;
+
+  @ApiPropertyOptional({
+    example: 'GBXXX...56CHARSTELLARADDRESS',
+    nullable: true,
+    description: 'Stellar public key for refunds',
+  })
+  stellarWalletAddress: string | null;
+
+  @ApiProperty({ example: '2025-01-01T00:00:00.000Z' })
+  createdAt: Date;
+
+  @ApiProperty({ example: '2025-02-15T12:30:00.000Z' })
+  updatedAt: Date;
+}

--- a/src/users/entities/event.entity.ts
+++ b/src/users/entities/event.entity.ts
@@ -1,10 +1,112 @@
-import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  OneToMany,
+} from 'typeorm';
+// import { UserRole } from '../common/enum/user-role-enum';
+import { Exclude } from 'class-transformer';
+import { Event } from '../../events/entities/event.entity';
+import { UserRole } from 'src/auth/common/enum/user-role-enum';
 
 @Entity()
-export class Users {
+export class User {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
+  @Column({ unique: true })
+  email: string;
+
   @Column()
-  name: string;
+  fullName: string;
+
+  @Column()
+  @Exclude()
+  password: string;
+
+  @Column({
+    type: 'enum',
+    enum: UserRole,
+    default: UserRole.SUBSCRIBER,
+  })
+  role: UserRole;
+
+  // =============================
+  // PROFILE FIELDS
+  // =============================
+
+  @Column({
+    nullable: true,
+    length: 30,
+    comment: 'User phone number',
+  })
+  phone: string | null;
+
+  @Column({
+    nullable: true,
+    comment: 'URL of the user avatar image',
+  })
+  avatarUrl: string | null;
+
+  @Column({
+    nullable: true,
+    length: 500,
+    comment: 'Short user biography (max 500 chars)',
+  })
+  bio: string | null;
+
+  @Column({
+    nullable: true,
+    length: 100,
+    comment: 'Country of residence',
+  })
+  country: string | null;
+
+  @Column({
+    nullable: true,
+    length: 56,
+    comment:
+      'Stellar public key — used for ticket refunds (starts with G, 56 chars)',
+  })
+  stellarWalletAddress: string | null;
+
+  // =============================
+  // VERIFICATION / RESET
+  // =============================
+
+  @Column({ nullable: true })
+  @Exclude()
+  verificationCode?: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  verificationCodeExpiresAt?: Date;
+
+  @Column({ nullable: true })
+  @Exclude()
+  passwordResetCode?: string;
+
+  @Column({ type: 'timestamp', nullable: true })
+  passwordResetCodeExpiresAt?: Date;
+
+  @Column({ default: false })
+  isVerified: boolean;
+
+  // =============================
+  // TIMESTAMPS
+  // =============================
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+
+  // =============================
+  // RELATIONS
+  // =============================
+
+  // A user can be the organizer of multiple events
+  @OneToMany(() => Event, (event) => event.organizer)
+  organizedEvents: Event[];
 }

--- a/src/verification/dto/verification-operations.dto.ts
+++ b/src/verification/dto/verification-operations.dto.ts
@@ -1,146 +1,218 @@
-import { IsString, IsOptional, IsBoolean, IsUUID, Length, Matches, IsNumber, IsEnum, Min, Max } from 'class-validator';
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsUUID,
+  Length,
+  Matches,
+  IsNumber,
+  IsEnum,
+  Min,
+  Max,
+} from 'class-validator';
 import { Type } from 'class-transformer';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class VerifyTicketDto {
+  @ApiProperty({
+    description: 'Unique ticket code to verify',
+    minLength: 1,
+    maxLength: 100,
+    example: 'TICK-ABC-123',
+  })
   @IsString()
   @Length(1, 100)
   ticketCode: string;
 
+  @ApiPropertyOptional({
+    description: 'Event UUID',
+    format: 'uuid',
+    example: '550e8400-e29b-41d4-a716-446655440000',
+  })
   @IsOptional()
   @IsUUID()
   eventId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Verifier UUID',
+    format: 'uuid',
+  })
   @IsOptional()
   @IsUUID()
   verifierId?: string;
 
+  @ApiPropertyOptional({
+    description: 'Mark ticket as used after verification',
+    default: true,
+    example: true,
+  })
   @IsOptional()
   @IsBoolean()
   markAsUsed?: boolean = true;
 
+  @ApiPropertyOptional({
+    description: 'Device information used for verification',
+    maxLength: 500,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 500)
   deviceInfo?: string;
 
+  @ApiPropertyOptional({
+    description: 'Verification location name',
+    maxLength: 100,
+  })
   @IsOptional()
   @IsString()
   @Length(1, 100)
   location?: string;
 
+  @ApiPropertyOptional({
+    description: 'Latitude coordinate',
+    example: '6.5244',
+  })
   @IsOptional()
   @IsString()
-  @Matches(/^-?([1-8]?[1-9]|[1-9]0)\.{1}\d{1,6}$/)
   latitude?: string;
 
+  @ApiPropertyOptional({
+    description: 'Longitude coordinate',
+    example: '3.3792',
+  })
   @IsOptional()
   @IsString()
-  @Matches(/^-?((1[0-7]|[1-9])?\d)\.{1}\d{1,6}$/)
   longitude?: string;
 }
 
 export class CheckInDto {
+  @ApiProperty({
+    description: 'Ticket code',
+    example: 'TICK-ABC-123',
+  })
   @IsString()
   @Length(1, 100)
   ticketCode: string;
 
+  @ApiPropertyOptional({
+    description: 'Verifier UUID',
+    format: 'uuid',
+  })
   @IsOptional()
   @IsUUID()
   verifierId?: string;
 }
 
 export class BulkVerifyTicketsDto {
-  @IsString()
+  @ApiProperty({
+    description: 'Array of ticket codes',
+    type: [String],
+    example: ['TICK-001', 'TICK-002'],
+  })
+  @IsString({ each: true })
   @Length(1, 100, { each: true })
   ticketCodes: string[];
 
+  @ApiPropertyOptional({ format: 'uuid' })
   @IsOptional()
   @IsUUID()
   eventId?: string;
 
+  @ApiPropertyOptional({ format: 'uuid' })
   @IsOptional()
   @IsUUID()
   verifierId?: string;
 
+  @ApiPropertyOptional({ default: true })
   @IsOptional()
   @IsBoolean()
   markAsUsed?: boolean = true;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
-  @Length(1, 500)
   deviceInfo?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
-  @Length(1, 100)
   location?: string;
 }
 
 export class VerificationQueryDto {
+  @ApiPropertyOptional({ format: 'uuid' })
   @IsOptional()
   @IsUUID()
   eventId?: string;
 
+  @ApiPropertyOptional({ format: 'uuid' })
   @IsOptional()
   @IsUUID()
   verifierId?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
-  @Length(1, 100)
   ticketCode?: string;
 
+  @ApiPropertyOptional({ example: 'VERIFIED' })
   @IsOptional()
   @IsString()
-  @Length(1, 20)
   status?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
-  @Length(1, 100)
   location?: string;
 
+  @ApiPropertyOptional({ example: '2025-01-01' })
   @IsOptional()
-  @IsString()
   dateFrom?: string;
 
+  @ApiPropertyOptional({ example: '2025-01-31' })
   @IsOptional()
-  @IsString()
   dateTo?: string;
 
+  @ApiPropertyOptional({ default: 1 })
   @IsOptional()
-  @Type(() => Number)
   page?: number = 1;
 
+  @ApiPropertyOptional({ default: 50 })
   @IsOptional()
-  @Type(() => Number)
   limit?: number = 50;
 
+  @ApiPropertyOptional({ default: 'verifiedAt' })
   @IsOptional()
-  @IsString()
   sortBy?: string = 'verifiedAt';
 
+  @ApiPropertyOptional({
+    enum: ['ASC', 'DESC'],
+    default: 'DESC',
+  })
   @IsOptional()
-  @IsString()
   sortOrder?: 'ASC' | 'DESC' = 'DESC';
 }
 
 export class ManualVerificationDto {
+  @ApiProperty()
   @IsString()
   @Length(1, 100)
   ticketCode: string;
 
+  @ApiProperty({
+    description: 'Reason for manual verification',
+  })
   @IsString()
   @Length(1, 500)
   reason: string;
 
+  @ApiPropertyOptional({ format: 'uuid' })
   @IsOptional()
   @IsUUID()
   verifierId?: string;
 
+  @ApiPropertyOptional()
   @IsOptional()
   @IsString()
-  @Length(1, 500)
   notes?: string;
 }

--- a/src/verification/dto/verification-response.dto.ts
+++ b/src/verification/dto/verification-response.dto.ts
@@ -1,53 +1,58 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { VerificationStatus } from '../interfaces/verification.interface';
 
 export class VerificationResponseDto {
-  status: VerificationStatus;
+  @ApiProperty({ example: 'VERIFIED' })
+  status: any;
 
+  @ApiProperty()
   isValid: boolean;
 
+  @ApiProperty()
   message: string;
 
+  @ApiPropertyOptional({ type: () => VerifiedTicketInfoDto })
   ticket?: VerifiedTicketInfoDto;
 
+  @ApiProperty({ type: String, format: 'date-time' })
   verifiedAt: Date;
 
+  @ApiPropertyOptional()
   verifiedBy?: string;
 
+  @ApiPropertyOptional()
   deviceInfo?: string;
 
+  @ApiPropertyOptional()
   location?: string;
 
+  @ApiPropertyOptional()
   latitude?: string;
 
+  @ApiPropertyOptional()
   longitude?: string;
 }
-
 export class VerifiedTicketInfoDto {
-  ticketId: string;
+  @ApiProperty() ticketId: string;
+  @ApiProperty() ticketCode: string;
+  @ApiProperty() eventId: string;
+  @ApiProperty() eventTitle: string;
+  @ApiProperty() ticketTypeName: string;
 
-  ticketCode: string;
+  @ApiPropertyOptional() holderName?: string;
+  @ApiPropertyOptional() seatInfo?: string;
 
-  eventId: string;
+  @ApiProperty() purchasePrice: number;
+  @ApiProperty() purchaseCurrency: string;
 
-  eventTitle: string;
-
-  ticketTypeName: string;
-
-  holderName?: string;
-
-  seatInfo?: string;
-
-  purchasePrice: number;
-
-  purchaseCurrency: string;
-
+  @ApiPropertyOptional({ type: String, format: 'date-time' })
   purchasedAt?: Date;
 
+  @ApiProperty({ type: String, format: 'date-time' })
   eventDate: Date;
 
-  eventVenue?: string;
-
-  eventCity?: string;
+  @ApiPropertyOptional() eventVenue?: string;
+  @ApiPropertyOptional() eventCity?: string;
 }
 
 export class VerificationLogResponseDto {
@@ -122,16 +127,26 @@ export class VerificationStatsDto {
 }
 
 export class BulkVerificationResponseDto {
+  @ApiProperty()
   totalProcessed: number;
 
+  @ApiProperty()
   successful: number;
 
+  @ApiProperty()
   failed: number;
 
+  @ApiProperty({
+    type: () => [VerificationResponseDto],
+  })
   results: VerificationResponseDto[];
 
+  @ApiProperty({
+    type: () => [VerificationErrorDto],
+  })
   errors: VerificationErrorDto[];
 
+  @ApiProperty({ type: String, format: 'date-time' })
   processedAt: Date;
 }
 

--- a/src/verification/verification.controller.ts
+++ b/src/verification/verification.controller.ts
@@ -10,6 +10,13 @@ import {
   UnprocessableEntityException,
   ParseUUIDPipe,
 } from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+} from '@nestjs/swagger';
 import { VerificationService } from './verification.service';
 import { VerifyTicketDto, CheckInDto } from './dto';
 import { JwtAuthGuard } from '../auth/guard/jwt.auth.guard';
@@ -18,15 +25,13 @@ import { Roles } from '../auth/decorators/roles.decorators';
 import { CurrentUser } from '../auth/decorators/current.user.decorators';
 import { UserRole } from '../auth/common/enum/user-role-enum';
 import { User } from '../auth/entities/user.entity';
-import type { VerificationResult, VerificationStats } from './interfaces/verification.interface';
+import type {
+  VerificationResult,
+  VerificationStats,
+} from './interfaces/verification.interface';
 import type { VerificationLog } from './interfaces/verification.interface';
 
-/**
- * Verification Controller for VeriTix
- *
- * Handles ticket verification HTTP endpoints. All business logic is delegated
- * to VerificationService. Returns 200 for valid/success, 422 for invalid ticket states.
- */
+@ApiTags('Verification')
 @Controller('verification')
 export class VerificationController {
   constructor(private readonly verificationService: VerificationService) {}
@@ -35,6 +40,18 @@ export class VerificationController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ORGANIZER, UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Verify a ticket code (organizer or admin only)' })
+  @ApiResponse({ status: 200, description: 'Ticket is valid' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden – organizer or admin role required',
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'Ticket is invalid, already used, expired, or for wrong event',
+  })
   async verify(
     @Body() dto: VerifyTicketDto,
     @CurrentUser() user: User,
@@ -55,6 +72,20 @@ export class VerificationController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles(UserRole.ORGANIZER, UserRole.ADMIN)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({
+    summary: 'Check in an attendee by ticket code (organizer or admin only)',
+  })
+  @ApiResponse({ status: 200, description: 'Attendee checked in successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({
+    status: 403,
+    description: 'Forbidden – organizer or admin role required',
+  })
+  @ApiResponse({
+    status: 422,
+    description: 'Ticket is invalid or attendee already checked in',
+  })
   async checkIn(
     @Body() dto: CheckInDto,
     @CurrentUser() user: User,
@@ -70,7 +101,19 @@ export class VerificationController {
   }
 
   @Get('peek/:ticketCode')
-  async peek(@Param('ticketCode') ticketCode: string): Promise<VerificationResult> {
+  @ApiOperation({
+    summary: 'Preview ticket validity without marking it as used (public)',
+  })
+  @ApiParam({
+    name: 'ticketCode',
+    type: String,
+    description: 'The ticket code to inspect',
+  })
+  @ApiResponse({ status: 200, description: 'Ticket validity result returned' })
+  @ApiResponse({ status: 422, description: 'Ticket is invalid or expired' })
+  async peek(
+    @Param('ticketCode') ticketCode: string,
+  ): Promise<VerificationResult> {
     const result = await this.verificationService.peek(ticketCode);
     if (!result.isValid) {
       throw new UnprocessableEntityException(result);
@@ -80,6 +123,12 @@ export class VerificationController {
 
   @Get('stats/:eventId')
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Get verification statistics for an event' })
+  @ApiParam({ name: 'eventId', type: String, description: 'Event UUID' })
+  @ApiResponse({ status: 200, description: 'Verification statistics returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
   async getStats(
     @Param('eventId', ParseUUIDPipe) eventId: string,
   ): Promise<VerificationStats> {
@@ -88,6 +137,12 @@ export class VerificationController {
 
   @Get('logs/:eventId')
   @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Get all verification logs for an event' })
+  @ApiParam({ name: 'eventId', type: String, description: 'Event UUID' })
+  @ApiResponse({ status: 200, description: 'Verification logs returned' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 404, description: 'Event not found' })
   async getLogs(
     @Param('eventId', ParseUUIDPipe) eventId: string,
   ): Promise<VerificationLog[]> {


### PR DESCRIPTION
User entity:
- Add nullable profile columns: phone (varchar 30), avatarUrl (varchar),
  bio (varchar 500), country (varchar 100), stellarWalletAddress (varchar 56)
- Add @Exclude() to verificationCode and passwordResetCode so ClassSerializerInterceptor
  cannot accidentally leak them

DTOs:
- Add src/auth/dto/update-profile.dto.ts with class-validator rules for
  all five profile fields; stellarWalletAddress validated via @Matches
  regex (G + 55 base32 chars) and @Length(56,56)
- Add src/auth/dto/user-response.dto.ts — safe user shape exposing all
  profile fields but excluding password, verificationCode, passwordResetCode,
  *CodeExpiresAt columns

UserHelper:
- Add mapToResponseDto(user) — replaces the minimal formatUserResponse
  helper and includes all new profile fields
- Keep formatUserResponse as a @deprecated alias so existing callers
  (login, verifyOtp responses) compile without changes

AuthService:
- Add updateProfile(userId, dto): fetches user, applies only the five
  allowlisted field keys via an explicit loop (email/password/role cannot
  leak even if DTO validation is bypassed), saves, returns UserResponseDto
- Update retrieveCurrentUser / login / verifyOtp to use mapToResponseDto

AuthController:
- PATCH /auth/profile — JwtAuthGuard, @CurrentUser(), delegates to
  authService.updateProfile(user.id, dto)
- GET /auth/current-user — now returns userHelper.mapToResponseDto(user)
  instead of the raw entity (fixes password exposure)
- Full Swagger decorators on both endpoints

Migration 1772000000000-AddUserProfileFields:
- ADD COLUMN IF NOT EXISTS for all five columns (safe to re-run)

Tests (auth.service.spec.ts):
- updateProfile happy paths: all fields, partial update, returns mapped DTO
- Immutability guards: email, password, role cannot be overwritten even
  if injected into the DTO at runtime
- Empty DTO no-op
- NotFoundException when user not found
- Valid Stellar key saved correctly
- UpdateProfileDto validation: empty passes, bio > 500 fails, invalid
  avatarUrl fails, stellar key < 56 fails, > 56 fails, wrong prefix fails,
  valid 56-char key passes

Closes #416 
closes #417 
closes #418 
closes #419 
closes #422 