### PR TITLE
Feat/issue564

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,10 +1,14 @@
-import { Controller, Get, UseGuards } from '@nestjs/common';
+import { Controller, Get, Delete, UseGuards, Body, HttpCode, HttpStatus } from '@nestjs/common';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
 import { UserResponseDto } from './dto/user-response.dto';
+import { DeleteAccountDto } from './dto/delete-account.dto';
+import { AuthService } from './auth.service';
 
 @Controller('auth')
 export class AuthController {
+  constructor(private readonly authService: AuthService) {}
+
   @Get('me')
   @UseGuards(JwtAuthGuard)
   async getCurrentUser(@CurrentUser() user: any): Promise<UserResponseDto> {
@@ -20,5 +24,15 @@ export class AuthController {
     });
 
     return userResponse;
+  }
+
+  @Delete('account')
+  @UseGuards(JwtAuthGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async deleteAccount(
+    @CurrentUser() user: any,
+    @Body() deleteAccountDto: DeleteAccountDto,
+  ): Promise<void> {
+    await this.authService.deleteAccount(user.userId, deleteAccountDto);
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,24 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { UserResponseDto } from './dto/user-response.dto';
+
+@Controller('auth')
+export class AuthController {
+  @Get('me')
+  @UseGuards(JwtAuthGuard)
+  async getCurrentUser(@CurrentUser() user: any): Promise<UserResponseDto> {
+    // Map the user object to UserResponseDto, excluding sensitive fields
+    const userResponse = new UserResponseDto({
+      id: user.userId,
+      email: user.email,
+      fullName: user.fullName,
+      role: user.role,
+      isVerified: user.isVerified,
+      organizationName: user.organizationName,
+      createdAt: user.createdAt,
+    });
+
+    return userResponse;
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -3,6 +3,7 @@ import { PassportModule } from '@nestjs/passport';
 import { JwtModule, JwtModuleOptions } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtStrategy } from './strategies/jwt.strategy';
+import { AuthController } from './auth.controller';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { JwtStrategy } from './strategies/jwt.strategy';
     }),
   ],
   providers: [JwtStrategy],
+  controllers: [AuthController],
   exports: [JwtModule, PassportModule],
 })
 export class AuthModule {}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,11 +2,15 @@ import { Module } from '@nestjs/common';
 import { PassportModule } from '@nestjs/passport';
 import { JwtModule, JwtModuleOptions } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtStrategy } from './strategies/jwt.strategy';
 import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { User } from '../users/entities/user.entity';
 
 @Module({
   imports: [
+    TypeOrmModule.forFeature([User]),
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       imports: [ConfigModule],
@@ -19,8 +23,8 @@ import { AuthController } from './auth.controller';
       }),
     }),
   ],
-  providers: [JwtStrategy],
+  providers: [JwtStrategy, AuthService],
   controllers: [AuthController],
-  exports: [JwtModule, PassportModule],
+  exports: [JwtModule, PassportModule, AuthService],
 })
 export class AuthModule {}

--- a/src/auth/auth.service.spec.ts
+++ b/src/auth/auth.service.spec.ts
@@ -1,0 +1,380 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { AuthService, DeleteAccountInput } from './auth.service';
+import { User } from '../users/entities/user.entity';
+import { UserRole } from '../users/enums/user-role.enum';
+import * as bcrypt from 'bcrypt';
+
+jest.mock('bcrypt');
+
+describe('AuthService', () => {
+  let service: AuthService;
+  let userRepository: any;
+
+  const mockUserId = 'user-123';
+  const mockUserPassword = 'hashed_password_123';
+
+  const mockUser: Partial<User> = {
+    id: mockUserId,
+    email: 'test@example.com',
+    fullName: 'Test User',
+    password: mockUserPassword,
+    role: UserRole.SUBSCRIBER,
+    isVerified: true,
+    tokenVersion: 0,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    deletedAt: null,
+  };
+
+  beforeEach(async () => {
+    userRepository = {
+      findOne: jest.fn(),
+      update: jest.fn(),
+      create: jest.fn(),
+      save: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AuthService,
+        {
+          provide: getRepositoryToken(User),
+          useValue: userRepository,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AuthService>(AuthService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('deleteAccount', () => {
+    describe('success cases', () => {
+      it('should delete account successfully with correct password', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        expect(userRepository.findOne).toHaveBeenCalledWith({
+          where: { id: mockUserId },
+        });
+        expect(bcrypt.compare).toHaveBeenCalledWith(
+          'correct-password',
+          mockUserPassword,
+        );
+        expect(userRepository.update).toHaveBeenCalledWith(mockUserId, {
+          email: `deleted_${mockUserId}@veritix.io`,
+          fullName: 'Deleted User',
+          deletedAt: expect.any(Date),
+          tokenVersion: mockUser.tokenVersion + 1,
+        });
+      });
+
+      it('should increment tokenVersion on account deletion', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        const userWithVersion3 = { ...mockUser, tokenVersion: 3 };
+        userRepository.findOne.mockResolvedValue(userWithVersion3);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        expect(userRepository.update).toHaveBeenCalledWith(
+          mockUserId,
+          expect.objectContaining({
+            tokenVersion: 4,
+          }),
+        );
+      });
+
+      it('should anonymise PII correctly on deletion', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        const updateCall = userRepository.update.mock.calls[0];
+        expect(updateCall[1].email).toBe(`deleted_${mockUserId}@veritix.io`);
+        expect(updateCall[1].fullName).toBe('Deleted User');
+        expect(updateCall[1].deletedAt).not.toBeNull();
+      });
+    });
+
+    describe('error cases', () => {
+      it('should throw NotFoundException if user does not exist', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'any-password' };
+        userRepository.findOne.mockResolvedValue(null);
+
+        await expect(
+          service.deleteAccount(mockUserId, deleteInput),
+        ).rejects.toThrow(NotFoundException);
+        await expect(
+          service.deleteAccount(mockUserId, deleteInput),
+        ).rejects.toThrow('User not found');
+      });
+
+      it('should throw ForbiddenException when password is incorrect', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'wrong-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+        await expect(
+          service.deleteAccount(mockUserId, deleteInput),
+        ).rejects.toThrow(ForbiddenException);
+        await expect(
+          service.deleteAccount(mockUserId, deleteInput),
+        ).rejects.toThrow('Invalid password');
+      });
+
+      it('should not call update if password verification fails', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'wrong-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+        try {
+          await service.deleteAccount(mockUserId, deleteInput);
+        } catch {
+          // Expected to throw
+        }
+
+        expect(userRepository.update).not.toHaveBeenCalled();
+      });
+
+      it('should not call update if user is not found', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'any-password' };
+        userRepository.findOne.mockResolvedValue(null);
+
+        try {
+          await service.deleteAccount(mockUserId, deleteInput);
+        } catch {
+          // Expected to throw
+        }
+
+        expect(userRepository.update).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle users with very high tokenVersion', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        const userWithHighVersion = { ...mockUser, tokenVersion: 999999 };
+        userRepository.findOne.mockResolvedValue(userWithHighVersion);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        expect(userRepository.update).toHaveBeenCalledWith(
+          mockUserId,
+          expect.objectContaining({
+            tokenVersion: 1000000,
+          }),
+        );
+      });
+
+      it('should set proper deletedAt timestamp', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+        const beforeTime = new Date();
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        const afterTime = new Date();
+        const updateCall = userRepository.update.mock.calls[0];
+        const deletedAtTime = updateCall[1].deletedAt;
+
+        expect(deletedAtTime.getTime()).toBeGreaterThanOrEqual(beforeTime.getTime());
+        expect(deletedAtTime.getTime()).toBeLessThanOrEqual(afterTime.getTime());
+      });
+
+      it('should handle password comparison with special characters', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'p@ssw0rd!#$%' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        expect(bcrypt.compare).toHaveBeenCalledWith(
+          'p@ssw0rd!#$%',
+          mockUserPassword,
+        );
+      });
+
+      it('should handle bcrypt.compare throwing an error', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'any-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockRejectedValue(
+          new Error('Bcrypt error'),
+        );
+
+        await expect(
+          service.deleteAccount(mockUserId, deleteInput),
+        ).rejects.toThrow('Bcrypt error');
+      });
+
+      it('should handle repository update errors gracefully', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+        userRepository.update.mockRejectedValue(
+          new Error('Database connection failed'),
+        );
+
+        await expect(
+          service.deleteAccount(mockUserId, deleteInput),
+        ).rejects.toThrow('Database connection failed');
+      });
+
+      it('should work with already deleted users (null deletedAt becomes set)', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        const alreadyDeletedUser = { ...mockUser, deletedAt: null };
+        userRepository.findOne.mockResolvedValue(alreadyDeletedUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        expect(userRepository.update).toHaveBeenCalledWith(
+          mockUserId,
+          expect.objectContaining({
+            deletedAt: expect.any(Date),
+          }),
+        );
+      });
+    });
+
+    describe('security considerations', () => {
+      it('should use bcrypt.compare for password verification (not equality)', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        expect(bcrypt.compare).toHaveBeenCalled();
+      });
+
+      it('should not expose password in error messages', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'sensitive-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+        try {
+          await service.deleteAccount(mockUserId, deleteInput);
+        } catch (error) {
+          expect((error as Error).message).not.toContain(
+            'sensitive-password',
+          );
+        }
+      });
+
+      it('should anonymise email with user ID for traceability', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        const customUserId = 'custom-user-id-456';
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(customUserId, deleteInput);
+
+        expect(userRepository.update).toHaveBeenCalledWith(
+          customUserId,
+          expect.objectContaining({
+            email: `deleted_${customUserId}@veritix.io`,
+          }),
+        );
+      });
+    });
+
+    describe('repository interactions', () => {
+      it('should query user before updating', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        expect(userRepository.findOne).toHaveBeenCalledBefore(
+          userRepository.update as any,
+        );
+      });
+
+      it('should only call update once', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(mockUserId, deleteInput);
+
+        expect(userRepository.update).toHaveBeenCalledTimes(1);
+      });
+
+      it('should pass correct user ID to update', async () => {
+        const deleteInput: DeleteAccountInput = { password: 'correct-password' };
+        const customUserId = 'another-user-id';
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await service.deleteAccount(customUserId, deleteInput);
+
+        expect(userRepository.update).toHaveBeenCalledWith(
+          customUserId,
+          expect.any(Object),
+        );
+      });
+    });
+
+    describe('input validation', () => {
+      it('should accept valid DeleteAccountInput objects', async () => {
+        const validInput: DeleteAccountInput = { password: 'valid-password' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await expect(
+          service.deleteAccount(mockUserId, validInput),
+        ).resolves.not.toThrow();
+      });
+
+      it('should handle empty password string', async () => {
+        const emptyPasswordInput: DeleteAccountInput = { password: '' };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(false);
+
+        await expect(
+          service.deleteAccount(mockUserId, emptyPasswordInput),
+        ).rejects.toThrow(ForbiddenException);
+      });
+
+      it('should handle very long password strings', async () => {
+        const longPassword = 'a'.repeat(1000);
+        const longPasswordInput: DeleteAccountInput = { password: longPassword };
+        userRepository.findOne.mockResolvedValue(mockUser);
+        (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+        await expect(
+          service.deleteAccount(mockUserId, longPasswordInput),
+        ).resolves.not.toThrow();
+      });
+    });
+  });
+
+  describe('service initialization', () => {
+    it('should be defined', () => {
+      expect(service).toBeDefined();
+    });
+
+    it('should have deleteAccount method', () => {
+      expect(service.deleteAccount).toBeDefined();
+      expect(typeof service.deleteAccount).toBe('function');
+    });
+
+    it('should inject UserRepository', () => {
+      expect(userRepository).toBeDefined();
+    });
+  });
+});

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, BadRequestException, ForbiddenException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { User } from '../users/entities/user.entity';
+
+export interface DeleteAccountInput {
+  password: string;
+}
+
+@Injectable()
+export class AuthService {
+  constructor(
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {}
+
+  /**
+   * Delete a user account with soft delete and PII anonymisation
+   * @param userId - ID of the user to delete
+   * @param input - Contains password for confirmation
+   * @throws ForbiddenException if password is incorrect
+   * @throws NotFoundException if user doesn't exist
+   */
+  async deleteAccount(userId: string, input: DeleteAccountInput): Promise<void> {
+    // Find the user
+    const user = await this.userRepository.findOne({ where: { id: userId } });
+
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // Verify password
+    const isPasswordValid = await bcrypt.compare(input.password, user.password);
+    if (!isPasswordValid) {
+      throw new ForbiddenException('Invalid password');
+    }
+
+    // Anonymise PII and perform soft delete
+    await this.userRepository.update(userId, {
+      email: `deleted_${userId}@veritix.io`,
+      fullName: 'Deleted User',
+      deletedAt: new Date(),
+      tokenVersion: user.tokenVersion + 1,
+    });
+  }
+}

--- a/src/auth/dto/delete-account.dto.ts
+++ b/src/auth/dto/delete-account.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, MinLength } from 'class-validator';
+
+export class DeleteAccountDto {
+  @IsString()
+  @MinLength(1)
+  password: string;
+}

--- a/src/auth/dto/user-response.dto.ts
+++ b/src/auth/dto/user-response.dto.ts
@@ -1,0 +1,21 @@
+import { UserRole } from '../../users/enums/user-role.enum';
+
+export class UserResponseDto {
+  id: string;
+
+  email: string;
+
+  fullName: string;
+
+  role: UserRole;
+
+  isVerified: boolean;
+
+  organizationName?: string;
+
+  createdAt: Date;
+
+  constructor(partial: Partial<UserResponseDto>) {
+    Object.assign(this, partial);
+  }
+}

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -2,16 +2,24 @@ import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { ConfigService } from '@nestjs/config';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { User } from '../../users/entities/user.entity';
 
 export interface JwtPayload {
   sub: string;
   email: string;
   role: string;
+  tokenVersion: number;
 }
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -24,10 +32,32 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       throw new UnauthorizedException('Invalid token payload');
     }
 
+    // Fetch user from database to check if account is deleted
+    const user = await this.userRepository.findOne({
+      where: { id: payload.sub },
+    });
+
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    // Check if user account has been soft-deleted
+    if (user.deletedAt) {
+      throw new UnauthorizedException('Account has been deleted');
+    }
+
+    // Check if tokenVersion has been incremented (session invalidation)
+    if (user.tokenVersion !== payload.tokenVersion) {
+      throw new UnauthorizedException('Token has been revoked');
+    }
+
     return {
       userId: payload.sub,
-      email: payload.email,
-      role: payload.role,
+      email: user.email,
+      fullName: user.fullName,
+      role: user.role,
+      isVerified: user.isVerified,
+      createdAt: user.createdAt,
     };
   }
 }

--- a/src/events/dto/create-event.dto.ts
+++ b/src/events/dto/create-event.dto.ts
@@ -7,6 +7,8 @@ import {
   IsEnum,
   IsBoolean,
   Length,
+  IsArray,
+  ArrayUnique,
 } from 'class-validator';
 import { EventStatus } from '../enums/event-status.enum';
 
@@ -19,7 +21,7 @@ export class CreateEventDto {
   description?: string;
 
   @IsString()
-  location: string;
+  venue: string;
 
   @IsString()
   @IsOptional()
@@ -32,17 +34,31 @@ export class CreateEventDto {
 
   @IsBoolean()
   @IsOptional()
-  isVirtual?: boolean;
+  isVirtual?: boolean = false;
+
+  @IsString()
+  @IsOptional()
+  imageUrl?: string;
 
   @IsDateString()
   eventDate: string;
 
-  @IsEnum(EventStatus)
+  @IsDateString()
   @IsOptional()
-  status?: EventStatus;
+  eventClosingDate?: string;
 
   @IsNumber()
   @Min(0)
   @IsOptional()
-  capacity?: number;
+  capacity?: number = 0;
+
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayUnique()
+  @IsOptional()
+  tags?: string[];
+
+  @IsEnum(EventStatus)
+  @IsOptional()
+  status?: EventStatus = EventStatus.DRAFT;
 }

--- a/src/events/dto/event-detail-response.dto.ts
+++ b/src/events/dto/event-detail-response.dto.ts
@@ -11,15 +11,21 @@ export class TicketTypeResponseDto {
 export class EventDetailResponseDto {
   id: string;
   title: string;
-  description: string;
-  location: string;
+  description?: string;
+  venue: string;
+  city?: string;
+  countryCode?: string;
+  isVirtual: boolean;
+  imageUrl?: string;
   eventDate: Date;
-  status: EventStatus;
+  eventClosingDate?: Date;
   capacity: number;
+  tags?: string[];
   isArchived: boolean;
+  status: EventStatus;
   organizerId: string;
   organizer: { id: string; fullName: string; email: string };
-  ticketTypes: TicketTypeResponseDto[];
+  ticketTypes?: TicketTypeResponseDto[];
   createdAt: Date;
   updatedAt: Date;
 }

--- a/src/events/dto/update-event.dto.ts
+++ b/src/events/dto/update-event.dto.ts
@@ -1,4 +1,50 @@
 import { PartialType, OmitType } from '@nestjs/mapped-types';
 import { CreateEventDto } from './create-event.dto';
+import { IsDateString, IsOptional, IsString, IsNumber, IsBoolean, IsArray, Length } from 'class-validator';
 
-export class UpdateEventDto extends PartialType(OmitType(CreateEventDto, ['status'] as const)) {}
+export class UpdateEventDto extends PartialType(OmitType(CreateEventDto, ['status'] as const)) {
+  @IsString()
+  @IsOptional()
+  title?: string;
+
+  @IsString()
+  @IsOptional()
+  description?: string;
+
+  @IsString()
+  @IsOptional()
+  venue?: string;
+
+  @IsString()
+  @IsOptional()
+  city?: string;
+
+  @IsString()
+  @IsOptional()
+  @Length(2, 2)
+  countryCode?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  isVirtual?: boolean;
+
+  @IsString()
+  @IsOptional()
+  imageUrl?: string;
+
+  @IsDateString()
+  @IsOptional()
+  eventDate?: string;
+
+  @IsDateString()
+  @IsOptional()
+  eventClosingDate?: string;
+
+  @IsNumber()
+  @IsOptional()
+  capacity?: number;
+
+  @IsArray()
+  @IsOptional()
+  tags?: string[];
+}

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -1,5 +1,3 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
-import { TicketType } from '../../ticket-types/entities/ticket-type.entity';
 import {
   Entity,
   PrimaryGeneratedColumn,
@@ -11,6 +9,7 @@ import {
   JoinColumn,
 } from 'typeorm';
 import { User } from '../../users/entities/user.entity';
+import { TicketType } from '../../ticket-types/entities/ticket-type.entity';
 import { EventStatus } from '../enums/event-status.enum';
 
 @Entity('events')
@@ -24,28 +23,22 @@ export class Event {
   @Column('text', { nullable: true })
   description: string;
 
+  @Column({
+    type: 'enum',
+    enum: EventStatus,
+    default: EventStatus.DRAFT,
+  })
+  status: EventStatus;
+
+  @Column({ type: 'uuid' })
+  organizerId: string;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'organizerId' })
+  organizer: User;
+
   @Column()
   venue: string;
-
-  @Column()
-  address: string;
-
-  @Column('timestamp')
-  eventDate: Date;
-
-  @Column({ default: true })
-  isActive: boolean;
-
-  @Column('decimal', { precision: 10, scale: 2, nullable: true })
-  maxCapacity: number;
-
-  @OneToMany(() => TicketType, ticketType => ticketType.event)
-  ticketTypes: TicketType[];
-  @Column({ type: 'text', nullable: true })
-  description: string;
-
-  @Column()
-  location: string;
 
   @Column({ nullable: true })
   city: string;
@@ -56,31 +49,26 @@ export class Event {
   @Column({ default: false })
   isVirtual: boolean;
 
+  @Column({ nullable: true })
+  imageUrl: string;
+
   @Column({ type: 'timestamptz' })
   eventDate: Date;
 
-  @Column({
-    type: 'enum',
-    enum: EventStatus,
-    default: EventStatus.DRAFT,
-  })
-  status: EventStatus;
+  @Column({ type: 'timestamptz', nullable: true })
+  eventClosingDate: Date;
 
   @Column({ type: 'int', default: 0 })
   capacity: number;
 
+  @Column('text', { array: true, nullable: true, default: () => "'{}'" })
+  tags: string[];
+
   @Column({ default: false })
   isArchived: boolean;
 
-  @Column({ type: 'uuid' })
-  organizerId: string;
-
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'organizerId' })
-  organizer: User;
-
-  @OneToMany('TicketType', 'event')
-  ticketTypes: any[];
+  @OneToMany(() => TicketType, (ticketType) => ticketType.event)
+  ticketTypes: TicketType[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/events/events.service.ts
+++ b/src/events/events.service.ts
@@ -24,8 +24,17 @@ export class EventsService {
 
   async createEvent(dto: CreateEventDto, user: User): Promise<Event> {
     const event = this.eventsRepository.create({
-      ...dto,
+      title: dto.title,
+      description: dto.description,
+      venue: dto.venue,
+      city: dto.city,
+      countryCode: dto.countryCode,
+      isVirtual: dto.isVirtual ?? false,
+      imageUrl: dto.imageUrl,
       eventDate: new Date(dto.eventDate),
+      eventClosingDate: dto.eventClosingDate ? new Date(dto.eventClosingDate) : null,
+      capacity: dto.capacity ?? 0,
+      tags: dto.tags ?? [],
       organizerId: user.id,
       status: dto.status || EventStatus.DRAFT,
     });
@@ -71,8 +80,17 @@ export class EventsService {
     if (event.organizerId !== user.id && user.role !== 'ADMIN') {
       throw new ForbiddenException('You do not have permission to update this event');
     }
-    Object.assign(event, dto);
-    if (dto.eventDate) event.eventDate = new Date(dto.eventDate);
+    
+    // Explicitly handle date fields to convert to Date objects
+    const updateData = { ...dto };
+    if (dto.eventDate) {
+      updateData.eventDate = new Date(dto.eventDate) as any;
+    }
+    if (dto.eventClosingDate) {
+      updateData.eventClosingDate = new Date(dto.eventClosingDate) as any;
+    }
+    
+    Object.assign(event, updateData);
     return await this.eventsRepository.save(event);
   }
 

--- a/src/migrations/1776904642000-UpdateEventEntityWithAllFields.ts
+++ b/src/migrations/1776904642000-UpdateEventEntityWithAllFields.ts
@@ -1,0 +1,47 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class UpdateEventEntityWithAllFields1776904642000 implements MigrationInterface {
+    name = 'UpdateEventEntityWithAllFields1776904642000'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Create EventStatus enum
+        await queryRunner.query(`CREATE TYPE "public"."events_status_enum" AS ENUM('DRAFT', 'PUBLISHED', 'CANCELLED', 'POSTPONED', 'COMPLETED')`);
+        
+        // Create events table with all required fields
+        await queryRunner.query(`CREATE TABLE "events" (
+            "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+            "title" character varying NOT NULL,
+            "description" text,
+            "status" "public"."events_status_enum" NOT NULL DEFAULT 'DRAFT',
+            "organizerId" uuid NOT NULL,
+            "venue" character varying NOT NULL,
+            "city" character varying,
+            "countryCode" character varying(2),
+            "isVirtual" boolean NOT NULL DEFAULT false,
+            "imageUrl" character varying,
+            "eventDate" TIMESTAMP WITH TIME ZONE NOT NULL,
+            "eventClosingDate" TIMESTAMP WITH TIME ZONE,
+            "capacity" integer NOT NULL DEFAULT 0,
+            "tags" text array DEFAULT '{}',
+            "isArchived" boolean NOT NULL DEFAULT false,
+            "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+            "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+            CONSTRAINT "PK_40f9b6c2b2d7abed91b00c3c4de" PRIMARY KEY ("id"),
+            CONSTRAINT "FK_events_users" FOREIGN KEY ("organizerId") REFERENCES "users"("id") ON DELETE CASCADE
+        )`, undefined);
+        
+        // Create index on organizerId for faster lookups
+        await queryRunner.query(`CREATE INDEX "IDX_events_organizerId" ON "events" ("organizerId")`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // Drop index
+        await queryRunner.query(`DROP INDEX "public"."IDX_events_organizerId"`);
+        
+        // Drop table
+        await queryRunner.query(`DROP TABLE "events"`);
+        
+        // Drop enum
+        await queryRunner.query(`DROP TYPE "public"."events_status_enum"`);
+    }
+}

--- a/src/migrations/1776904642001-AddTokenVersionToUsers.ts
+++ b/src/migrations/1776904642001-AddTokenVersionToUsers.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddTokenVersionToUsers1776904642001 implements MigrationInterface {
+    name = 'AddTokenVersionToUsers1776904642001'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // Add tokenVersion column to users table if it doesn't exist
+        const hasColumn = await queryRunner.hasColumn("users", "tokenVersion");
+        if (!hasColumn) {
+            await queryRunner.query(`ALTER TABLE "users" ADD "tokenVersion" integer NOT NULL DEFAULT 0`);
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "users" DROP COLUMN "tokenVersion"`);
+    }
+}

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -32,6 +32,9 @@ export class User {
   @Column({ default: false })
   isVerified: boolean;
 
+  @Column({ default: 0 })
+  tokenVersion: number;
+
   @CreateDateColumn()
   createdAt: Date;
 


### PR DESCRIPTION
- Closes #564
feat(events): create Event entity with lifecycle status enum and all required fields 
- Create Event entity with complete field structure: UUID primary key, EventStatus enum, 
Organizer FK, venue/city/countryCode, virtual event support, event dates, 
capacity/tags, isArchived flag, OneToMany to TicketType - Update Event DTOs to match entity: CreateEventDto/UpdateEventDto fields, EventDetailResponseDto mapping - Enhance

- Closes #565