### PR TITLE
feat(events): implement GET /events, GET /events/:id, PATCH /events/:id, PATCH /events/:id/status

### DIFF
--- a/src/events/dto/create-event.dto.ts
+++ b/src/events/dto/create-event.dto.ts
@@ -5,6 +5,8 @@ import {
   IsDateString,
   Min,
   IsEnum,
+  IsBoolean,
+  Length,
 } from 'class-validator';
 import { EventStatus } from '../enums/event-status.enum';
 
@@ -18,6 +20,19 @@ export class CreateEventDto {
 
   @IsString()
   location: string;
+
+  @IsString()
+  @IsOptional()
+  city?: string;
+
+  @IsString()
+  @IsOptional()
+  @Length(2, 2)
+  countryCode?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isVirtual?: boolean;
 
   @IsDateString()
   eventDate: string;

--- a/src/events/dto/event-detail-response.dto.ts
+++ b/src/events/dto/event-detail-response.dto.ts
@@ -1,0 +1,25 @@
+import { EventStatus } from '../enums/event-status.enum';
+
+export class TicketTypeResponseDto {
+  id: string;
+  name: string;
+  price: number;
+  quantity: number;
+  sold: number;
+}
+
+export class EventDetailResponseDto {
+  id: string;
+  title: string;
+  description: string;
+  location: string;
+  eventDate: Date;
+  status: EventStatus;
+  capacity: number;
+  isArchived: boolean;
+  organizerId: string;
+  organizer: { id: string; fullName: string; email: string };
+  ticketTypes: TicketTypeResponseDto[];
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/events/dto/event-query.dto.ts
+++ b/src/events/dto/event-query.dto.ts
@@ -1,0 +1,43 @@
+import { IsOptional, IsString, IsBoolean, IsDateString, IsEnum, IsIn } from 'class-validator';
+import { Type } from 'class-transformer';
+import { PaginationDto } from '../../common/dto/pagination.dto';
+import { EventStatus } from '../enums/event-status.enum';
+
+export class EventQueryDto extends PaginationDto {
+  @IsOptional()
+  @IsString()
+  search?: string;
+
+  @IsOptional()
+  @IsEnum(EventStatus)
+  status?: EventStatus;
+
+  @IsOptional()
+  @IsString()
+  city?: string;
+
+  @IsOptional()
+  @IsString()
+  countryCode?: string;
+
+  @IsOptional()
+  @Type(() => Boolean)
+  @IsBoolean()
+  isVirtual?: boolean;
+
+  @IsOptional()
+  @IsDateString()
+  dateFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  dateTo?: string;
+
+  @IsOptional()
+  @IsIn(['eventDate', 'createdAt'])
+  sortBy?: 'eventDate' | 'createdAt' = 'createdAt';
+
+  @IsOptional()
+  @IsIn(['asc', 'desc'])
+  sortOrder?: 'asc' | 'desc' = 'desc';
+}

--- a/src/events/dto/update-event.dto.ts
+++ b/src/events/dto/update-event.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType, OmitType } from '@nestjs/mapped-types';
+import { CreateEventDto } from './create-event.dto';
+
+export class UpdateEventDto extends PartialType(OmitType(CreateEventDto, ['status'] as const)) {}

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -25,6 +25,15 @@ export class Event {
   @Column()
   location: string;
 
+  @Column({ nullable: true })
+  city: string;
+
+  @Column({ nullable: true, length: 2 })
+  countryCode: string;
+
+  @Column({ default: false })
+  isVirtual: boolean;
+
   @Column({ type: 'timestamptz' })
   eventDate: Date;
 
@@ -47,6 +56,9 @@ export class Event {
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'organizerId' })
   organizer: User;
+
+  @OneToMany('TicketType', 'event')
+  ticketTypes: any[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/events/enums/event-status.enum.ts
+++ b/src/events/enums/event-status.enum.ts
@@ -3,4 +3,5 @@ export enum EventStatus {
   PUBLISHED = 'PUBLISHED',
   CANCELLED = 'CANCELLED',
   COMPLETED = 'COMPLETED',
+  POSTPONED = 'POSTPONED',
 }

--- a/src/events/event-transitions.ts
+++ b/src/events/event-transitions.ts
@@ -1,0 +1,13 @@
+import { EventStatus } from './enums/event-status.enum';
+
+export const EVENT_TRANSITIONS: Record<EventStatus, EventStatus[]> = {
+  [EventStatus.DRAFT]: [EventStatus.PUBLISHED, EventStatus.CANCELLED],
+  [EventStatus.PUBLISHED]: [EventStatus.CANCELLED, EventStatus.POSTPONED, EventStatus.COMPLETED],
+  [EventStatus.POSTPONED]: [EventStatus.PUBLISHED, EventStatus.CANCELLED],
+  [EventStatus.CANCELLED]: [],
+  [EventStatus.COMPLETED]: [],
+};
+
+export function isValidTransition(from: EventStatus, to: EventStatus): boolean {
+  return EVENT_TRANSITIONS[from]?.includes(to) ?? false;
+}

--- a/src/events/events.controller.ts
+++ b/src/events/events.controller.ts
@@ -7,9 +7,13 @@ import {
   Param,
   Get,
   Query,
+  Patch,
 } from '@nestjs/common';
 import { EventsService } from './events.service';
 import { CreateEventDto } from './dto/create-event.dto';
+import { UpdateEventDto } from './dto/update-event.dto';
+import { EventQueryDto } from './dto/event-query.dto';
+import { EventStatus } from './enums/event-status.enum';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Roles } from '../common/decorators/roles.decorator';
@@ -24,18 +28,20 @@ export class EventsController {
   @Post()
   @UseGuards(JwtAuthGuard, RolesGuard)
   @Roles('ORGANIZER', 'ADMIN')
-  async create(
-    @Body() createEventDto: CreateEventDto,
-    @CurrentUser() user: User,
-  ) {
+  async create(@Body() createEventDto: CreateEventDto, @CurrentUser() user: User) {
     return await this.eventsService.createEvent(createEventDto, user);
   }
 
-  @Delete(':id')
-  @UseGuards(JwtAuthGuard)
-  async remove(@Param('id') id: string, @CurrentUser() user: User) {
-    await this.eventsService.remove(id, user);
-    return { message: 'Event archived successfully' };
+  @Get()
+  async findAll(@Query() query: EventQueryDto) {
+    return await this.eventsService.findAll(query);
+  }
+
+  @Get('my')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles('ORGANIZER', 'ADMIN')
+  async findMyEvents(@CurrentUser() user: User, @Query() pagination: PaginationDto) {
+    return await this.eventsService.findByOrganizer(user.id, pagination);
   }
 
   @Get(':id/capacity')
@@ -43,13 +49,31 @@ export class EventsController {
     return await this.eventsService.getCapacity(id);
   }
 
-  @Get('my')
-  @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ORGANIZER', 'ADMIN')
-  async findMyEvents(
+  @Get(':id')
+  async getById(@Param('id') id: string) {
+    return await this.eventsService.getById(id);
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard)
+  async update(@Param('id') id: string, @Body() dto: UpdateEventDto, @CurrentUser() user: User) {
+    return await this.eventsService.update(id, dto, user);
+  }
+
+  @Patch(':id/status')
+  @UseGuards(JwtAuthGuard)
+  async changeStatus(
+    @Param('id') id: string,
+    @Body('status') status: EventStatus,
     @CurrentUser() user: User,
-    @Query() pagination: PaginationDto,
   ) {
-    return await this.eventsService.findByOrganizer(user.id, pagination);
+    return await this.eventsService.changeStatus(id, status, user);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  async remove(@Param('id') id: string, @CurrentUser() user: User) {
+    await this.eventsService.remove(id, user);
+    return { message: 'Event archived successfully' };
   }
 }

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -1,9 +1,17 @@
-import { Injectable, BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Event } from './entities/event.entity';
 import { CreateEventDto } from './dto/create-event.dto';
+import { UpdateEventDto } from './dto/update-event.dto';
+import { EventQueryDto } from './dto/event-query.dto';
 import { EventStatus } from './enums/event-status.enum';
+import { isValidTransition } from './event-transitions';
 import { User } from '../users/entities/user.entity';
 import { PaginationDto } from '../common/dto/pagination.dto';
 
@@ -21,72 +29,103 @@ export class EventsService {
       organizerId: user.id,
       status: dto.status || EventStatus.DRAFT,
     });
+    return await this.eventsRepository.save(event);
+  }
 
+  async findAll(query: EventQueryDto): Promise<{ data: Event[]; total: number; page: number; limit: number; totalPages: number }> {
+    const { search, status, city, countryCode, isVirtual, dateFrom, dateTo, sortBy = 'createdAt', sortOrder = 'desc', page = 1, limit = 20 } = query;
+
+    const qb = this.eventsRepository.createQueryBuilder('event')
+      .where('event.isArchived = false')
+      .andWhere('event.status = :status', { status: status ?? EventStatus.PUBLISHED });
+
+    if (search) {
+      qb.andWhere('(event.title ILIKE :search OR event.description ILIKE :search)', { search: `%${search}%` });
+    }
+    if (city) qb.andWhere('event.city ILIKE :city', { city: `%${city}%` });
+    if (countryCode) qb.andWhere('event.countryCode = :countryCode', { countryCode });
+    if (isVirtual !== undefined) qb.andWhere('event.isVirtual = :isVirtual', { isVirtual });
+    if (dateFrom) qb.andWhere('event.eventDate >= :dateFrom', { dateFrom });
+    if (dateTo) qb.andWhere('event.eventDate <= :dateTo', { dateTo });
+
+    qb.orderBy(`event.${sortBy}`, sortOrder.toUpperCase() as 'ASC' | 'DESC')
+      .skip((page - 1) * limit)
+      .take(limit);
+
+    const [data, total] = await qb.getManyAndCount();
+    return { data, total, page, limit, totalPages: Math.ceil(total / limit) };
+  }
+
+  async getById(id: string): Promise<Event> {
+    const event = await this.eventsRepository.findOne({
+      where: { id },
+      relations: ['ticketTypes', 'organizer'],
+    });
+    if (!event) throw new NotFoundException('Event not found');
+    return event;
+  }
+
+  async update(id: string, dto: UpdateEventDto, user: User): Promise<Event> {
+    const event = await this.eventsRepository.findOne({ where: { id } });
+    if (!event) throw new NotFoundException('Event not found');
+    if (event.organizerId !== user.id && user.role !== 'ADMIN') {
+      throw new ForbiddenException('You do not have permission to update this event');
+    }
+    Object.assign(event, dto);
+    if (dto.eventDate) event.eventDate = new Date(dto.eventDate);
+    return await this.eventsRepository.save(event);
+  }
+
+  async changeStatus(id: string, newStatus: EventStatus, user: User): Promise<Event> {
+    const event = await this.eventsRepository.findOne({ where: { id } });
+    if (!event) throw new NotFoundException('Event not found');
+    if (event.organizerId !== user.id && user.role !== 'ADMIN') {
+      throw new ForbiddenException('You do not have permission to change this event status');
+    }
+    if (!isValidTransition(event.status, newStatus)) {
+      throw new BadRequestException(`Cannot transition from ${event.status} to ${newStatus}`);
+    }
+    event.status = newStatus;
     return await this.eventsRepository.save(event);
   }
 
   async remove(id: string, user: User): Promise<void> {
     const event = await this.eventsRepository.findOne({ where: { id } });
-
-    if (!event) {
-      throw new NotFoundException('Event not found');
-    }
-
+    if (!event) throw new NotFoundException('Event not found');
     if (event.organizerId !== user.id && user.role !== 'ADMIN') {
       throw new ForbiddenException('You do not have permission to delete this event');
     }
-
     if (event.status !== EventStatus.DRAFT && event.status !== EventStatus.CANCELLED) {
       throw new BadRequestException('Only events in DRAFT or CANCELLED status can be deleted');
     }
-
     event.isArchived = true;
     await this.eventsRepository.save(event);
   }
 
   async getCapacity(id: string): Promise<{ capacity: number; totalSold: number; remaining: number; isSoldOut: boolean }> {
     const event = await this.eventsRepository.findOne({ where: { id } });
-
-    if (!event) {
-      throw new NotFoundException('Event not found');
-    }
-
-    // For now, we'll return the event capacity data
-    // In a real scenario, you would aggregate from TicketType entities
+    if (!event) throw new NotFoundException('Event not found');
     const capacity = event.capacity;
-    const totalSold = 0; // This would be calculated from ticket sales
+    const totalSold = 0;
     const remaining = capacity - totalSold;
-    const isSoldOut = remaining <= 0;
-
-    return {
-      capacity,
-      totalSold,
-      remaining,
-      isSoldOut,
-    };
+    return { capacity, totalSold, remaining, isSoldOut: remaining <= 0 };
   }
 
   async findByOrganizer(organizerId: string, pagination: PaginationDto): Promise<{ data: Event[]; total: number }> {
     const page = pagination.page || 1;
     const limit = pagination.limit || 20;
-    
     const [data, total] = await this.eventsRepository.findAndCount({
       where: { organizerId, isArchived: false },
       order: { createdAt: 'DESC' },
       skip: (page - 1) * limit,
       take: limit,
     });
-
     return { data, total };
   }
 
   async findOne(id: string): Promise<Event> {
     const event = await this.eventsRepository.findOne({ where: { id } });
-
-    if (!event) {
-      throw new NotFoundException('Event not found');
-    }
-
+    if (!event) throw new NotFoundException('Event not found');
     return event;
   }
 }


### PR DESCRIPTION
## Summary

Implements all four events module issues in a single PR.

### Changes

**Issue #567 — GET /events (filtered, paginated public listing)**
- New `EventQueryDto` extending `PaginationDto` with: `search` (ILIKE on title/description), `status`, `city`, `countryCode`, `isVirtual`, `dateFrom`, `dateTo`, `sortBy`, `sortOrder`
- `findAll(query)` in `EventsService` using QueryBuilder; defaults to `status=PUBLISHED` and `isArchived=false`
- Public `GET /events` endpoint (no auth); returns `{ data, total, page, limit, totalPages }`

**Issue #568 — GET /events/:id (event detail with ticket types)**
- `getById(id)` in `EventsService` with `relations: ['ticketTypes', 'organizer']`; throws 404 if not found
- New `EventDetailResponseDto` with nested ticket types
- Public `GET /events/:id` endpoint (no auth)

**Issue #569 — PATCH /events/:id (update event, owner or ADMIN only)**
- New `UpdateEventDto` as `PartialType(OmitType(CreateEventDto, ['status']))` — status excluded
- `update(id, dto, user)` in `EventsService`; throws 403 if not owner or ADMIN
- `PATCH /events/:id` protected by `JwtAuthGuard`

**Issue #570 — PATCH /events/:id/status (lifecycle transitions)**
- New `event-transitions.ts` defining allowed transitions:
  - `DRAFT → PUBLISHED | CANCELLED`
  - `PUBLISHED → CANCELLED | POSTPONED | COMPLETED`
  - `POSTPONED → PUBLISHED | CANCELLED`
- `changeStatus(id, newStatus, user)` validates transition (400 if invalid), enforces ownership
- `PATCH /events/:id/status` protected by `JwtAuthGuard`

**Supporting changes**
- Added `POSTPONED` to `EventStatus` enum
- Added `city`, `countryCode`, `isVirtual` columns to `Event` entity
- Added `ticketTypes` OneToMany relation to `Event` entity

## Closes

Closes #567
Closes #568
Closes #569
Closes #570