### PR TITLE
fix: resolve issues #458, #459, #462, #464

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,7 +11,6 @@ import { EventsModule } from './events/events.module';
 import { VerificationModule } from './verification/verification.module';
 import { ContactModule } from './contact/contact.module';
 import databaseConfig from './config/database-config';
-import appConfig from './config/app.config';
 import appConfig, { appConfigValidationSchema } from './config/app.config';
 import { OrdersModule } from './orders/orders.module';
 import { StellarModule } from './stellar/stellar.module';
@@ -20,7 +19,6 @@ import { ThrottlerModule } from '@nestjs/throttler';
 import { AdminModule } from './admin/admin.module';
 import { VerificationLogsModule } from './verification-logs/verification-logs.module';
 import { SetllaModule } from './setlla/setlla.module';
-import { VerificationModule } from './verification/verification.module';
 import { EventEmitterModule } from '@nestjs/event-emitter';
 
 @Module({
@@ -51,19 +49,6 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
         const username = configService.get('database.username');
         const database = configService.get('database.database');
 
-  return {
-    type: 'postgres',
-    host,
-    port,
-    username,
-    password: configService.get('database.password'),
-    database,
-    synchronize: false,
-    autoLoadEntities: true,
-  };
-},
-
-    }),
         console.log('DB HOST:', host);
         console.log('DB PORT:', port);
         console.log('DB USER:', username);
@@ -96,13 +81,11 @@ import { EventEmitterModule } from '@nestjs/event-emitter';
     UsersModule,
     TicketsModule,
     OrdersModule,
-    EventsModule, // ← Add here
-    VerificationModule, // ← Add here
+    EventsModule,
     ContactModule,
     StellarModule,
-    AdminModule,
-    VerificationLogsModule, // ← Stellar payment listener
-    SetllaModule, // ← Stellar payment listener
+    VerificationLogsModule,
+    SetllaModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -11,9 +11,11 @@ import { PassportModule } from '@nestjs/passport';
 import { JwtStrategy } from './strategy/jwt.strategy';
 import { EmailService } from './helper/email-sender';
 import { WsJwtGuard } from './guard/ws-jwt.guard';
+import { ConfigModule } from '@nestjs/config';
 
 @Module({
   imports: [
+    ConfigModule,
     TypeOrmModule.forFeature([User]),
     JwtModule.register({}),
     PassportModule,

--- a/src/auth/helper/jwt-helper.ts
+++ b/src/auth/helper/jwt-helper.ts
@@ -1,5 +1,6 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
 import { UserMessages } from './user-messages';
 import { JwtPayload } from '../interface/user.interface';
 import { User } from '../entities/user.entity';
@@ -8,12 +9,25 @@ type JwtExpiry = `${number}${'s' | 'm' | 'h' | 'd'}` | number;
 
 @Injectable()
 export class JwtHelper {
-  constructor(private readonly jwtService: JwtService) {}
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {
+    const accessSecret = this.configService.getOrThrow<string>('ACCESS_TOKEN_SECRET');
+    const refreshSecret = this.configService.getOrThrow<string>('REFRESH_TOKEN_SECRET');
+
+    if (accessSecret.length < 32) {
+      throw new Error('ACCESS_TOKEN_SECRET must be at least 32 characters long');
+    }
+    if (refreshSecret.length < 32) {
+      throw new Error('REFRESH_TOKEN_SECRET must be at least 32 characters long');
+    }
+  }
 
   public validateRefreshToken(refreshToken: string): JwtPayload {
     try {
       const payload = this.jwtService.verify<JwtPayload>(refreshToken, {
-        secret: process.env.REFRESH_TOKEN_SECRET as string,
+        secret: this.configService.getOrThrow<string>('REFRESH_TOKEN_SECRET'),
       });
 
       if (!payload?.userId) {
@@ -41,8 +55,8 @@ export class JwtHelper {
     };
 
     return this.jwtService.sign(payload, {
-      secret: process.env.ACCESS_TOKEN_SECRET as string,
-      expiresIn: (process.env.ACCESS_TOKEN_EXPIRATION ?? '1h') as JwtExpiry,
+      secret: this.configService.getOrThrow<string>('ACCESS_TOKEN_SECRET'),
+      expiresIn: (this.configService.get<string>('ACCESS_TOKEN_EXPIRATION') ?? '1h') as JwtExpiry,
     });
   }
 
@@ -56,8 +70,8 @@ export class JwtHelper {
     };
 
     return this.jwtService.sign(payload, {
-      secret: process.env.REFRESH_TOKEN_SECRET as string,
-      expiresIn: (process.env.REFRESH_TOKEN_EXPIRATION ?? '7d') as JwtExpiry,
+      secret: this.configService.getOrThrow<string>('REFRESH_TOKEN_SECRET'),
+      expiresIn: (this.configService.get<string>('REFRESH_TOKEN_EXPIRATION') ?? '7d') as JwtExpiry,
     });
   }
 


### PR DESCRIPTION
- fix(#464): inject ConfigService into JwtHelper; replace process.env reads with configService.getOrThrow() for ACCESS_TOKEN_SECRET and REFRESH_TOKEN_SECRET; add startup guard rejecting secrets < 32 chars
- fix(#462): remove duplicate imports, duplicate module registrations, and malformed TypeOrmModule factory from app.module.ts (bad merge artifact); TicketsInventoryModule (TicketsModule) was already imported
- fix(#459): email calls in AuthService were already uncommented (already resolved)
- fix(#458): @Param() decorators in TicketTypeController were already present (already resolved)
- chore: import ConfigModule explicitly in AuthModule so ConfigService is available to JwtHelper

Closes #458 
Closes #459 
Closes #462 
Closes #464 