### PR TITLE
feat(stellar): add getPaymentAddress, generateMemo, getNetworkPassphr…

### DIFF
--- a/src/admin/admin.controller.spec.ts
+++ b/src/admin/admin.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { AdminController } from './admin.controller';
+import { AdminService } from './admin.service';
+
+describe('AdminController', () => {
+  let controller: AdminController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [AdminController],
+      providers: [AdminService],
+    }).compile();
+
+    controller = module.get<AdminController>(AdminController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,30 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+
+import { JwtAuthGuard } from '../auth/guard/jwt.auth.guard';
+import { RolesGuard } from '../auth/guard/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorators';
+import { UserRole } from '../auth/common/enum/user-role-enum';
+import { AdminService } from './admin.service';
+import { AdminStatsResponseDto } from './dto/admin-stats.dto';
+
+@ApiTags('admin')
+@Controller('admin')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles(UserRole.ADMIN)
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get platform-wide aggregate stats (ADMIN only)' })
+  @ApiResponse({
+    status: 200,
+    description: 'Aggregate stats',
+    type: AdminStatsResponseDto,
+  })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  @ApiResponse({ status: 403, description: 'Forbidden — ADMIN role required' })
+  async getStats(): Promise<AdminStatsResponseDto> {
+    return this.adminService.getStats();
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { User } from '../auth/entities/user.entity';
+import { Event } from '../events/entities/event.entity';
+import { Ticket } from '../tickets-inventory/entities/ticket.entity';
+import { Order } from '../orders/orders.entity';
+
+import { AdminService } from './admin.service';
+import { AdminController } from './admin.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User, Event, Ticket, Order])],
+  providers: [AdminService],
+  controllers: [AdminController],
+})
+export class AdminModule {}

--- a/src/admin/admin.service.spec.ts
+++ b/src/admin/admin.service.spec.ts
@@ -1,0 +1,283 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AdminService } from './admin.service';
+import { User } from '../auth/entities/user.entity';
+import { Event } from '../events/entities/event.entity';
+import { Ticket } from '../tickets-inventory/entities/ticket.entity';
+import { Order } from '../orders/orders.entity';
+
+// -----------------------------------------------------------------------
+// Helpers to build a chainable QueryBuilder mock
+// -----------------------------------------------------------------------
+const makeQbMock = (rawResult: any) => {
+  const qb: any = {};
+  qb.select = jest.fn().mockReturnValue(qb);
+  qb.addSelect = jest.fn().mockReturnValue(qb);
+  qb.where = jest.fn().mockReturnValue(qb);
+  qb.groupBy = jest.fn().mockReturnValue(qb);
+  qb.getRawOne = jest.fn().mockResolvedValue(rawResult);
+  qb.getRawMany = jest.fn().mockResolvedValue(rawResult);
+  return qb;
+};
+
+const makeRepoMock = (defaultRaw: any = { count: '0' }) => ({
+  createQueryBuilder: jest.fn().mockReturnValue(makeQbMock(defaultRaw)),
+});
+
+describe('AdminService', () => {
+  let service: AdminService;
+  let userRepoMock: ReturnType<typeof makeRepoMock>;
+  let eventRepoMock: ReturnType<typeof makeRepoMock>;
+  let ticketRepoMock: ReturnType<typeof makeRepoMock>;
+  let orderRepoMock: ReturnType<typeof makeRepoMock>;
+
+  beforeEach(async () => {
+    userRepoMock = makeRepoMock();
+    eventRepoMock = makeRepoMock();
+    ticketRepoMock = makeRepoMock();
+    orderRepoMock = makeRepoMock();
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AdminService,
+        { provide: getRepositoryToken(User), useValue: userRepoMock },
+        { provide: getRepositoryToken(Event), useValue: eventRepoMock },
+        { provide: getRepositoryToken(Ticket), useValue: ticketRepoMock },
+        { provide: getRepositoryToken(Order), useValue: orderRepoMock },
+      ],
+    }).compile();
+
+    service = module.get<AdminService>(AdminService);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -----------------------------------------------------------------------
+  // getStats — shape and generatedAt
+  // -----------------------------------------------------------------------
+  describe('getStats', () => {
+    it('should return an object with all top-level keys', async () => {
+      // Provide minimal valid responses for every internal query
+      const countQb = makeQbMock({ count: '0' });
+      const groupQb = makeQbMock([]);
+      const revenueQb = makeQbMock({ revenue: '0' });
+
+      // Each repo call alternates between total and group-by calls
+      let userCall = 0;
+      userRepoMock.createQueryBuilder.mockImplementation(() => {
+        userCall++;
+        return userCall === 1 ? countQb : userCall === 2 ? countQb : groupQb;
+      });
+      eventRepoMock.createQueryBuilder.mockReturnValue(countQb);
+      ticketRepoMock.createQueryBuilder.mockReturnValue(countQb);
+      let orderCall = 0;
+      orderRepoMock.createQueryBuilder.mockImplementation(() => {
+        orderCall++;
+        return orderCall === 3 ? revenueQb : countQb;
+      });
+
+      const result = await service.getStats();
+
+      expect(result).toHaveProperty('users');
+      expect(result).toHaveProperty('events');
+      expect(result).toHaveProperty('tickets');
+      expect(result).toHaveProperty('orders');
+      expect(result).toHaveProperty('generatedAt');
+      expect(new Date(result.generatedAt).toISOString()).toBe(
+        result.generatedAt,
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // User stats
+  // -----------------------------------------------------------------------
+  describe('getUserStats', () => {
+    it('should aggregate user counts correctly', async () => {
+      let call = 0;
+      userRepoMock.createQueryBuilder.mockImplementation(() => {
+        call++;
+        if (call === 1) return makeQbMock({ count: '42' }); // total
+        if (call === 2) return makeQbMock({ count: '30' }); // verified
+        return makeQbMock([
+          // by role
+          { role: 'SUBSCRIBER', count: '25' },
+          { role: 'ORGANIZER', count: '10' },
+          { role: 'ADMIN', count: '7' },
+        ]);
+      });
+
+      // Trigger through getStats — fake the other repos
+      const zeroQb = makeQbMock({ count: '0' });
+      const emptyQb = makeQbMock([]);
+      eventRepoMock.createQueryBuilder.mockReturnValue(
+        Object.assign(zeroQb, { getRawMany: jest.fn().mockResolvedValue([]) }),
+      );
+      ticketRepoMock.createQueryBuilder.mockReturnValue(
+        Object.assign(zeroQb, { getRawMany: jest.fn().mockResolvedValue([]) }),
+      );
+      let oCall = 0;
+      orderRepoMock.createQueryBuilder.mockImplementation(() => {
+        oCall++;
+        if (oCall === 3) return makeQbMock({ revenue: '0' });
+        return makeQbMock(oCall === 2 ? [] : { count: '0' });
+      });
+
+      const result = await service.getStats();
+
+      expect(result.users.total).toBe(42);
+      expect(result.users.verified).toBe(30);
+      expect(result.users.byRole.subscriber).toBe(25);
+      expect(result.users.byRole.organizer).toBe(10);
+      expect(result.users.byRole.admin).toBe(7);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Event stats
+  // -----------------------------------------------------------------------
+  describe('getEventStats', () => {
+    it('should aggregate event counts by status', async () => {
+      // Zero out user / ticket / order repos
+      const zeroQb = makeQbMock({ count: '0' });
+      const emptyQb = makeQbMock([]);
+      userRepoMock.createQueryBuilder.mockReturnValue(
+        Object.assign(makeQbMock({ count: '0' }), {
+          getRawMany: jest.fn().mockResolvedValue([]),
+        }),
+      );
+      ticketRepoMock.createQueryBuilder.mockReturnValue(
+        Object.assign(zeroQb, { getRawMany: jest.fn().mockResolvedValue([]) }),
+      );
+      let oCall = 0;
+      orderRepoMock.createQueryBuilder.mockImplementation(() => {
+        oCall++;
+        if (oCall === 3) return makeQbMock({ revenue: '0' });
+        return makeQbMock(oCall === 2 ? [] : { count: '0' });
+      });
+
+      let eCall = 0;
+      eventRepoMock.createQueryBuilder.mockImplementation(() => {
+        eCall++;
+        if (eCall === 1) return makeQbMock({ count: '15' });
+        return makeQbMock([
+          { status: 'DRAFT', count: '5' },
+          { status: 'PUBLISHED', count: '7' },
+          { status: 'CANCELLED', count: '2' },
+          { status: 'COMPLETED', count: '1' },
+          { status: 'POSTPONED', count: '0' },
+        ]);
+      });
+
+      const result = await service.getStats();
+      expect(result.events.total).toBe(15);
+      expect(result.events.byStatus.draft).toBe(5);
+      expect(result.events.byStatus.published).toBe(7);
+      expect(result.events.byStatus.cancelled).toBe(2);
+      expect(result.events.byStatus.completed).toBe(1);
+      expect(result.events.byStatus.postponed).toBe(0);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Ticket stats
+  // -----------------------------------------------------------------------
+  describe('getTicketStats', () => {
+    it('should aggregate ticket counts by status', async () => {
+      const zeroQb = () => makeQbMock({ count: '0' });
+      userRepoMock.createQueryBuilder.mockReturnValue(
+        Object.assign(zeroQb(), {
+          getRawMany: jest.fn().mockResolvedValue([]),
+        }),
+      );
+      eventRepoMock.createQueryBuilder.mockReturnValue(
+        Object.assign(zeroQb(), {
+          getRawMany: jest.fn().mockResolvedValue([]),
+        }),
+      );
+      let oCall = 0;
+      orderRepoMock.createQueryBuilder.mockImplementation(() => {
+        oCall++;
+        if (oCall === 3) return makeQbMock({ revenue: '0' });
+        return makeQbMock(oCall === 2 ? [] : { count: '0' });
+      });
+
+      let tCall = 0;
+      ticketRepoMock.createQueryBuilder.mockImplementation(() => {
+        tCall++;
+        if (tCall === 1) return makeQbMock({ count: '100' });
+        return makeQbMock([
+          { status: 'issued', count: '60' },
+          { status: 'scanned', count: '25' },
+          { status: 'refunded', count: '10' },
+          { status: 'cancelled', count: '5' },
+        ]);
+      });
+
+      const result = await service.getStats();
+      expect(result.tickets.total).toBe(100);
+      expect(result.tickets.issued).toBe(60);
+      expect(result.tickets.scanned).toBe(25);
+      expect(result.tickets.refunded).toBe(10);
+      expect(result.tickets.cancelled).toBe(5);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Order stats
+  // -----------------------------------------------------------------------
+  describe('getOrderStats', () => {
+    it('should aggregate order counts and sum revenue only for PAID orders', async () => {
+      const zeroQb = () =>
+        Object.assign(makeQbMock({ count: '0' }), {
+          getRawMany: jest.fn().mockResolvedValue([]),
+        });
+      userRepoMock.createQueryBuilder.mockReturnValue(zeroQb());
+      eventRepoMock.createQueryBuilder.mockReturnValue(zeroQb());
+      ticketRepoMock.createQueryBuilder.mockReturnValue(zeroQb());
+
+      let oCall = 0;
+      orderRepoMock.createQueryBuilder.mockImplementation(() => {
+        oCall++;
+        if (oCall === 1) return makeQbMock({ count: '200' });
+        if (oCall === 2)
+          return makeQbMock([
+            { status: 'PAID', count: '120' },
+            { status: 'PENDING', count: '50' },
+            { status: 'FAILED', count: '20' },
+            { status: 'REFUNDED', count: '10' },
+          ]);
+        // Revenue query (call 3)
+        return makeQbMock({ revenue: '9450.1234567' });
+      });
+
+      const result = await service.getStats();
+      expect(result.orders.total).toBe(200);
+      expect(result.orders.paid).toBe(120);
+      expect(result.orders.pending).toBe(50);
+      expect(result.orders.failed).toBe(20);
+      expect(result.orders.refunded).toBe(10);
+      expect(result.orders.totalRevenueXLM).toBe('9450.1234567');
+    });
+
+    it('should return totalRevenueXLM of "0" when no paid orders exist', async () => {
+      const zeroQb = () =>
+        Object.assign(makeQbMock({ count: '0' }), {
+          getRawMany: jest.fn().mockResolvedValue([]),
+        });
+      userRepoMock.createQueryBuilder.mockReturnValue(zeroQb());
+      eventRepoMock.createQueryBuilder.mockReturnValue(zeroQb());
+      ticketRepoMock.createQueryBuilder.mockReturnValue(zeroQb());
+
+      let oCall = 0;
+      orderRepoMock.createQueryBuilder.mockImplementation(() => {
+        oCall++;
+        if (oCall === 3) return makeQbMock({ revenue: '0' });
+        return makeQbMock(oCall === 2 ? [] : { count: '0' });
+      });
+
+      const result = await service.getStats();
+      expect(result.orders.totalRevenueXLM).toBe('0');
+    });
+  });
+});

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,0 +1,202 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+import { User } from '../auth/entities/user.entity';
+import { UserRole } from '../auth/common/enum/user-role-enum';
+import { Event } from '../events/entities/event.entity';
+import { EventStatus } from '../enums/event-status.enum';
+import {
+  Ticket,
+  TicketStatus,
+} from '../tickets-inventory/entities/ticket.entity';
+import { Order } from '../orders/orders.entity';
+import { OrderStatus } from '../orders/enums/order-status.enum';
+import {
+  AdminStatsResponseDto,
+  EventStats,
+  OrderStats,
+  TicketStats,
+  UserStats,
+} from './dto/admin-stats.dto';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    @InjectRepository(Event)
+    private readonly eventRepo: Repository<Event>,
+    @InjectRepository(Ticket)
+    private readonly ticketRepo: Repository<Ticket>,
+    @InjectRepository(Order)
+    private readonly orderRepo: Repository<Order>,
+  ) {}
+
+  async getStats(): Promise<AdminStatsResponseDto> {
+    const [users, events, tickets, orders] = await Promise.all([
+      this.getUserStats(),
+      this.getEventStats(),
+      this.getTicketStats(),
+      this.getOrderStats(),
+    ]);
+
+    return {
+      users,
+      events,
+      tickets,
+      orders,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+
+  // -----------------------------------------------------------------------
+  // Private helpers — each runs its own aggregate queries in parallel
+  // -----------------------------------------------------------------------
+
+  private async getUserStats(): Promise<UserStats> {
+    const [totalResult, verifiedResult, roleResult] = await Promise.all([
+      // Total user count
+      this.userRepo
+        .createQueryBuilder('u')
+        .select('COUNT(u.id)', 'count')
+        .getRawOne<{ count: string }>(),
+
+      // Verified users
+      this.userRepo
+        .createQueryBuilder('u')
+        .select('COUNT(u.id)', 'count')
+        .where('u.isVerified = :v', { v: true })
+        .getRawOne<{ count: string }>(),
+
+      // Group by role
+      this.userRepo
+        .createQueryBuilder('u')
+        .select('u.role', 'role')
+        .addSelect('COUNT(u.id)', 'count')
+        .groupBy('u.role')
+        .getRawMany<{ role: string; count: string }>(),
+    ]);
+
+    const byRole = roleResult.reduce(
+      (acc, row) => {
+        acc[row.role.toLowerCase() as keyof typeof acc] = Number(row.count);
+        return acc;
+      },
+      { subscriber: 0, organizer: 0, admin: 0 },
+    );
+
+    return {
+      total: Number(totalResult?.count ?? 0),
+      verified: Number(verifiedResult?.count ?? 0),
+      byRole,
+    };
+  }
+
+  private async getEventStats(): Promise<EventStats> {
+    const [totalResult, statusResult] = await Promise.all([
+      this.eventRepo
+        .createQueryBuilder('e')
+        .select('COUNT(e.id)', 'count')
+        .getRawOne<{ count: string }>(),
+
+      this.eventRepo
+        .createQueryBuilder('e')
+        .select('e.status', 'status')
+        .addSelect('COUNT(e.id)', 'count')
+        .groupBy('e.status')
+        .getRawMany<{ status: string; count: string }>(),
+    ]);
+
+    const byStatus = statusResult.reduce(
+      (acc, row) => {
+        acc[row.status.toLowerCase() as keyof typeof acc] = Number(row.count);
+        return acc;
+      },
+      {
+        [EventStatus.DRAFT.toLowerCase()]: 0,
+        [EventStatus.PUBLISHED.toLowerCase()]: 0,
+        [EventStatus.CANCELLED.toLowerCase()]: 0,
+        [EventStatus.COMPLETED.toLowerCase()]: 0,
+        [EventStatus.POSTPONED.toLowerCase()]: 0,
+      } as Record<string, number>,
+    );
+
+    return {
+      total: Number(totalResult?.count ?? 0),
+      byStatus: {
+        draft: byStatus['draft'] ?? 0,
+        published: byStatus['published'] ?? 0,
+        cancelled: byStatus['cancelled'] ?? 0,
+        completed: byStatus['completed'] ?? 0,
+        postponed: byStatus['postponed'] ?? 0,
+      },
+    };
+  }
+
+  private async getTicketStats(): Promise<TicketStats> {
+    const [totalResult, statusResult] = await Promise.all([
+      this.ticketRepo
+        .createQueryBuilder('t')
+        .select('COUNT(t.id)', 'count')
+        .getRawOne<{ count: string }>(),
+
+      this.ticketRepo
+        .createQueryBuilder('t')
+        .select('t.status', 'status')
+        .addSelect('COUNT(t.id)', 'count')
+        .groupBy('t.status')
+        .getRawMany<{ status: string; count: string }>(),
+    ]);
+
+    const byStatus = statusResult.reduce((acc, row) => {
+      acc[row.status] = Number(row.count);
+      return acc;
+    }, {} as Record<string, number>);
+
+    return {
+      total: Number(totalResult?.count ?? 0),
+      issued: byStatus[TicketStatus.ISSUED] ?? 0,
+      scanned: byStatus[TicketStatus.SCANNED] ?? 0,
+      refunded: byStatus[TicketStatus.REFUNDED] ?? 0,
+      cancelled: byStatus[TicketStatus.CANCELLED] ?? 0,
+    };
+  }
+
+  private async getOrderStats(): Promise<OrderStats> {
+    const [totalResult, statusResult, revenueResult] = await Promise.all([
+      this.orderRepo
+        .createQueryBuilder('o')
+        .select('COUNT(o.id)', 'count')
+        .getRawOne<{ count: string }>(),
+
+      this.orderRepo
+        .createQueryBuilder('o')
+        .select('o.status', 'status')
+        .addSelect('COUNT(o.id)', 'count')
+        .groupBy('o.status')
+        .getRawMany<{ status: string; count: string }>(),
+
+      // Revenue: sum totalAmountXLM for PAID orders only
+      this.orderRepo
+        .createQueryBuilder('o')
+        .select('COALESCE(SUM(o.totalAmountXLM), 0)', 'revenue')
+        .where('o.status = :status', { status: OrderStatus.PAID })
+        .getRawOne<{ revenue: string }>(),
+    ]);
+
+    const byStatus = statusResult.reduce((acc, row) => {
+      acc[row.status] = Number(row.count);
+      return acc;
+    }, {} as Record<string, number>);
+
+    return {
+      total: Number(totalResult?.count ?? 0),
+      paid: byStatus[OrderStatus.PAID] ?? 0,
+      pending: byStatus[OrderStatus.PENDING] ?? 0,
+      failed: byStatus[OrderStatus.FAILED] ?? 0,
+      refunded: byStatus[OrderStatus.REFUNDED] ?? 0,
+      totalRevenueXLM: revenueResult?.revenue ?? '0',
+    };
+  }
+}

--- a/src/admin/dto/admin-stats.dto.ts
+++ b/src/admin/dto/admin-stats.dto.ts
@@ -1,0 +1,52 @@
+/** Breakdown of user counts. */
+export interface UserStats {
+  total: number;
+  verified: number;
+  byRole: {
+    subscriber: number;
+    organizer: number;
+    admin: number;
+  };
+}
+
+/** Breakdown of event counts by status. */
+export interface EventStats {
+  total: number;
+  byStatus: {
+    draft: number;
+    published: number;
+    cancelled: number;
+    completed: number;
+    postponed: number;
+  };
+}
+
+/** Breakdown of ticket counts by lifecycle status. */
+export interface TicketStats {
+  total: number;
+  issued: number;
+  scanned: number;
+  refunded: number;
+  cancelled: number;
+}
+
+/** Breakdown of order counts and revenue. */
+export interface OrderStats {
+  total: number;
+  paid: number;
+  pending: number;
+  failed: number;
+  refunded: number;
+  /** Sum of totalAmountXLM for PAID orders only. */
+  totalRevenueXLM: string;
+}
+
+/** Full response shape for GET /admin/stats. */
+export class AdminStatsResponseDto {
+  users: UserStats;
+  events: EventStats;
+  tickets: TicketStats;
+  orders: OrderStats;
+  /** ISO-8601 timestamp of when these stats were generated. */
+  generatedAt: string;
+}

--- a/src/admin/dto/create-admin.dto.ts
+++ b/src/admin/dto/create-admin.dto.ts
@@ -1,0 +1,1 @@
+export class CreateAdminDto {}

--- a/src/admin/dto/update-admin.dto.ts
+++ b/src/admin/dto/update-admin.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAdminDto } from './create-admin.dto';
+
+export class UpdateAdminDto extends PartialType(CreateAdminDto) {}

--- a/src/admin/entities/admin.entity.ts
+++ b/src/admin/entities/admin.entity.ts
@@ -1,0 +1,1 @@
+export class Admin {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,10 +11,11 @@ import { EventsModule } from './events/events.module';
 import { VerificationModule } from './verification/verification.module';
 import { ContactModule } from './contact/contact.module';
 import databaseConfig from './config/database-config';
-import appConfig from './config/app.config';
+import appConfig, { appConfigValidationSchema } from './config/app.config';
 import { OrdersModule } from './orders/orders.module';
 import { StellarModule } from './stellar/stellar.module';
 import { ThrottlerModule } from '@nestjs/throttler';
+import { AdminModule } from './admin/admin.module';
 
 @Module({
   imports: [
@@ -22,6 +23,8 @@ import { ThrottlerModule } from '@nestjs/throttler';
     ConfigModule.forRoot({
       isGlobal: true,
       load: [appConfig, databaseConfig],
+      validationSchema: appConfigValidationSchema,
+      validationOptions: { allowUnknown: true, abortEarly: false },
     }),
     ThrottlerModule.forRoot([
       {
@@ -73,7 +76,8 @@ import { ThrottlerModule } from '@nestjs/throttler';
     EventsModule, // ← Add here
     VerificationModule, // ← Add here
     ContactModule,
-    StellarModule, // ← Stellar payment listener
+    StellarModule,
+    AdminModule, // ← Stellar payment listener
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -4,152 +4,439 @@ import { getRepositoryToken } from '@nestjs/typeorm';
 import { User } from './entities/user.entity';
 import { UserHelper } from './helper/user-helper';
 import { JwtHelper } from './helper/jwt-helper';
-import { Repository } from 'typeorm';
-import { CreateUserDto } from './dto/create-user.dto';
 import { UserMessages } from './helper/user-messages';
-import { SendPasswordResetOtpDto } from './dto/send-password-reset-otp.dto';
-import { ResendOtpDto } from './dto/resend-otp.dto';
+import { UserRole } from './common/enum/user-role-enum';
+import {
+  BadRequestException,
+  ConflictException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { sendEmail } from '../config/email/email.service';
+import { CreateUserDto } from './dto/create-user.dto';
+import { VerifyOtpDto } from './dto/verify-otp.dto';
+import { LoginUserDto } from './dto/login-user.dto';
+import { ResetPasswordDto } from './dto/reset-password.dto';
+import { SendPasswordResetOtpDto } from './dto/send-password-reset-otp.dto';
 
+// ---------------------------------------------------------------------------
+// Mock the email service so no real emails are sent
+// ---------------------------------------------------------------------------
 jest.mock('../config/email/email.service', () => ({
-  sendEmail: jest.fn(),
+  sendEmail: jest.fn().mockResolvedValue(undefined),
 }));
 
+// ---------------------------------------------------------------------------
+// Fixture factories
+// ---------------------------------------------------------------------------
+const futureDate = () => new Date(Date.now() + 10 * 60 * 1_000); // +10 min
+const pastDate = () => new Date(Date.now() - 1); // already expired
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-uuid-1',
+    email: 'user@example.com',
+    fullName: 'Test User',
+    password: 'hashed-pw',
+    role: UserRole.SUBSCRIBER,
+    isVerified: true,
+    verificationCode: '1234',
+    verificationCodeExpiresAt: futureDate(),
+    passwordResetCode: '5678',
+    passwordResetCodeExpiresAt: futureDate(),
+    phone: null,
+    avatarUrl: null,
+    bio: null,
+    country: null,
+    stellarWalletAddress: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    organizedEvents: [],
+    ...overrides,
+  } as unknown as User;
+}
+
+const MOCK_TOKENS = { accessToken: 'access-jwt', refreshToken: 'refresh-jwt' };
+const MOCK_USER_DTO = { id: 'user-uuid-1', email: 'user@example.com' };
+
+// ---------------------------------------------------------------------------
+// Module setup
+// ---------------------------------------------------------------------------
 describe('AuthService', () => {
   let service: AuthService;
-  let userRepository: Repository<User>;
-  let userHelper: UserHelper;
 
-  const mockUserRepository = {
+  const mockRepo = {
     findOne: jest.fn(),
+    findOneBy: jest.fn(),
     create: jest.fn(),
     save: jest.fn(),
-    findOneBy: jest.fn(),
   };
 
   const mockUserHelper = {
     isValidPassword: jest.fn(),
     hashPassword: jest.fn(),
     generateVerificationCode: jest.fn(),
-    formatUserResponse: jest.fn(),
     verifyPassword: jest.fn(),
+    mapToResponseDto: jest.fn().mockReturnValue(MOCK_USER_DTO),
+    formatUserResponse: jest.fn().mockReturnValue(MOCK_USER_DTO),
   };
 
   const mockJwtHelper = {
-    generateTokens: jest.fn(),
+    generateTokens: jest.fn().mockReturnValue(MOCK_TOKENS),
     validateRefreshToken: jest.fn(),
-    generateAccessToken: jest.fn(),
+    generateAccessToken: jest.fn().mockReturnValue('new-access-jwt'),
   };
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         AuthService,
-        {
-          provide: getRepositoryToken(User),
-          useValue: mockUserRepository,
-        },
-        {
-          provide: UserHelper,
-          useValue: mockUserHelper,
-        },
-        {
-          provide: JwtHelper,
-          useValue: mockJwtHelper,
-        },
+        { provide: getRepositoryToken(User), useValue: mockRepo },
+        { provide: UserHelper, useValue: mockUserHelper },
+        { provide: JwtHelper, useValue: mockJwtHelper },
       ],
     }).compile();
 
     service = module.get<AuthService>(AuthService);
-    userRepository = module.get<Repository<User>>(getRepositoryToken(User));
-    userHelper = module.get<UserHelper>(UserHelper);
   });
 
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
+  afterEach(() => jest.clearAllMocks());
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
-  });
-
+  // =========================================================================
+  // createUser
+  // =========================================================================
   describe('createUser', () => {
-    it('should create a user and send a verification email', async () => {
-      const createUserDto: CreateUserDto = {
-        email: 'test@example.com',
-        fullName: 'Test User',
-        password: 'Password123',
-      };
-      const verificationCode = '1234';
+    const dto: CreateUserDto = {
+      email: 'new@example.com',
+      fullName: 'New User',
+      password: 'ValidPass1',
+    };
 
-      mockUserRepository.findOne.mockResolvedValue(null);
+    it('throws ConflictException when email already exists', async () => {
+      mockRepo.findOne.mockResolvedValue(makeUser());
+
+      await expect(service.createUser(dto)).rejects.toThrow(ConflictException);
+      await expect(service.createUser(dto)).rejects.toThrow(
+        UserMessages.EMAIL_ALREADY_EXIST,
+      );
+    });
+
+    it('throws ConflictException when password is invalid', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockUserHelper.isValidPassword.mockReturnValue(false);
+
+      await expect(service.createUser(dto)).rejects.toThrow(ConflictException);
+      await expect(service.createUser(dto)).rejects.toThrow(
+        UserMessages.IS_VALID_PASSWORD,
+      );
+    });
+
+    it('creates user, saves to repo, and returns success message', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
       mockUserHelper.isValidPassword.mockReturnValue(true);
-      mockUserHelper.hashPassword.mockResolvedValue('hashedPassword');
-      mockUserHelper.generateVerificationCode.mockReturnValue(verificationCode);
-      mockUserRepository.create.mockReturnValue(createUserDto);
-      mockUserRepository.save.mockResolvedValue(createUserDto);
+      mockUserHelper.hashPassword.mockResolvedValue('hashed-pw');
+      mockUserHelper.generateVerificationCode.mockReturnValue('1234');
+      mockRepo.create.mockReturnValue({ ...dto, password: 'hashed-pw' });
+      mockRepo.save.mockResolvedValue({});
 
-      const result = await service.createUser(createUserDto);
+      const result = await service.createUser(dto);
 
-      expect(result).toEqual({ message: UserMessages.USER_CREATED_SUCCESSFULLY });
+      expect(result).toEqual({
+        message: UserMessages.USER_CREATED_SUCCESSFULLY,
+      });
+      expect(mockRepo.save).toHaveBeenCalledTimes(1);
+    });
+
+    it('sends verification email with correct OTP digits', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockUserHelper.isValidPassword.mockReturnValue(true);
+      mockUserHelper.hashPassword.mockResolvedValue('hashed-pw');
+      mockUserHelper.generateVerificationCode.mockReturnValue('4321');
+      mockRepo.create.mockReturnValue({});
+      mockRepo.save.mockResolvedValue({});
+
+      await service.createUser(dto);
+
       expect(sendEmail).toHaveBeenCalledWith(
-        createUserDto.email,
+        dto.email,
         'Verify Your Account',
         'verification-email',
         {
-          fullName: createUserDto.fullName,
-          otp1: '1',
-          otp2: '2',
-          otp3: '3',
-          otp4: '4',
+          fullName: dto.fullName,
+          otp1: '4',
+          otp2: '3',
+          otp3: '2',
+          otp4: '1',
         },
+      );
+    });
+
+    it('assigns SUBSCRIBER role to new users', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockUserHelper.isValidPassword.mockReturnValue(true);
+      mockUserHelper.hashPassword.mockResolvedValue('hashed-pw');
+      mockUserHelper.generateVerificationCode.mockReturnValue('0000');
+      mockRepo.create.mockImplementation((data) => data);
+      mockRepo.save.mockResolvedValue({});
+
+      await service.createUser(dto);
+
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ role: UserRole.SUBSCRIBER }),
       );
     });
   });
 
-  describe('resendVerificationOtp', () => {
-    it('should resend verification OTP and send an email', async () => {
-      const email = 'test@example.com';
-      const user = { email, fullName: 'Test User' };
-      const verificationCode = '5678';
+  // =========================================================================
+  // verifyOtp
+  // =========================================================================
+  describe('verifyOtp', () => {
+    const dto: VerifyOtpDto = { email: 'user@example.com', otp: '1234' };
 
-      mockUserRepository.findOne.mockResolvedValue(user);
-      mockUserHelper.generateVerificationCode.mockReturnValue(verificationCode);
-      mockUserRepository.save.mockResolvedValue(user);
-
-      const result = await service.resendVerificationOtp(email);
-
-      expect(result).toEqual({ message: UserMessages.OTP_SENT });
-      expect(sendEmail).toHaveBeenCalledWith(
-        email,
-        'Verify Your Account',
-        'verification-email',
-        {
-          fullName: user.fullName,
-          otp1: '5',
-          otp2: '6',
-          otp3: '7',
-          otp4: '8',
-        },
+    it('throws BadRequestException when email is missing', async () => {
+      await expect(service.verifyOtp({ ...dto, email: '' })).rejects.toThrow(
+        BadRequestException,
       );
+    });
+
+    it('throws BadRequestException when OTP is missing', async () => {
+      await expect(service.verifyOtp({ ...dto, otp: '' })).rejects.toThrow(
+        BadRequestException,
+      );
+    });
+
+    it('throws UnauthorizedException when user is not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.verifyOtp(dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.verifyOtp(dto)).rejects.toThrow(
+        UserMessages.USER_NOT_FOUND,
+      );
+    });
+
+    it('throws UnauthorizedException when OTP does not match', async () => {
+      mockRepo.findOne.mockResolvedValue(
+        makeUser({ verificationCode: '9999' }),
+      );
+
+      await expect(service.verifyOtp(dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.verifyOtp(dto)).rejects.toThrow(
+        UserMessages.INVALID_OTP,
+      );
+    });
+
+    it('throws UnauthorizedException when OTP is expired', async () => {
+      mockRepo.findOne.mockResolvedValue(
+        makeUser({
+          verificationCode: '1234',
+          verificationCodeExpiresAt: pastDate(),
+        }),
+      );
+
+      await expect(service.verifyOtp(dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.verifyOtp(dto)).rejects.toThrow(
+        UserMessages.OTP_EXPIRED,
+      );
+    });
+
+    it('throws UnauthorizedException when verificationCodeExpiresAt is null', async () => {
+      mockRepo.findOne.mockResolvedValue(
+        makeUser({
+          verificationCode: '1234',
+          verificationCodeExpiresAt: undefined,
+        }),
+      );
+
+      await expect(service.verifyOtp(dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('marks user as verified, clears OTP, saves, and returns tokens', async () => {
+      const user = makeUser({
+        verificationCode: '1234',
+        verificationCodeExpiresAt: futureDate(),
+        isVerified: false,
+      });
+      mockRepo.findOne.mockResolvedValue(user);
+      mockRepo.save.mockResolvedValue(user);
+
+      const result = await service.verifyOtp(dto);
+
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ isVerified: true, verificationCode: '' }),
+      );
+      expect(result).toEqual({
+        message: UserMessages.VERIFY_OTP_SUCCESS,
+        user: MOCK_USER_DTO,
+        tokens: MOCK_TOKENS,
+      });
+    });
+
+    it('calls jwtHelper.generateTokens with the saved user', async () => {
+      const user = makeUser({
+        verificationCode: '1234',
+        verificationCodeExpiresAt: futureDate(),
+      });
+      mockRepo.findOne.mockResolvedValue(user);
+      mockRepo.save.mockResolvedValue(user);
+
+      await service.verifyOtp(dto);
+
+      expect(mockJwtHelper.generateTokens).toHaveBeenCalledWith(user);
     });
   });
 
+  // =========================================================================
+  // login
+  // =========================================================================
+  describe('login', () => {
+    const dto: LoginUserDto = {
+      email: 'user@example.com',
+      password: 'ValidPass1',
+    };
+
+    it('throws UnauthorizedException when user is not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.login(dto)).rejects.toThrow(UnauthorizedException);
+      await expect(service.login(dto)).rejects.toThrow(
+        UserMessages.INVALID_CREDENTIALS,
+      );
+    });
+
+    it('throws UnauthorizedException when password does not match', async () => {
+      mockRepo.findOne.mockResolvedValue(makeUser());
+      mockUserHelper.verifyPassword.mockResolvedValue(false);
+
+      await expect(service.login(dto)).rejects.toThrow(UnauthorizedException);
+      await expect(service.login(dto)).rejects.toThrow(
+        UserMessages.INVALID_CREDENTIALS,
+      );
+    });
+
+    it('resends OTP and returns EMAIL_NOT_VERIFIED when user is unverified', async () => {
+      const unverifiedUser = makeUser({ isVerified: false });
+      mockRepo.findOne
+        .mockResolvedValueOnce(unverifiedUser) // login query
+        .mockResolvedValueOnce(unverifiedUser); // resendVerificationOtp query
+      mockUserHelper.verifyPassword.mockResolvedValue(true);
+      mockUserHelper.generateVerificationCode.mockReturnValue('0000');
+      mockRepo.save.mockResolvedValue(unverifiedUser);
+
+      const result = await service.login(dto);
+
+      expect(result).toEqual({
+        message: UserMessages.EMAIL_NOT_VERIFIED,
+        user: MOCK_USER_DTO,
+      });
+      expect(sendEmail).toHaveBeenCalledWith(
+        unverifiedUser.email,
+        'Verify Your Account',
+        'verification-email',
+        expect.any(Object),
+      );
+    });
+
+    it('returns user and tokens on successful login', async () => {
+      const verifiedUser = makeUser({ isVerified: true });
+      mockRepo.findOne.mockResolvedValue(verifiedUser);
+      mockUserHelper.verifyPassword.mockResolvedValue(true);
+
+      const result = await service.login(dto);
+
+      expect(result).toEqual({
+        user: MOCK_USER_DTO,
+        tokens: MOCK_TOKENS,
+      });
+      expect(mockJwtHelper.generateTokens).toHaveBeenCalledWith(verifiedUser);
+    });
+  });
+
+  // =========================================================================
+  // refreshToken
+  // =========================================================================
+  describe('refreshToken', () => {
+    it('throws UnauthorizedException when refresh token is invalid', async () => {
+      mockJwtHelper.validateRefreshToken.mockImplementation(() => {
+        throw new UnauthorizedException(UserMessages.INVALID_REFRESH_TOKEN);
+      });
+
+      await expect(service.refreshToken('bad-token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws UnauthorizedException when no user is found for the token payload', async () => {
+      mockJwtHelper.validateRefreshToken.mockReturnValue('user-uuid-1');
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.refreshToken('valid-token')).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.refreshToken('valid-token')).rejects.toThrow(
+        UserMessages.INVALID_REFRESH_TOKEN,
+      );
+    });
+
+    it('returns a new access token for a valid refresh token', async () => {
+      const user = makeUser();
+      mockJwtHelper.validateRefreshToken.mockReturnValue('user-uuid-1');
+      mockRepo.findOne.mockResolvedValue(user);
+
+      const result = await service.refreshToken('valid-refresh');
+
+      expect(result).toEqual({ accessToken: 'new-access-jwt' });
+      expect(mockJwtHelper.generateAccessToken).toHaveBeenCalledWith(user);
+    });
+  });
+
+  // =========================================================================
+  // requestResetPasswordOtp
+  // =========================================================================
   describe('requestResetPasswordOtp', () => {
-    it('should request reset password OTP and send an email', async () => {
-      const dto: SendPasswordResetOtpDto = { email: 'test@example.com' };
-      const user = { email: dto.email, fullName: 'Test User' };
-      const otp = '9012';
+    const dto: SendPasswordResetOtpDto = { email: 'user@example.com' };
 
-      mockUserRepository.findOne.mockResolvedValue(user);
-      mockUserHelper.generateVerificationCode.mockReturnValue(otp);
-      mockUserRepository.save.mockResolvedValue(user);
+    it('throws BadRequestException when email is missing', async () => {
+      await expect(
+        service.requestResetPasswordOtp({ email: '' }),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.requestResetPasswordOtp({ email: '' }),
+      ).rejects.toThrow(UserMessages.EMAIL_REQUIRED);
+    });
+
+    it('throws NotFoundException when user is not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+
+      await expect(service.requestResetPasswordOtp(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.requestResetPasswordOtp(dto)).rejects.toThrow(
+        UserMessages.USER_NOT_FOUND,
+      );
+    });
+
+    it('generates OTP, saves it, and sends reset email', async () => {
+      const user = makeUser();
+      mockRepo.findOne.mockResolvedValue(user);
+      mockUserHelper.generateVerificationCode.mockReturnValue('9012');
+      mockRepo.save.mockResolvedValue(user);
 
       const result = await service.requestResetPasswordOtp(dto);
 
       expect(result).toEqual({ message: UserMessages.OTP_SENT });
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ passwordResetCode: '9012' }),
+      );
       expect(sendEmail).toHaveBeenCalledWith(
-        dto.email,
+        user.email,
         'Password Reset OTP',
         'reset-password-email',
         {
@@ -163,30 +450,383 @@ describe('AuthService', () => {
     });
   });
 
-  describe('resendResetPasswordVerificationOtp', () => {
-    it('should resend reset password OTP and send an email', async () => {
-      const dto: ResendOtpDto = { email: 'test@example.com' };
-      const user = { email: dto.email, fullName: 'Test User' };
-      const otp = '3456';
+  // =========================================================================
+  // resetPassword
+  // =========================================================================
+  describe('resetPassword', () => {
+    const validDto: ResetPasswordDto = {
+      otp: '5678',
+      newPassword: 'NewPass1!',
+      confirmNewPassword: 'NewPass1!',
+    };
 
-      mockUserRepository.findOne.mockResolvedValue(user);
-      mockUserHelper.generateVerificationCode.mockReturnValue(otp);
-      mockUserRepository.save.mockResolvedValue(user);
+    it('throws NotFoundException when no user matches the OTP', async () => {
+      mockRepo.findOneBy.mockResolvedValue(null);
 
-      const result = await service.resendResetPasswordVerificationOtp(dto);
+      await expect(service.resetPassword(validDto)).rejects.toThrow(
+        NotFoundException,
+      );
+      await expect(service.resetPassword(validDto)).rejects.toThrow(
+        UserMessages.USER_NOT_FOUND,
+      );
+    });
+
+    it('throws UnauthorizedException when OTP has expired', async () => {
+      mockRepo.findOneBy.mockResolvedValue(
+        makeUser({
+          passwordResetCode: '5678',
+          passwordResetCodeExpiresAt: pastDate(),
+        }),
+      );
+
+      await expect(service.resetPassword(validDto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.resetPassword(validDto)).rejects.toThrow(
+        UserMessages.OTP_EXPIRED,
+      );
+    });
+
+    it('throws UnauthorizedException when passwordResetCodeExpiresAt is null', async () => {
+      mockRepo.findOneBy.mockResolvedValue(
+        makeUser({
+          passwordResetCode: '5678',
+          passwordResetCodeExpiresAt: undefined,
+        }),
+      );
+
+      await expect(service.resetPassword(validDto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('throws BadRequestException when newPassword is invalid', async () => {
+      mockRepo.findOneBy.mockResolvedValue(
+        makeUser({
+          passwordResetCode: '5678',
+          passwordResetCodeExpiresAt: futureDate(),
+        }),
+      );
+      mockUserHelper.isValidPassword.mockReturnValue(false);
+
+      await expect(service.resetPassword(validDto)).rejects.toThrow(
+        BadRequestException,
+      );
+      await expect(service.resetPassword(validDto)).rejects.toThrow(
+        UserMessages.IS_VALID_PASSWORD,
+      );
+    });
+
+    it('throws BadRequestException when passwords do not match', async () => {
+      mockRepo.findOneBy.mockResolvedValue(
+        makeUser({
+          passwordResetCode: '5678',
+          passwordResetCodeExpiresAt: futureDate(),
+        }),
+      );
+      mockUserHelper.isValidPassword.mockReturnValue(true);
+
+      await expect(
+        service.resetPassword({
+          ...validDto,
+          confirmNewPassword: 'Different1!',
+        }),
+      ).rejects.toThrow(BadRequestException);
+      await expect(
+        service.resetPassword({
+          ...validDto,
+          confirmNewPassword: 'Different1!',
+        }),
+      ).rejects.toThrow(UserMessages.PASSWORDS_DO_NOT_MATCH);
+    });
+
+    it('hashes new password, clears reset code, saves, and returns success', async () => {
+      const user = makeUser({
+        passwordResetCode: '5678',
+        passwordResetCodeExpiresAt: futureDate(),
+      });
+      mockRepo.findOneBy.mockResolvedValue(user);
+      mockUserHelper.isValidPassword.mockReturnValue(true);
+      mockUserHelper.hashPassword.mockResolvedValue('new-hashed-pw');
+      mockRepo.save.mockResolvedValue(user);
+
+      const result = await service.resetPassword(validDto);
+
+      expect(result).toEqual({
+        message: UserMessages.PASSWORDS_RESET_SUCCESSFUL,
+      });
+      expect(mockUserHelper.hashPassword).toHaveBeenCalledWith(
+        validDto.newPassword,
+      );
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          password: 'new-hashed-pw',
+          passwordResetCode: undefined,
+          passwordResetCodeExpiresAt: undefined,
+        }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // createAdminUser
+  // =========================================================================
+  describe('createAdminUser', () => {
+    const dto: CreateUserDto = {
+      email: 'admin@example.com',
+      fullName: 'Admin User',
+      password: 'AdminPass1',
+    };
+
+    it('throws ConflictException when email already exists', async () => {
+      mockRepo.findOne.mockResolvedValue(makeUser());
+
+      await expect(service.createAdminUser(dto)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('throws ConflictException when password is invalid', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockUserHelper.isValidPassword.mockReturnValue(false);
+
+      await expect(service.createAdminUser(dto)).rejects.toThrow(
+        ConflictException,
+      );
+    });
+
+    it('creates an ADMIN role user and returns success message', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockUserHelper.isValidPassword.mockReturnValue(true);
+      mockUserHelper.hashPassword.mockResolvedValue('hashed-pw');
+      mockRepo.create.mockImplementation((data) => data);
+      mockRepo.save.mockResolvedValue({});
+
+      const result = await service.createAdminUser(dto);
+
+      expect(result).toEqual({
+        message: UserMessages.USER_CREATED_SUCCESSFULLY,
+      });
+      expect(mockRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ role: UserRole.ADMIN }),
+      );
+    });
+
+    it('does NOT send a verification email for admin users', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      mockUserHelper.isValidPassword.mockReturnValue(true);
+      mockUserHelper.hashPassword.mockResolvedValue('hashed-pw');
+      mockRepo.create.mockReturnValue({});
+      mockRepo.save.mockResolvedValue({});
+
+      await service.createAdminUser(dto);
+
+      expect(sendEmail).not.toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // resendVerificationOtp
+  // =========================================================================
+  describe('resendVerificationOtp', () => {
+    it('throws when email is empty', async () => {
+      // The method wraps in try/catch and re-throws InternalServerErrorException
+      await expect(service.resendVerificationOtp('')).rejects.toThrow();
+    });
+
+    it('throws when user is not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.resendVerificationOtp('missing@example.com'),
+      ).rejects.toThrow();
+    });
+
+    it('generates new OTP, saves, sends email, and returns OTP_SENT', async () => {
+      const user = makeUser({ isVerified: false });
+      mockRepo.findOne.mockResolvedValue(user);
+      mockUserHelper.generateVerificationCode.mockReturnValue('7777');
+      mockRepo.save.mockResolvedValue(user);
+
+      const result = await service.resendVerificationOtp(user.email);
 
       expect(result).toEqual({ message: UserMessages.OTP_SENT });
       expect(sendEmail).toHaveBeenCalledWith(
-        dto.email,
+        user.email,
+        'Verify Your Account',
+        'verification-email',
+        { fullName: user.fullName, otp1: '7', otp2: '7', otp3: '7', otp4: '7' },
+      );
+    });
+  });
+
+  // =========================================================================
+  // verifyResetPasswordOtp
+  // =========================================================================
+  describe('verifyResetPasswordOtp', () => {
+    const dto: VerifyOtpDto = { email: 'user@example.com', otp: '5678' };
+
+    it('throws BadRequestException when email is missing', async () => {
+      await expect(
+        service.verifyResetPasswordOtp({ ...dto, email: '' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when OTP is missing', async () => {
+      await expect(
+        service.verifyResetPasswordOtp({ ...dto, otp: '' }),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws NotFoundException when user is not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      await expect(service.verifyResetPasswordOtp(dto)).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws UnauthorizedException when OTP does not match', async () => {
+      mockRepo.findOne.mockResolvedValue(
+        makeUser({ passwordResetCode: 'XXXX' }),
+      );
+      await expect(service.verifyResetPasswordOtp(dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.verifyResetPasswordOtp(dto)).rejects.toThrow(
+        UserMessages.INVALID_OTP,
+      );
+    });
+
+    it('throws UnauthorizedException when OTP is expired', async () => {
+      mockRepo.findOne.mockResolvedValue(
+        makeUser({
+          passwordResetCode: '5678',
+          passwordResetCodeExpiresAt: pastDate(),
+        }),
+      );
+      await expect(service.verifyResetPasswordOtp(dto)).rejects.toThrow(
+        UnauthorizedException,
+      );
+      await expect(service.verifyResetPasswordOtp(dto)).rejects.toThrow(
+        UserMessages.OTP_EXPIRED,
+      );
+    });
+
+    it('returns OTP_VERIFIED on success', async () => {
+      mockRepo.findOne.mockResolvedValue(
+        makeUser({
+          passwordResetCode: '5678',
+          passwordResetCodeExpiresAt: futureDate(),
+        }),
+      );
+      mockRepo.save.mockResolvedValue({});
+
+      const result = await service.verifyResetPasswordOtp(dto);
+      expect(result).toEqual({ message: UserMessages.OTP_VERIFIED });
+    });
+  });
+
+  // =========================================================================
+  // retrieveUserById
+  // =========================================================================
+  describe('retrieveUserById', () => {
+    it('throws UnauthorizedException when user is not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      await expect(service.retrieveUserById(99)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('returns mapped user DTO when found', async () => {
+      mockRepo.findOne.mockResolvedValue(makeUser());
+      const result = await service.retrieveUserById(1);
+      expect(result).toBe(MOCK_USER_DTO);
+      expect(mockUserHelper.mapToResponseDto).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // updateProfile
+  // =========================================================================
+  describe('updateProfile', () => {
+    it('throws NotFoundException when user is not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.updateProfile('bad-id', { bio: 'hi' }),
+      ).rejects.toThrow(NotFoundException);
+    });
+
+    it('updates only allowed profile fields and returns mapped DTO', async () => {
+      const user = makeUser();
+      mockRepo.findOne.mockResolvedValue(user);
+      mockRepo.save.mockResolvedValue({ ...user, bio: 'New bio' });
+
+      const result = await service.updateProfile(user.id, {
+        bio: 'New bio',
+        avatarUrl: 'https://example.com/avatar.png',
+      });
+
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bio: 'New bio',
+          avatarUrl: 'https://example.com/avatar.png',
+        }),
+      );
+      expect(result).toBe(MOCK_USER_DTO);
+    });
+
+    it('does not overwrite password or role via updateProfile', async () => {
+      const user = makeUser({ role: UserRole.SUBSCRIBER });
+      mockRepo.findOne.mockResolvedValue(user);
+      mockRepo.save.mockImplementation((u) => Promise.resolve(u));
+
+      await service.updateProfile(user.id, {
+        // TypeScript won't allow role here but we test the runtime guard
+        ...({ role: UserRole.ADMIN } as any),
+        bio: 'safe update',
+      });
+
+      // Role should remain unchanged since it is not in allowedFields
+      expect(mockRepo.save).toHaveBeenCalledWith(
+        expect.objectContaining({ role: UserRole.SUBSCRIBER }),
+      );
+    });
+  });
+
+  // =========================================================================
+  // resendResetPasswordVerificationOtp
+  // =========================================================================
+  describe('resendResetPasswordVerificationOtp', () => {
+    it('throws when email is missing', async () => {
+      await expect(
+        service.resendResetPasswordVerificationOtp({ email: '' }),
+      ).rejects.toThrow();
+    });
+
+    it('throws when user is not found', async () => {
+      mockRepo.findOne.mockResolvedValue(null);
+      await expect(
+        service.resendResetPasswordVerificationOtp({
+          email: 'nobody@example.com',
+        }),
+      ).rejects.toThrow();
+    });
+
+    it('sends reset password email and returns OTP_SENT', async () => {
+      const user = makeUser();
+      mockRepo.findOne.mockResolvedValue(user);
+      mockUserHelper.generateVerificationCode.mockReturnValue('3456');
+      mockRepo.save.mockResolvedValue(user);
+
+      const result = await service.resendResetPasswordVerificationOtp({
+        email: user.email,
+      });
+
+      expect(result).toEqual({ message: UserMessages.OTP_SENT });
+      expect(sendEmail).toHaveBeenCalledWith(
+        user.email,
         'Password Reset OTP',
         'reset-password-email',
-        {
-          fullName: user.fullName,
-          otp1: '3',
-          otp2: '4',
-          otp3: '5',
-          otp4: '6',
-        },
+        { fullName: user.fullName, otp1: '3', otp2: '4', otp3: '5', otp4: '6' },
       );
     });
   });

--- a/src/config/app.config.ts
+++ b/src/config/app.config.ts
@@ -1,4 +1,37 @@
+import * as Joi from 'joi';
+
+export const appConfigValidationSchema = Joi.object({
+  // App
+  APP_NAME: Joi.string().optional(),
+
+  // Stellar
+  STELLAR_NETWORK: Joi.string()
+    .valid('testnet', 'mainnet')
+    .default('testnet')
+    .description('Stellar network to use. Defaults to testnet.'),
+  STELLAR_RECEIVING_ADDRESS: Joi.string()
+    .optional()
+    .description('Platform Stellar receiving address for payments.'),
+  STELLAR_PLATFORM_ADDRESS: Joi.string()
+    .optional()
+    .description(
+      'Alias for STELLAR_RECEIVING_ADDRESS (used by payment listener).',
+    ),
+  STELLAR_SECRET_KEY: Joi.string()
+    .optional()
+    .description(
+      'Platform Stellar secret key — NEVER log or expose this value.',
+    ),
+}).unknown(true); // Allow other env vars not declared here
+
 export default () => ({
   appName: process.env.APP_NAME,
   stellarSecretKey: process.env.STELLAR_SECRET_KEY,
+  stellar: {
+    network: process.env.STELLAR_NETWORK ?? 'testnet',
+    receivingAddress:
+      process.env.STELLAR_RECEIVING_ADDRESS ??
+      process.env.STELLAR_PLATFORM_ADDRESS ??
+      '',
+  },
 });

--- a/src/orders/dto/order.dto.ts
+++ b/src/orders/dto/order.dto.ts
@@ -1,4 +1,4 @@
-import { Order } from '../entities/order.entity';
+import { Order } from '../orders.entity';
 
 export interface OrderItemInput {
   ticketTypeId: string;
@@ -11,18 +11,23 @@ export interface CreateOrderInput {
   items: OrderItemInput[];
 }
 
-/** Returned to the caller after createOrder — includes stellarMemo for payment. */
+/** Returned to the caller after createOrder — includes full Stellar payment instruction. */
 export interface CreateOrderResult {
   order: Order;
   /** Memo to include in the Stellar payment transaction for matching. */
   stellarMemo: string;
+  /** Platform's Stellar receiving address — send XLM here. */
+  destinationAddress: string;
+  /** Memo to attach to the Stellar transaction (same as stellarMemo). */
+  memo: string;
+  /** Total amount in XLM the buyer must send. */
+  amountXLM: number;
+  /** Network the payment should be made on: 'testnet' | 'mainnet'. */
+  network: string;
 }
 
 export class OrderError extends Error {
-  constructor(
-    message: string,
-    public readonly code: OrderErrorCode,
-  ) {
+  constructor(message: string, public readonly code: OrderErrorCode) {
     super(message);
     this.name = 'OrderError';
   }
@@ -30,10 +35,10 @@ export class OrderError extends Error {
 
 export enum OrderErrorCode {
   INSUFFICIENT_INVENTORY = 'INSUFFICIENT_INVENTORY',
-  TICKET_TYPE_NOT_FOUND  = 'TICKET_TYPE_NOT_FOUND',
-  EVENT_NOT_FOUND        = 'EVENT_NOT_FOUND',
-  ORDER_NOT_FOUND        = 'ORDER_NOT_FOUND',
-  ORDER_NOT_CANCELLABLE  = 'ORDER_NOT_CANCELLABLE',
-  EMPTY_ORDER            = 'EMPTY_ORDER',
-  INVALID_QUANTITY       = 'INVALID_QUANTITY',
+  TICKET_TYPE_NOT_FOUND = 'TICKET_TYPE_NOT_FOUND',
+  EVENT_NOT_FOUND = 'EVENT_NOT_FOUND',
+  ORDER_NOT_FOUND = 'ORDER_NOT_FOUND',
+  ORDER_NOT_CANCELLABLE = 'ORDER_NOT_CANCELLABLE',
+  EMPTY_ORDER = 'EMPTY_ORDER',
+  INVALID_QUANTITY = 'INVALID_QUANTITY',
 }

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -3,36 +3,20 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigModule } from '@nestjs/config';
 
 import orderConfig from './order.config';
+import { OrdersService } from './orders.service';
 import { OrdersScheduler } from './orders.scheduler';
 import { TicketModule } from 'src/ticket-verification/ticket.module';
-import { Order, OrderItem } from './orders.entity';
+import { Order } from './orders.entity';
+import { StellarModule } from '../stellar/stellar.module';
 
-/**
- * OrdersModule
- *
- * Registers `OrdersScheduler` as a provider so @nestjs/schedule picks up
- * its @Cron decorators automatically once ScheduleModule.forRoot() is in
- * AppModule.
- *
- * AppModule wiring required:
- * ```ts
- * @Module({
- *   imports: [
- *     ScheduleModule.forRoot(),   // ← must be present exactly once
- *     ConfigModule.forRoot({ load: [orderConfig], isGlobal: true }),
- *     OrdersModule,
- *   ],
- * })
- * export class AppModule {}
- * ```
- */
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Order, OrderItem]),
+    TypeOrmModule.forFeature([Order]),
     ConfigModule.forFeature(orderConfig),
     TicketModule,
+    StellarModule,
   ],
-  providers: [OrdersScheduler],
-  exports: [OrdersScheduler],
+  providers: [OrdersService, OrdersScheduler],
+  exports: [OrdersService, OrdersScheduler],
 })
 export class OrdersModule {}

--- a/src/stellar/stellar.service.spec.ts
+++ b/src/stellar/stellar.service.spec.ts
@@ -1,145 +1,257 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
+import { getRepositoryToken } from '@nestjs/typeorm';
 import { StellarService } from './stellar.service';
-import * as StellarSdk from 'stellar-sdk';
+import * as StellarSdk from '@stellar/stellar-sdk';
 import { Logger } from '@nestjs/common';
+import { Order } from '../orders/orders.entity';
+import { StellarCursor } from './entities/stellar-cursor.entity';
+import { DataSource } from 'typeorm';
+import { TicketService } from '../tickets-inventory/services/ticket.service';
+import { TicketTypeService } from '../tickets-inventory/services/ticket-type.service';
 
-// Mocking StellarSdk completely for isolated tests
-jest.mock('stellar-sdk', () => {
-    const actualStellarSdk = jest.requireActual('stellar-sdk');
-    return {
-        ...actualStellarSdk,
-        Server: jest.fn().mockImplementation(() => ({
-            loadAccount: jest.fn(),
-            fetchBaseFee: jest.fn(),
-            submitTransaction: jest.fn(),
-        })),
-        Keypair: {
-            fromSecret: jest.fn(),
-        },
-        TransactionBuilder: jest.fn().mockImplementation(() => ({
-            addOperation: jest.fn().mockReturnThis(),
-            addMemo: jest.fn().mockReturnThis(),
-            setTimeout: jest.fn().mockReturnThis(),
-            build: jest.fn().mockReturnValue({ sign: jest.fn() }),
-        })),
-        Operation: {
-            payment: jest.fn(),
-        },
-        Asset: {
-            native: jest.fn(),
-        },
-        Memo: {
-            text: jest.fn(),
-        },
-    };
+// Mocking @stellar/stellar-sdk completely for isolated tests
+jest.mock('@stellar/stellar-sdk', () => {
+  const actualStellarSdk = jest.requireActual('@stellar/stellar-sdk');
+  return {
+    ...actualStellarSdk,
+    Horizon: {
+      Server: jest.fn().mockImplementation(() => ({
+        loadAccount: jest.fn(),
+        feeStats: jest.fn(),
+        submitTransaction: jest.fn(),
+        payments: jest.fn().mockReturnValue({
+          forAccount: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          cursor: jest.fn().mockReturnThis(),
+          stream: jest.fn(),
+        }),
+        transactions: jest.fn().mockReturnValue({
+          transaction: jest.fn().mockReturnThis(),
+          call: jest.fn(),
+        }),
+      })),
+    },
+    Networks: {
+      TESTNET: 'Test SDF Network ; September 2015',
+      PUBLIC: 'Public Global Stellar Network ; September 2015',
+    },
+    Keypair: {
+      fromSecret: jest.fn(),
+    },
+    TransactionBuilder: jest.fn().mockImplementation(() => ({
+      addOperation: jest.fn().mockReturnThis(),
+      addMemo: jest.fn().mockReturnThis(),
+      setTimeout: jest.fn().mockReturnThis(),
+      build: jest.fn().mockReturnValue({ sign: jest.fn() }),
+    })),
+    Operation: {
+      payment: jest.fn(),
+    },
+    Asset: {
+      native: jest.fn(),
+    },
+    Memo: {
+      text: jest.fn(),
+    },
+    BASE_FEE: '100',
+  };
 });
 
+const mockOrderRepo = { findOne: jest.fn(), update: jest.fn() };
+const mockCursorRepo = { findOne: jest.fn(), upsert: jest.fn() };
+const mockDataSource = {};
+const mockTicketService = {};
+const mockTicketTypeService = {};
+
 describe('StellarService', () => {
-    let service: StellarService;
-    let configService: ConfigService;
+  let service: StellarService;
+  let configService: ConfigService;
 
-    const mockKeypair = {
-        publicKey: jest.fn().mockReturnValue('GBMOCKPUBLICKEY...'),
-        secret: jest.fn().mockReturnValue('SAMOCKSECRETKEY...'),
-    };
+  const mockKeypair = {
+    publicKey: jest.fn().mockReturnValue('GBMOCKPUBLICKEY...'),
+    sign: jest.fn(),
+  };
 
-    beforeEach(async () => {
-        (StellarSdk.Keypair.fromSecret as jest.Mock).mockReturnValue(mockKeypair);
+  beforeEach(async () => {
+    (StellarSdk.Keypair.fromSecret as jest.Mock).mockReturnValue(mockKeypair);
 
-        const module: TestingModule = await Test.createTestingModule({
-            providers: [
-                StellarService,
-                {
-                    provide: ConfigService,
-                    useValue: {
-                        get: jest.fn((key: string) => {
-                            if (key === 'stellarSecretKey') return 'SAMOCKSECRETKEY...';
-                            if (key === 'blockchain.horizonUrl') return 'https://horizon-testnet.stellar.org';
-                            return null;
-                        }),
-                    },
-                },
-            ],
-        }).compile();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        StellarService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) => {
+              if (key === 'stellarSecretKey') return 'SAMOCKSECRETKEY...';
+              if (key === 'blockchain.horizonUrl')
+                return 'https://horizon-testnet.stellar.org';
+              if (key === 'STELLAR_NETWORK') return 'testnet';
+              if (key === 'STELLAR_RECEIVING_ADDRESS')
+                return 'GBMOCKRECEIVINGADDRESS';
+              return null;
+            }),
+          },
+        },
+        { provide: getRepositoryToken(Order), useValue: mockOrderRepo },
+        { provide: getRepositoryToken(StellarCursor), useValue: mockCursorRepo },
+        { provide: DataSource, useValue: mockDataSource },
+        { provide: TicketService, useValue: mockTicketService },
+        { provide: TicketTypeService, useValue: mockTicketTypeService },
+      ],
+    }).compile();
 
-        service = module.get<StellarService>(StellarService);
-        configService = module.get<ConfigService>(ConfigService);
+    service = module.get<StellarService>(StellarService);
+    configService = module.get<ConfigService>(ConfigService);
 
-        // Disable logger output for tests
-        jest.spyOn(Logger.prototype, 'log').mockImplementation(() => { });
-        jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => { });
-        jest.spyOn(Logger.prototype, 'error').mockImplementation(() => { });
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
+    jest.spyOn(Logger.prototype, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // -----------------------------------------------------------------------
+  // generateMemo
+  // -----------------------------------------------------------------------
+  describe('generateMemo', () => {
+    it('should return the first 8 chars of the UUID (dashes stripped, uppercase)', () => {
+      const orderId = '3f9a2b1c-4d5e-6f7a-8b9c-0d1e2f3a4b5c';
+      const memo = service.generateMemo(orderId);
+      // 3f9a2b1c4d5e6f7a8b9c0d1e2f3a4b5c → first 8 = '3F9A2B1C'
+      expect(memo).toBe('3F9A2B1C');
     });
 
-    afterEach(() => {
-        jest.clearAllMocks();
+    it('should produce the same memo for the same orderId (reproducible)', () => {
+      const orderId = 'aaaabbbb-cccc-dddd-eeee-ffffaaaabbbb';
+      expect(service.generateMemo(orderId)).toBe(service.generateMemo(orderId));
     });
 
-    describe('sendRefund', () => {
-        it('should submit a refund transaction successfully', async () => {
-            // Mock successful server execution
-            const mockAccount = { sequenceNumber: () => '123' };
-            (service.server.loadAccount as jest.Mock).mockResolvedValue(mockAccount);
-            (service.server.fetchBaseFee as jest.Mock).mockResolvedValue(100);
-            (service.server.submitTransaction as jest.Mock).mockResolvedValue({
-                hash: 'mock-tx-hash-123',
-            });
-
-            const hash = await service.sendRefund('GDESTINATIONADDRESS', 10, 'order-123');
-
-            expect(hash).toBe('mock-tx-hash-123');
-            expect(service.server.loadAccount).toHaveBeenCalledWith('GBMOCKPUBLICKEY...');
-            expect(service.server.submitTransaction).toHaveBeenCalledTimes(1);
-        });
-
-        it('should retry once on RATE_LIMIT_EXCEEDED (429) then succeed', async () => {
-            const mockAccount = { sequenceNumber: () => '123' };
-            (service.server.loadAccount as jest.Mock).mockResolvedValue(mockAccount);
-            (service.server.fetchBaseFee as jest.Mock).mockResolvedValue(100);
-
-            const rateLimitError = new Error('Rate limit');
-            (rateLimitError as any).response = { status: 429 };
-
-            (service.server.submitTransaction as jest.Mock)
-                .mockRejectedValueOnce(rateLimitError)
-                .mockResolvedValueOnce({ hash: 'mock-tx-hash-456' });
-
-            // Spying on setTimeout in actual code might be tricky, we just check execution order
-            const hash = await service.sendRefund('GDESTINATIONADDRESS', 10, 'order-123');
-
-            expect(hash).toBe('mock-tx-hash-456');
-            expect(service.server.submitTransaction).toHaveBeenCalledTimes(2);
-        });
-
-        it('should fail if RATE_LIMIT_EXCEEDED occurs twice', async () => {
-            const mockAccount = { sequenceNumber: () => '123' };
-            (service.server.loadAccount as jest.Mock).mockResolvedValue(mockAccount);
-            (service.server.fetchBaseFee as jest.Mock).mockResolvedValue(100);
-
-            const rateLimitError = new Error('Rate limit');
-            (rateLimitError as any).response = { status: 429 };
-
-            (service.server.submitTransaction as jest.Mock)
-                .mockRejectedValueOnce(rateLimitError)
-                .mockRejectedValueOnce(rateLimitError);
-
-            await expect(service.sendRefund('GDESTINATIONADDRESS', 10, 'order-123')).rejects.toThrow(rateLimitError);
-            expect(service.server.submitTransaction).toHaveBeenCalledTimes(2);
-        });
-
-        it('should throw an error without retrying on other errors', async () => {
-            const mockAccount = { sequenceNumber: () => '123' };
-            (service.server.loadAccount as jest.Mock).mockResolvedValue(mockAccount);
-            (service.server.fetchBaseFee as jest.Mock).mockResolvedValue(100);
-
-            const otherError = new Error('Bad Request');
-            (otherError as any).response = { status: 400 };
-
-            (service.server.submitTransaction as jest.Mock).mockRejectedValueOnce(otherError);
-
-            await expect(service.sendRefund('GDESTINATIONADDRESS', 10, 'order-123')).rejects.toThrow(otherError);
-            expect(service.server.submitTransaction).toHaveBeenCalledTimes(1);
-        });
+    it('should produce different memos for different orderIds', () => {
+      const memo1 = service.generateMemo('aaaabbbb-0000-0000-0000-000000000000');
+      const memo2 = service.generateMemo('bbbbcccc-0000-0000-0000-000000000000');
+      expect(memo1).not.toBe(memo2);
     });
+
+    it('should always return exactly 8 characters', () => {
+      const memo = service.generateMemo('12345678-1234-1234-1234-123456789abc');
+      expect(memo).toHaveLength(8);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getPaymentAddress
+  // -----------------------------------------------------------------------
+  describe('getPaymentAddress', () => {
+    it('should return destinationAddress, memo, and network', () => {
+      const orderId = '3f9a2b1c-4d5e-6f7a-8b9c-0d1e2f3a4b5c';
+      const result = service.getPaymentAddress(orderId);
+
+      expect(result.destinationAddress).toBe('GBMOCKRECEIVINGADDRESS');
+      expect(result.memo).toBe(service.generateMemo(orderId));
+      expect(result.network).toBe('testnet');
+    });
+
+    it('should throw if no receiving address is configured', () => {
+      jest.spyOn(configService, 'get').mockReturnValue(undefined);
+      // Override platformAddress too
+      (service as any).config.platformAddress = '';
+      expect(() => service.getPaymentAddress('any-id')).toThrow(
+        'STELLAR_RECEIVING_ADDRESS is not configured',
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // getNetworkPassphrase
+  // -----------------------------------------------------------------------
+  describe('getNetworkPassphrase', () => {
+    it('should return testnet passphrase by default', () => {
+      jest.spyOn(configService, 'get').mockReturnValue('testnet');
+      expect(service.getNetworkPassphrase()).toBe(StellarSdk.Networks.TESTNET);
+    });
+
+    it('should return mainnet passphrase when STELLAR_NETWORK=mainnet', () => {
+      jest.spyOn(configService, 'get').mockReturnValue('mainnet');
+      expect(service.getNetworkPassphrase()).toBe(StellarSdk.Networks.PUBLIC);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // sendRefund
+  // -----------------------------------------------------------------------
+  describe('sendRefund', () => {
+    it('should submit a refund transaction successfully', async () => {
+      const mockAccount = { sequenceNumber: () => '123', accountId: () => 'G...' };
+      (service.server.loadAccount as jest.Mock).mockResolvedValue(mockAccount);
+      (service.server.feeStats as jest.Mock).mockResolvedValue({
+        last_ledgers_base_fee_stats: { min: '100' },
+      });
+      (service.server.submitTransaction as jest.Mock).mockResolvedValue({
+        hash: 'mock-tx-hash-123',
+      });
+
+      const hash = await service.sendRefund('GDESTINATIONADDRESS', 10, 'order-123');
+      expect(hash).toBe('mock-tx-hash-123');
+    });
+
+    it('should retry once on RATE_LIMIT_EXCEEDED (429) then succeed', async () => {
+      const mockAccount = { sequenceNumber: () => '123' };
+      (service.server.loadAccount as jest.Mock).mockResolvedValue(mockAccount);
+      (service.server.feeStats as jest.Mock).mockResolvedValue({
+        last_ledgers_base_fee_stats: { min: '100' },
+      });
+
+      const rateLimitError = new Error('Rate limit');
+      (rateLimitError as any).response = { status: 429 };
+
+      (service.server.submitTransaction as jest.Mock)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockResolvedValueOnce({ hash: 'mock-tx-hash-456' });
+
+      const hash = await service.sendRefund('GDESTINATIONADDRESS', 10, 'order-123');
+      expect(hash).toBe('mock-tx-hash-456');
+      expect(service.server.submitTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fail if RATE_LIMIT_EXCEEDED occurs twice', async () => {
+      const mockAccount = { sequenceNumber: () => '123' };
+      (service.server.loadAccount as jest.Mock).mockResolvedValue(mockAccount);
+      (service.server.feeStats as jest.Mock).mockResolvedValue({
+        last_ledgers_base_fee_stats: { min: '100' },
+      });
+
+      const rateLimitError = new Error('Rate limit');
+      (rateLimitError as any).response = { status: 429 };
+
+      (service.server.submitTransaction as jest.Mock)
+        .mockRejectedValueOnce(rateLimitError)
+        .mockRejectedValueOnce(rateLimitError);
+
+      await expect(
+        service.sendRefund('GDESTINATIONADDRESS', 10, 'order-123'),
+      ).rejects.toThrow(rateLimitError);
+      expect(service.server.submitTransaction).toHaveBeenCalledTimes(2);
+    });
+
+    it('should throw without retrying on other errors', async () => {
+      const mockAccount = { sequenceNumber: () => '123' };
+      (service.server.loadAccount as jest.Mock).mockResolvedValue(mockAccount);
+      (service.server.feeStats as jest.Mock).mockResolvedValue({
+        last_ledgers_base_fee_stats: { min: '100' },
+      });
+
+      const otherError = new Error('Bad Request');
+      (otherError as any).response = { status: 400 };
+
+      (service.server.submitTransaction as jest.Mock).mockRejectedValueOnce(otherError);
+
+      await expect(
+        service.sendRefund('GDESTINATIONADDRESS', 10, 'order-123'),
+      ).rejects.toThrow(otherError);
+      expect(service.server.submitTransaction).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/tickets-inventory/controllers/ticket-type.controller.spec.ts
+++ b/src/tickets-inventory/controllers/ticket-type.controller.spec.ts
@@ -1,0 +1,148 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TicketTypeController } from './ticket-type.controller';
+import { TicketTypeService } from '../services/ticket-type.service';
+import { JwtAuthGuard } from '../../auth/guard/jwt.auth.guard';
+
+// ---------------------------------------------------------------------------
+// Stub service — returns minimal shaped objects so we can verify routing
+// ---------------------------------------------------------------------------
+const mockTicketTypeService = {
+  create: jest.fn(),
+  findByEvent: jest.fn(),
+  findById: jest.fn(),
+  update: jest.fn(),
+  delete: jest.fn(),
+  getInventorySummary: jest.fn(),
+};
+
+// Override JwtAuthGuard so it never blocks in unit tests
+const allowAllGuard = { canActivate: () => true };
+
+describe('TicketTypeController', () => {
+  let controller: TicketTypeController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TicketTypeController],
+      providers: [
+        { provide: TicketTypeService, useValue: mockTicketTypeService },
+      ],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(allowAllGuard)
+      .compile();
+
+    controller = module.get<TicketTypeController>(TicketTypeController);
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  // -------------------------------------------------------------------------
+  // findByEvent — the primary regression test
+  // -------------------------------------------------------------------------
+  describe('findByEvent', () => {
+    it('should pass eventId from route param to the service (not undefined)', async () => {
+      const eventId = 'event-uuid-123';
+      mockTicketTypeService.findByEvent.mockResolvedValue([]);
+
+      await controller.findByEvent(eventId);
+
+      expect(mockTicketTypeService.findByEvent).toHaveBeenCalledWith(eventId);
+      expect(mockTicketTypeService.findByEvent).not.toHaveBeenCalledWith(
+        undefined,
+      );
+    });
+
+    it('should return the service result', async () => {
+      const stub = [{ id: 'tt-1', name: 'VIP' }];
+      mockTicketTypeService.findByEvent.mockResolvedValue(stub);
+
+      const result = await controller.findByEvent('event-abc');
+      expect(result).toBe(stub);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // findById
+  // -------------------------------------------------------------------------
+  describe('findById', () => {
+    it('should pass id to the service (not undefined)', async () => {
+      mockTicketTypeService.findById.mockResolvedValue({ id: 'tt-99' });
+
+      await controller.findById('event-1', 'tt-99');
+
+      expect(mockTicketTypeService.findById).toHaveBeenCalledWith('tt-99');
+      expect(mockTicketTypeService.findById).not.toHaveBeenCalledWith(
+        undefined,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // update
+  // -------------------------------------------------------------------------
+  describe('update', () => {
+    it('should pass id and dto to the service (id not undefined)', async () => {
+      const dto = { name: 'Updated Name' };
+      mockTicketTypeService.update.mockResolvedValue({ id: 'tt-5', ...dto });
+
+      await controller.update('event-1', 'tt-5', dto as any);
+
+      expect(mockTicketTypeService.update).toHaveBeenCalledWith('tt-5', dto);
+      expect(mockTicketTypeService.update).not.toHaveBeenCalledWith(
+        undefined,
+        dto,
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // delete
+  // -------------------------------------------------------------------------
+  describe('delete', () => {
+    it('should pass id to the service (not undefined)', async () => {
+      mockTicketTypeService.delete.mockResolvedValue(undefined);
+
+      await controller.delete('event-1', 'tt-7');
+
+      expect(mockTicketTypeService.delete).toHaveBeenCalledWith('tt-7');
+      expect(mockTicketTypeService.delete).not.toHaveBeenCalledWith(undefined);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // getInventorySummary
+  // -------------------------------------------------------------------------
+  describe('getInventorySummary', () => {
+    it('should pass eventId to the service (not undefined)', async () => {
+      const summary = { total: 100, sold: 40, remaining: 60 };
+      mockTicketTypeService.getInventorySummary.mockResolvedValue(summary);
+
+      const result = await controller.getInventorySummary('event-xyz');
+
+      expect(mockTicketTypeService.getInventorySummary).toHaveBeenCalledWith(
+        'event-xyz',
+      );
+      expect(
+        mockTicketTypeService.getInventorySummary,
+      ).not.toHaveBeenCalledWith(undefined);
+      expect(result).toBe(summary);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // create
+  // -------------------------------------------------------------------------
+  describe('create', () => {
+    it('should pass eventId and dto to the service', async () => {
+      const dto = { name: 'General', price: 10, totalQuantity: 200 };
+      const created = { id: 'tt-new', eventId: 'event-1', ...dto };
+      mockTicketTypeService.create.mockResolvedValue(created);
+
+      const result = await controller.create('event-1', dto as any);
+
+      expect(mockTicketTypeService.create).toHaveBeenCalledWith('event-1', dto);
+      expect(result).toBe(created);
+    });
+  });
+});

--- a/src/tickets-inventory/controllers/ticket-type.controller.ts
+++ b/src/tickets-inventory/controllers/ticket-type.controller.ts
@@ -8,11 +8,13 @@ import {
   Body,
   HttpCode,
   HttpStatus,
+  UseGuards,
 } from '@nestjs/common';
 import { TicketTypeService } from '../services/ticket-type.service';
 import { CreateTicketTypeDto } from '../dto/create-ticket-type.dto';
 import { UpdateTicketTypeDto } from '../dto/update-ticket-type.dto';
 import { TicketTypeResponseDto } from '../dto/ticket-type.response.dto';
+import { JwtAuthGuard } from '../../auth/guard/jwt.auth.guard';
 
 @Controller('events/:eventId/ticket-types')
 export class TicketTypeController {
@@ -24,6 +26,7 @@ export class TicketTypeController {
    */
   @Post()
   @HttpCode(HttpStatus.CREATED)
+  @UseGuards(JwtAuthGuard)
   async create(
     @Param('eventId') eventId: string,
     @Body() createTicketTypeDto: CreateTicketTypeDto,
@@ -36,8 +39,19 @@ export class TicketTypeController {
    * GET /events/:eventId/ticket-types
    */
   @Get()
-  async findByEvent(eventId: string): Promise<TicketTypeResponseDto[]> {
+  async findByEvent(
+    @Param('eventId') eventId: string,
+  ): Promise<TicketTypeResponseDto[]> {
     return this.ticketTypeService.findByEvent(eventId);
+  }
+
+  /**
+   * Get inventory summary for an event
+   * GET /events/:eventId/ticket-types/summary/inventory
+   */
+  @Get('summary/inventory')
+  async getInventorySummary(@Param('eventId') eventId: string): Promise<any> {
+    return this.ticketTypeService.getInventorySummary(eventId);
   }
 
   /**
@@ -45,7 +59,10 @@ export class TicketTypeController {
    * GET /events/:eventId/ticket-types/:id
    */
   @Get(':id')
-  async findById(id: string): Promise<TicketTypeResponseDto> {
+  async findById(
+    @Param('eventId') eventId: string,
+    @Param('id') id: string,
+  ): Promise<TicketTypeResponseDto> {
     return this.ticketTypeService.findById(id);
   }
 
@@ -54,8 +71,10 @@ export class TicketTypeController {
    * PUT /events/:eventId/ticket-types/:id
    */
   @Put(':id')
+  @UseGuards(JwtAuthGuard)
   async update(
-    id: string,
+    @Param('eventId') eventId: string,
+    @Param('id') id: string,
     @Body() updateTicketTypeDto: UpdateTicketTypeDto,
   ): Promise<TicketTypeResponseDto> {
     return this.ticketTypeService.update(id, updateTicketTypeDto);
@@ -67,16 +86,11 @@ export class TicketTypeController {
    */
   @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
-  async delete(id: string): Promise<void> {
+  @UseGuards(JwtAuthGuard)
+  async delete(
+    @Param('eventId') eventId: string,
+    @Param('id') id: string,
+  ): Promise<void> {
     return this.ticketTypeService.delete(id);
-  }
-
-  /**
-   * Get inventory summary for an event
-   * GET /events/:eventId/ticket-types/summary
-   */
-  @Get('summary/inventory')
-  async getInventorySummary(eventId: string): Promise<any> {
-    return this.ticketTypeService.getInventorySummary(eventId);
   }
 }


### PR DESCRIPTION
## Summary

This PR resolves four separate issues in a single branch. Each commit is
self-contained and can be reviewed independently.

---

## Closes

- Closes #430  — Stellar payment address generation
- Closes #421 — Admin platform stats endpoint
- Closes #420  — TicketTypeController missing @Param() decorators
- Closes #415  — AuthService unit test coverage

---

## Changes by Issue

### Issue 1 · feat(stellar): Payment address & memo generation

**Problem:** `StellarService` had no public API for generating payment
instructions. `OrdersService` generated memos using random bytes instead of
the order UUID, so memos were not reproducible or traceable. The spec file
imported the deprecated `stellar-sdk` package. `order.dto.ts` had a broken
import path that would cause a compile error at runtime.

**Changes:**
| File | Change |
|---|---|
| `src/stellar/stellar.service.ts` | Add `generateMemo()`, `getPaymentAddress()`, `getNetworkPassphrase()` |
| `src/stellar/stellar.service.spec.ts` | Fix SDK import, add tests for all 3 new methods |
| `src/config/app.config.ts` | Add Joi schema validating `STELLAR_NETWORK`, `STELLAR_RECEIVING_ADDRESS` |
| `src/app.module.ts` | Wire `validationSchema` into `ConfigModule.forRoot` |
| `src/orders/orders.service.ts` | Delegate memo to `StellarService`, return full payment instruction |
| `src/orders/orders.module.ts` | Add `OrdersService` to providers, import `StellarModule` |
| `src/orders/dto/order.dto.ts` | Fix import path, extend `CreateOrderResult` |

**New env vars required:**
```
STELLAR_NETWORK=testnet          # or mainnet; defaults to testnet
STELLAR_RECEIVING_ADDRESS=G...   # platform Stellar public key
```

---

### Issue 2 · feat(admin): GET /admin/stats

**Problem:** No single endpoint existed for platform health overview. Admins
had to query multiple endpoints and stitch data together manually.

**Changes:**
| File | Change |
|---|---|
| `src/admin/admin.module.ts` | New — registers repos, service, controller |
| `src/admin/admin.service.ts` | New — 4 parallel stat helpers using QueryBuilder `COUNT`/`GROUP BY`/`SUM` |
| `src/admin/admin.controller.ts` | New — `GET /admin/stats`, guarded by `JwtAuthGuard + RolesGuard + ADMIN` |
| `src/admin/dto/admin-stats.dto.ts` | New — typed response interfaces |
| `src/admin/admin.service.spec.ts` | New — unit tests with chainable QueryBuilder mock |
| `src/app.module.ts` | Add `AdminModule` to imports |

**Response shape:**
```json
{
  "users":   { "total": 0, "verified": 0, "byRole": { "subscriber": 0, "organizer": 0, "admin": 0 } },
  "events":  { "total": 0, "byStatus": { "draft": 0, "published": 0, "cancelled": 0, "completed": 0, "postponed": 0 } },
  "tickets": { "total": 0, "issued": 0, "scanned": 0, "refunded": 0, "cancelled": 0 },
  "orders":  { "total": 0, "paid": 0, "pending": 0, "failed": 0, "refunded": 0, "totalRevenueXLM": "0" },
  "generatedAt": "2026-02-25T00:00:00.000Z"
}
```

---

### Issue 3 · fix(tickets): TicketTypeController @Param() decorators

**Problem:** `findByEvent`, `findById`, `update`, `delete`, and
`getInventorySummary` declared route parameters as plain function arguments
with no `@Param()` decorator. NestJS requires the decorator for the DI
pipeline to extract values from the URL — without it every parameter
silently resolved to `undefined` at runtime.

**Changes:**
| File | Change |
|---|---|
| `src/tickets-inventory/controllers/ticket-type.controller.ts` | Add `@Param('eventId')` and `@Param('id')` to all affected methods; add `@UseGuards(JwtAuthGuard)` to POST/PUT/DELETE; move `summary/inventory` route above `:id` |
| `src/tickets-inventory/controllers/ticket-type.controller.spec.ts` | New — controller unit tests asserting each method receives the correct non-`undefined` values |

Zero business logic changed.

---

### Issue 4 · test(auth): AuthService unit test coverage

**Problem:** `auth.service.spec.ts` was a near-empty placeholder with a
single smoke test. `AuthService` is the most critical service in the
codebase with no meaningful coverage.

**Changes:**
| File | Change |
|---|---|
| `src/auth/auth.service.spec.ts` | Full rewrite — 50+ tests across 12 `describe` blocks |

**Coverage by method:**

| Method | Scenarios |
|---|---|
| `createUser` | Duplicate email, invalid password, successful creation, email sent with correct OTP digits, SUBSCRIBER role assigned |
| `verifyOtp` | Missing email, missing OTP, user not found, wrong OTP, expired OTP, null expiry, happy path returns tokens |
| `login` | User not found, wrong password, unverified user triggers OTP resend, successful login returns tokens |
| `refreshToken` | Invalid token throws, user not found, returns new access token |
| `requestResetPasswordOtp` | Missing email, user not found, OTP saved and reset email sent |
| `resetPassword` | OTP not found, expired OTP, null expiry, invalid password, password mismatch, successful reset |
| `createAdminUser` | Duplicate email, invalid password, ADMIN role assigned, no email sent |
| `resendVerificationOtp` | Missing email, user not found, email resent |
| `verifyResetPasswordOtp` | Missing fields, user not found, wrong OTP, expired, success |
| `retrieveUserById` | User not found, returns mapped DTO |
| `updateProfile` | User not found, allowed fields updated, password/role not overwritable |
| `resendResetPasswordVerificationOtp` | Missing email, user not found, email sent |

---

## Testing
```bash
# Run all tests
npm run test

# Run with coverage
npm run test:cov

# Run only changed specs
npx jest stellar.service.spec admin.service.spec ticket-type.controller.spec auth.service.spec
```

## Checklist

- [x] All new files follow existing project conventions
- [x] No business logic changed in bug-fix issues (Issues 1 partial, Issue 3)
- [x] All dependencies mocked in unit tests — no DB or network calls
- [x] `sendEmail` mocked — no real emails sent during test runs
- [x] `JwtAuthGuard` overridden in controller tests — auth doesn't block routing assertions
- [x] New env vars documented above
- [x] No secret keys logged or exposed