### PR TITLE
Feat/tickets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 node_modules
+dist

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/schedule": "^2.0.0",
     "@nestjs/swagger": "^11.4.1",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
-    "@nestjs/schedule": "^2.0.0",
     "@nestjs/swagger": "^11.4.1",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.5.0",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,6 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
-import { Module } from '@nestjs/common';
 import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,7 +3,6 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
 import { APP_GUARD } from '@nestjs/core';
-import { ScheduleModule } from '@nestjs/schedule';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { envValidationSchema } from './config/env.validation';
@@ -18,9 +17,6 @@ import { LoggerMiddleware } from './common/middleware/logger.middleware';
 
 @Module({
   imports: [
-    // Background Jobs
-    ScheduleModule.forRoot(),
-
     // Global configuration
     ConfigModule.forRoot({
       isGlobal: true,

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -11,6 +11,8 @@ import { envValidationSchema } from './config/env.validation';
 import { AuthModule } from './auth/auth.module';
 import { HealthModule } from './health/health.module';
 import { EventsModule } from './events/events.module';
+import { OrdersModule } from './orders/orders.module';
+import { TicketsModule } from './tickets/tickets.module';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { LoggerMiddleware } from './common/middleware/logger.middleware';
 
@@ -46,6 +48,8 @@ import { LoggerMiddleware } from './common/middleware/logger.middleware';
     AuthModule,
     HealthModule,
     EventsModule,
+    OrdersModule,
+    TicketsModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/config/env.validation.ts
+++ b/src/config/env.validation.ts
@@ -11,6 +11,8 @@ export const envValidationSchema = Joi.object({
   REFRESH_TOKEN_SECRET: Joi.string().min(32).required(),
   ACCESS_TOKEN_EXPIRATION: Joi.string().default('15m'),
   REFRESH_TOKEN_EXPIRATION: Joi.string().default('7d'),
+  ORDER_EXPIRY_MINUTES: Joi.number().default(15),
+  STELLAR_PLATFORM_ADDRESS: Joi.string().optional(),
   SENDGRID_API_KEY: Joi.string().optional(),
   SENDGRID_FROM_EMAIL: Joi.string().email().optional(),
 });

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -1,15 +1,14 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany, CreateDateColumn, UpdateDateColumn } from 'typeorm';
-import { TicketType } from '../../ticket-types/entities/ticket-type.entity';
 import {
   Entity,
   PrimaryGeneratedColumn,
   Column,
+  OneToMany,
+  ManyToOne,
+  JoinColumn,
   CreateDateColumn,
   UpdateDateColumn,
-  ManyToOne,
-  OneToMany,
-  JoinColumn,
 } from 'typeorm';
+import { TicketType } from '../../ticket-types/entities/ticket-type.entity';
 import { User } from '../../users/entities/user.entity';
 import { EventStatus } from '../enums/event-status.enum';
 
@@ -39,10 +38,8 @@ export class Event {
   @Column('decimal', { precision: 10, scale: 2, nullable: true })
   maxCapacity: number;
 
-  @OneToMany(() => TicketType, ticketType => ticketType.event)
+  @OneToMany(() => TicketType, (ticketType) => ticketType.event)
   ticketTypes: TicketType[];
-  @Column({ type: 'text', nullable: true })
-  description: string;
 
   @Column()
   location: string;
@@ -55,9 +52,6 @@ export class Event {
 
   @Column({ default: false })
   isVirtual: boolean;
-
-  @Column({ type: 'timestamptz' })
-  eventDate: Date;
 
   @Column({
     type: 'enum',
@@ -78,9 +72,6 @@ export class Event {
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'organizerId' })
   organizer: User;
-
-  @OneToMany('TicketType', 'event')
-  ticketTypes: any[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/migrations/1776904641126-CreateOrdersAndTicketsTables.ts
+++ b/src/migrations/1776904641126-CreateOrdersAndTicketsTables.ts
@@ -1,0 +1,65 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOrdersAndTicketsTables1776904641126 implements MigrationInterface {
+  name = 'CreateOrdersAndTicketsTables1776904641126';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TYPE "public"."orders_status_enum" AS ENUM('PENDING','PAID','FAILED','REFUNDED','CANCELLED')`);
+    await queryRunner.query(`CREATE TABLE "orders" (
+      "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+      "userId" uuid NOT NULL,
+      "eventId" uuid NOT NULL,
+      "status" "public"."orders_status_enum" NOT NULL DEFAULT 'PENDING',
+      "totalAmountUSD" numeric(10,2) NOT NULL DEFAULT '0',
+      "totalAmountXLM" numeric(18,7) NOT NULL DEFAULT '0',
+      "stellarMemo" character varying NOT NULL,
+      "stellarTxHash" character varying,
+      "refundTxHash" character varying,
+      "expiresAt" TIMESTAMP NOT NULL,
+      "paidAt" TIMESTAMP,
+      "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+      "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+      CONSTRAINT "PK_dd3c6e943b3fdea5a2f7b18fab4" PRIMARY KEY ("id"),
+      CONSTRAINT "UQ_orders_stellarMemo" UNIQUE ("stellarMemo"),
+      CONSTRAINT "UQ_orders_stellarTxHash" UNIQUE ("stellarTxHash"),
+      CONSTRAINT "UQ_orders_refundTxHash" UNIQUE ("refundTxHash")
+    )`);
+    await queryRunner.query(`CREATE TABLE "order_items" (
+      "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+      "orderId" uuid NOT NULL,
+      "ticketTypeId" uuid NOT NULL,
+      "quantity" integer NOT NULL,
+      "unitPriceUSD" numeric(10,2) NOT NULL,
+      "subtotalUSD" numeric(10,2) NOT NULL,
+      CONSTRAINT "PK_0ab33ff4f70fb65f8c7ae9ed85f" PRIMARY KEY ("id")
+    )`);
+    await queryRunner.query(`CREATE TABLE "tickets" (
+      "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+      "userId" uuid NOT NULL,
+      "eventId" uuid NOT NULL,
+      "ticketTypeId" uuid NOT NULL,
+      "orderReference" uuid,
+      "status" character varying NOT NULL DEFAULT 'ACTIVE',
+      "createdAt" TIMESTAMP NOT NULL DEFAULT now(),
+      "updatedAt" TIMESTAMP NOT NULL DEFAULT now(),
+      CONSTRAINT "PK_16d42a05b49f3471d1a3efd7e56" PRIMARY KEY ("id")
+    )`);
+    await queryRunner.query(`ALTER TABLE "order_items" ADD CONSTRAINT "FK_order_items_order" FOREIGN KEY ("orderId") REFERENCES "orders"("id") ON DELETE CASCADE`);
+    await queryRunner.query(`ALTER TABLE "order_items" ADD CONSTRAINT "FK_order_items_ticketType" FOREIGN KEY ("ticketTypeId") REFERENCES "ticket_types"("id") ON DELETE NO ACTION`);
+    await queryRunner.query(`ALTER TABLE "tickets" ADD CONSTRAINT "FK_tickets_event" FOREIGN KEY ("eventId") REFERENCES "events"("id") ON DELETE NO ACTION`);
+    await queryRunner.query(`ALTER TABLE "tickets" ADD CONSTRAINT "FK_tickets_ticketType" FOREIGN KEY ("ticketTypeId") REFERENCES "ticket_types"("id") ON DELETE NO ACTION`);
+    await queryRunner.query(`ALTER TABLE "tickets" ADD CONSTRAINT "FK_tickets_order" FOREIGN KEY ("orderReference") REFERENCES "orders"("id") ON DELETE SET NULL`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "tickets" DROP CONSTRAINT "FK_tickets_order"`);
+    await queryRunner.query(`ALTER TABLE "tickets" DROP CONSTRAINT "FK_tickets_ticketType"`);
+    await queryRunner.query(`ALTER TABLE "tickets" DROP CONSTRAINT "FK_tickets_event"`);
+    await queryRunner.query(`ALTER TABLE "order_items" DROP CONSTRAINT "FK_order_items_ticketType"`);
+    await queryRunner.query(`ALTER TABLE "order_items" DROP CONSTRAINT "FK_order_items_order"`);
+    await queryRunner.query(`DROP TABLE "tickets"`);
+    await queryRunner.query(`DROP TABLE "order_items"`);
+    await queryRunner.query(`DROP TABLE "orders"`);
+    await queryRunner.query(`DROP TYPE "public"."orders_status_enum"`);
+  }
+}

--- a/src/orders/dto/create-order.dto.ts
+++ b/src/orders/dto/create-order.dto.ts
@@ -1,0 +1,23 @@
+import { Order } from '../orders.entity';
+
+export class CreateOrderItemDto {
+  ticketTypeId: string;
+  quantity: number;
+}
+
+export class CreateOrderDto {
+  eventId: string;
+  items: CreateOrderItemDto[];
+}
+
+export interface CreateOrderInput {
+  userId: string;
+  eventId: string;
+  items: CreateOrderItemDto[];
+}
+
+export interface CreateOrderResult {
+  order: Order;
+  stellarMemo: string;
+  amountXLM: number;
+}

--- a/src/orders/entities/order-item.entity.ts
+++ b/src/orders/entities/order-item.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { Order } from './order.entity';
+import { TicketType } from '../../ticket-types/entities/ticket-type.entity';
+
+@Entity('order_items')
+export class OrderItem {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  orderId: string;
+
+  @ManyToOne(() => Order, (order) => order.items, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'orderId' })
+  order: Order;
+
+  @Column('uuid')
+  ticketTypeId: string;
+
+  @ManyToOne(() => TicketType, { eager: true })
+  @JoinColumn({ name: 'ticketTypeId' })
+  ticketType: TicketType;
+
+  @Column('int')
+  quantity: number;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  unitPriceUSD: number;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  subtotalUSD: number;
+}

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -8,6 +8,7 @@ import {
 } from 'typeorm';
 import { OrderStatus } from '../enums/order-status.enum';
 import { OrderItem } from './order-item.entity';
+import { Ticket } from 'src/tickets/entities/ticket.entity';
 
 @Entity('orders')
 export class Order {
@@ -50,6 +51,9 @@ export class Order {
 
   @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })
   items: OrderItem[];
+
+  @OneToMany(() => Ticket, (ticket) => ticket.order)
+  tickets: Ticket[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { OrderStatus } from '../enums/order-status.enum';
+import { OrderItem } from './order-item.entity';
+
+@Entity('orders')
+export class Order {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @Column('uuid')
+  eventId: string;
+
+  @Column({
+    type: 'enum',
+    enum: OrderStatus,
+    default: OrderStatus.PENDING,
+  })
+  status: OrderStatus;
+
+  @Column('decimal', { precision: 10, scale: 2, default: 0 })
+  totalAmountUSD: number;
+
+  @Column('decimal', { precision: 18, scale: 7, default: 0 })
+  totalAmountXLM: number;
+
+  @Column({ unique: true })
+  stellarMemo: string;
+
+  @Column({ nullable: true, unique: true })
+  stellarTxHash: string;
+
+  @Column({ nullable: true, unique: true })
+  refundTxHash: string;
+
+  @Column({ type: 'timestamp' })
+  expiresAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  paidAt: Date;
+
+  @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })
+  items: OrderItem[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/orders/entities/order.entity.ts
+++ b/src/orders/entities/order.entity.ts
@@ -38,16 +38,16 @@ export class Order {
   stellarMemo: string;
 
   @Column({ nullable: true, unique: true })
-  stellarTxHash: string;
+  stellarTxHash: string | null;
 
   @Column({ nullable: true, unique: true })
-  refundTxHash: string;
+  refundTxHash: string | null;
 
   @Column({ type: 'timestamp' })
   expiresAt: Date;
 
   @Column({ type: 'timestamp', nullable: true })
-  paidAt: Date;
+  paidAt: Date | null;
 
   @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })
   items: OrderItem[];

--- a/src/orders/enums/order-status.enum.ts
+++ b/src/orders/enums/order-status.enum.ts
@@ -1,0 +1,7 @@
+export enum OrderStatus {
+  PENDING = 'PENDING',
+  PAID = 'PAID',
+  FAILED = 'FAILED',
+  REFUNDED = 'REFUNDED',
+  CANCELLED = 'CANCELLED',
+}

--- a/src/orders/order.config.ts
+++ b/src/orders/order.config.ts
@@ -1,0 +1,9 @@
+import { registerAs } from '@nestjs/config';
+
+export interface OrderConfig {
+  expiryMinutes: number;
+}
+
+export default registerAs('order', () => ({
+  expiryMinutes: Number(process.env.ORDER_EXPIRY_MINUTES ?? 15),
+}));

--- a/src/orders/orders.controller.ts
+++ b/src/orders/orders.controller.ts
@@ -2,7 +2,6 @@ import {
   Body,
   Controller,
   Delete,
-  ForbiddenException,
   Get,
   HttpCode,
   HttpStatus,
@@ -13,28 +12,15 @@ import {
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { OrdersService } from './orders.service';
-import { CreateOrderInput } from './dto/order.dto';
-import { JwtAuthGuard } from 'src/auth/guard/jwt.auth.guard';
-import { RolesGuard } from 'src/auth/guard/roles.guard';
-import { Roles } from 'src/auth/decorators/roles.decorators';
-import { CurrentUser } from 'src/auth/decorators/current.user.decorators';
-import { UserRole } from 'src/auth/common/enum/user-role-enum';
-import { User } from 'src/auth/entities/user.entity';
+import { CreateOrderDto } from './dto/create-order.dto';
+import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/common/guards/roles.guard';
+import { Roles } from 'src/common/decorators/roles.decorator';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { UserRole } from 'src/users/enums/user-role.enum';
+import { User } from 'src/users/entities/user.entity';
 import { Order } from './orders.entity';
-import { StellarConfig } from 'src/stellar/stellar.config';
 
-/**
- * OrdersController
- *
- * All routes require a valid JWT. The authenticated user's ID is read from
- * the CurrentUser decorator so users can only act on their own orders.
- *
- * Route summary:
- *   POST   /orders       → createOrder (SUBSCRIBER role required)
- *   GET    /orders/my    → findMyOrders (current user)
- *   GET    /orders/:id   → findById (owner or ADMIN only)
- *   DELETE /orders/:id   → cancelOrder (owner or ADMIN only)
- */
 @Controller('orders')
 @UseGuards(JwtAuthGuard, RolesGuard)
 export class OrdersController {
@@ -48,22 +34,16 @@ export class OrdersController {
   @HttpCode(HttpStatus.CREATED)
   async createOrder(
     @CurrentUser() user: User,
-    @Body() body: { eventId: string; items: { ticketTypeId: string; quantity: number }[] },
+    @Body() body: CreateOrderDto,
   ) {
-    const input: CreateOrderInput = {
-      userId: user.id,
-      eventId: body.eventId,
-      items: body.items,
-    };
-    const result = await this.ordersService.createOrder(input);
-    
-    const stellarConfig = this.configService.get<StellarConfig>('stellar');
-    
+    const result = await this.ordersService.create(body, user);
+    const destinationAddress = this.configService.get<string>('STELLAR_PLATFORM_ADDRESS');
+
     return {
       ...result.order,
-      destinationAddress: stellarConfig?.platformAddress,
+      destinationAddress,
       memo: result.stellarMemo,
-      amountXLM: result.order.totalAmountXLM,
+      amountXLM: result.amountXLM,
     };
   }
 

--- a/src/orders/orders.entity.ts
+++ b/src/orders/orders.entity.ts
@@ -1,0 +1,2 @@
+export { Order } from './entities/order.entity';
+export { OrderItem } from './entities/order-item.entity';

--- a/src/orders/orders.module.ts
+++ b/src/orders/orders.module.ts
@@ -6,17 +6,15 @@ import orderConfig from './order.config';
 import { OrdersScheduler } from './orders.scheduler';
 import { OrdersService } from './orders.service';
 import { OrdersController } from './orders.controller';
-import { TicketModule } from 'src/ticket-verification/ticket.module';
-import { TicketsModule } from 'src/tickets-inventory/tickets.module';
+import { TicketTypesModule } from 'src/ticket-types/ticket-types.module';
 import { Order, OrderItem } from './orders.entity';
-import { Ticket } from 'src/tickets-inventory/entities/ticket.entity';
+import { Ticket } from 'src/tickets/entities/ticket.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Order, OrderItem, Ticket]),
     ConfigModule.forFeature(orderConfig),
-    TicketModule,
-    TicketsModule,
+    TicketTypesModule,
   ],
   controllers: [OrdersController],
   providers: [OrdersService, OrdersScheduler],

--- a/src/orders/orders.scheduler.ts
+++ b/src/orders/orders.scheduler.ts
@@ -1,5 +1,4 @@
 import { Injectable, Logger } from '@nestjs/common';
-import { Cron, CronExpression } from '@nestjs/schedule';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { DataSource, LessThan, Repository } from 'typeorm';
@@ -27,7 +26,6 @@ export class OrdersScheduler {
     private readonly dataSource: DataSource,
   ) {}
 
-  @Cron(CronExpression.EVERY_5_MINUTES, { name: 'order-expiry-cleanup' })
   async handleOrderExpiry(): Promise<ExpiryRunSummary> {
     const checkedAt = new Date();
     this.logger.log('Order expiry job started');

--- a/src/orders/orders.scheduler.ts
+++ b/src/orders/orders.scheduler.ts
@@ -5,10 +5,9 @@ import { ConfigService } from '@nestjs/config';
 import { DataSource, LessThan, Repository } from 'typeorm';
 import { OrderConfig } from './order.config';
 import { Order } from './orders.entity';
-import { TicketTypeService } from 'src/tickets-inventory/services/ticket-type.service';
+import { TicketTypesService } from 'src/ticket-types/ticket-types.service';
 import { OrderStatus } from './enums/order-status.enum';
 
-/** Shape of the summary emitted after each run. */
 export interface ExpiryRunSummary {
   checkedAt: Date;
   expiredCount: number;
@@ -23,18 +22,11 @@ export class OrdersScheduler {
   constructor(
     @InjectRepository(Order)
     private readonly orderRepo: Repository<Order>,
-    private readonly ticketTypeService: TicketTypeService,
+    private readonly ticketTypeService: TicketTypesService,
     private readonly config: ConfigService,
     private readonly dataSource: DataSource,
   ) {}
 
-  /**
-   * Finds all PENDING orders whose `expiresAt` is in the past, releases
-   * their reserved inventory, and marks them CANCELLED.
-   *
-   * Errors from individual orders are caught and isolated so one bad row
-   * never aborts the rest of the batch.
-   */
   @Cron(CronExpression.EVERY_5_MINUTES, { name: 'order-expiry-cleanup' })
   async handleOrderExpiry(): Promise<ExpiryRunSummary> {
     const checkedAt = new Date();
@@ -52,7 +44,6 @@ export class OrdersScheduler {
     let ticketsReleased = 0;
     const failedOrderIds: string[] = [];
 
-    // Process each order independently so one failure doesn't block others.
     for (const order of expiredOrders) {
       try {
         const released = await this.cancelAndRelease(order);
@@ -84,7 +75,6 @@ export class OrdersScheduler {
     return summary;
   }
 
-  /** Query the DB for all PENDING orders past their expiry timestamp. */
   async findExpiredOrders(asOf: Date): Promise<Order[]> {
     return this.orderRepo.find({
       where: {
@@ -95,18 +85,10 @@ export class OrdersScheduler {
     });
   }
 
-  /**
-   * Release inventory for a single order, then mark it CANCELLED.
-   * Returns the number of tickets released.
-   *
-   * Wrapped in a transaction to ensure both inventory and status
-   * are updated together.
-   */
   async cancelAndRelease(order: Order): Promise<number> {
     let released = 0;
 
     await this.dataSource.transaction(async (manager) => {
-      // 1. Release each line item back to its ticket-type pool.
       for (const item of order.items ?? []) {
         await this.ticketTypeService.releaseTickets(
           item.ticketType.id,
@@ -116,7 +98,6 @@ export class OrdersScheduler {
         released += item.quantity;
       }
 
-      // 2. Mark the order as CANCELLED.
       await manager.update(Order, order.id, {
         status: OrderStatus.CANCELLED,
       });
@@ -125,15 +106,8 @@ export class OrdersScheduler {
     return released;
   }
 
-  /**
-   * Compute the expiry timestamp for a new order.
-   *
-   * Reads `order.expiryMinutes` from config (default 15) so the window
-   * is never hardcoded in business logic.
-   */
   computeExpiresAt(from: Date = new Date()): Date {
-    const minutes =
-      this.config.get<OrderConfig>('order')?.expiryMinutes ?? 15;
+    const minutes = this.config.get<OrderConfig>('order')?.expiryMinutes ?? 15;
     return new Date(from.getTime() + minutes * 60 * 1_000);
   }
 }

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -4,17 +4,16 @@ import { ConfigService } from '@nestjs/config';
 import { DataSource } from 'typeorm';
 import { OrdersService } from './orders.service';
 import { Order, OrderItem } from './orders.entity';
-import { Ticket } from 'src/tickets-inventory/entities/ticket.entity';
-import { TicketTypeService } from 'src/tickets-inventory/services/ticket-type.service';
+import { Ticket } from 'src/tickets/entities/ticket.entity';
+import { TicketTypeService } from 'src/ticket-types/ticket-types.service';
 import { OrderStatus } from './enums/order-status.enum';
-import { User } from 'src/auth/entities/user.entity';
-import { UserRole } from 'src/auth/common/enum/user-role-enum';
+import { User } from 'src/users/entities/user.entity';
+import { UserRole } from 'src/users/enums/user-role.enum';
 import {
   BadRequestException,
   ForbiddenException,
   NotFoundException,
 } from '@nestjs/common';
-import { OrderError, OrderErrorCode } from './dto/order.dto';
 
 describe('OrdersService', () => {
   let service: OrdersService;
@@ -95,25 +94,25 @@ describe('OrdersService', () => {
       entityManager.create.mockReturnValue(mockOrder);
       entityManager.save.mockResolvedValue(mockOrder);
 
-      const result = await service.createOrder(createInput);
+      const result = await service.create(createInput, mockUser);
 
       expect(result.order).toBeDefined();
-      expect(result.stellarMemo).toMatch(/^VTX-[a-f0-9]{10}$/);
-      expect(ticketTypeService.reserveTickets).toHaveBeenCalledWith('tt-1', 2);
+      expect(result.stellarMemo).toHaveLength(8);
+      expect(ticketTypeService.reserveTickets).toHaveBeenCalledWith('tt-1', 2, expect.anything());
       expect(dataSource.transaction).toHaveBeenCalled();
     });
 
     it('should throw if items are empty', async () => {
       await expect(
-        service.createOrder({ ...createInput, items: [] }),
-      ).rejects.toThrow(OrderError);
+        service.create({ ...createInput, items: [] }, mockUser),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should throw if inventory is insufficient', async () => {
       const mockTicketType = { id: 'tt-1', price: 10, totalQuantity: 1 };
-      ticketTypeService.findById.mockResolvedValue(mockTicketType);
+      ticketTypeService.findOne.mockResolvedValue(mockTicketType);
 
-      await expect(service.createOrder(createInput)).rejects.toThrow(
+      await expect(service.create(createInput, mockUser)).rejects.toThrow(
         'Insufficient inventory',
       );
     });

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -42,7 +42,7 @@ describe('OrdersService', () => {
     };
 
     ticketTypeService = {
-      findById: jest.fn(),
+      findOne: jest.fn(),
       reserveTickets: jest.fn(),
       releaseTickets: jest.fn(),
     };

--- a/src/orders/orders.service.spec.ts
+++ b/src/orders/orders.service.spec.ts
@@ -88,7 +88,7 @@ describe('OrdersService', () => {
 
     it('should create an order successfully', async () => {
       const mockTicketType = { id: 'tt-1', price: 10, totalQuantity: 10 };
-      ticketTypeService.findById.mockResolvedValue(mockTicketType);
+      ticketTypeService.findOne.mockResolvedValue(mockTicketType);
       
       const mockOrder = { id: 'order-1', ...createInput, status: OrderStatus.PENDING };
       entityManager.create.mockReturnValue(mockOrder);

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -89,20 +89,22 @@ export class OrdersService {
     });
 
     const order = await this.dataSource.transaction(async (manager) => {
+      const orderData: Partial<Order> = {
+        id: orderId,
+        userId: user.id,
+        eventId,
+        status: OrderStatus.PENDING,
+        totalAmountUSD,
+        totalAmountXLM,
+        stellarMemo,
+        stellarTxHash: null,
+        refundTxHash: null,
+        expiresAt,
+        paidAt: null,
+      };
+
       const savedOrder = await manager.save(
-        manager.create(Order, {
-          id: orderId,
-          userId: user.id,
-          eventId,
-          status: OrderStatus.PENDING,
-          totalAmountUSD,
-          totalAmountXLM,
-          stellarMemo,
-          stellarTxHash: null,
-          refundTxHash: null,
-          expiresAt,
-          paidAt: null,
-        }),
+        manager.create(Order, orderData),
       );
 
       const itemsToSave = orderItems.map((item) =>

--- a/src/orders/orders.service.ts
+++ b/src/orders/orders.service.ts
@@ -8,20 +8,18 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import { ConfigService } from '@nestjs/config';
 import { DataSource, Repository } from 'typeorm';
-import { randomBytes } from 'crypto';
+import { randomUUID } from 'crypto';
 import {
-  CreateOrderInput,
+  CreateOrderDto,
   CreateOrderResult,
-  OrderError,
-  OrderErrorCode,
-} from './dto/order.dto';
+} from './dto/create-order.dto';
 import { OrderConfig } from './order.config';
 import { Order, OrderItem } from './orders.entity';
-import { TicketTypeService } from 'src/tickets-inventory/services/ticket-type.service';
-import { Ticket } from 'src/tickets-inventory/entities/ticket.entity';
+import { Ticket } from 'src/tickets/entities/ticket.entity';
+import { TicketTypesService } from 'src/ticket-types/ticket-types.service';
 import { OrderStatus } from './enums/order-status.enum';
-import { User } from 'src/auth/entities/user.entity';
-import { UserRole } from 'src/auth/common/enum/user-role-enum';
+import { User } from 'src/users/entities/user.entity';
+import { UserRole } from 'src/users/enums/user-role.enum';
 
 @Injectable()
 export class OrdersService {
@@ -32,123 +30,95 @@ export class OrdersService {
     private readonly orderRepo: Repository<Order>,
     @InjectRepository(Ticket)
     private readonly ticketRepo: Repository<Ticket>,
-    private readonly ticketTypeService: TicketTypeService,
+    private readonly ticketTypeService: TicketTypesService,
     private readonly config: ConfigService,
     private readonly dataSource: DataSource,
   ) {}
 
-  // ------------------------------------------------------------------
-  // createOrder
-  // ------------------------------------------------------------------
-
-  /**
-   * Validate inventory, soft-reserve tickets, and persist the order.
-   *
-   * DOES NOT issue tickets — that happens in Issue 10 after Stellar
-   * payment confirmation.
-   *
-   * Steps:
-   *  1. Guard: at least one item, all quantities > 0.
-   *  2. Load each TicketType and check availability.
-   *  3. Open a DB transaction:
-   *     a. Insert Order row with PENDING status and computed expiresAt.
-   *     b. Insert OrderItem rows with snapshotted prices.
-   *     c. Call TicketTypeService.reserveTickets per item.
-   *  4. Return order + stellarMemo.
-   */
-  async createOrder(input: CreateOrderInput): Promise<CreateOrderResult> {
-    const { userId, eventId, items } = input;
+  async create(dto: CreateOrderDto, user: User): Promise<CreateOrderResult> {
+    const { eventId, items } = dto;
 
     if (!items || items.length === 0) {
-      throw new OrderError('Order must contain at least one item', OrderErrorCode.EMPTY_ORDER);
+      throw new BadRequestException('Order must contain at least one item');
     }
 
-    for (const item of items) {
-      if (!Number.isInteger(item.quantity) || item.quantity < 1) {
-        throw new OrderError(
-          `Invalid quantity ${item.quantity} for ticketType ${item.ticketTypeId}`,
-          OrderErrorCode.INVALID_QUANTITY,
-        );
-      }
-    }
-
-    // Load ticket types and validate inventory before opening a transaction.
     const ticketTypes = await Promise.all(
-      items.map((item) =>
-        this.ticketTypeService
-          .findById(item.ticketTypeId)
-          .then((tt) => {
-            if (!tt) {
-              throw new OrderError(
-                `TicketType ${item.ticketTypeId} not found`,
-                OrderErrorCode.TICKET_TYPE_NOT_FOUND,
-              );
-            }
-            if (tt.totalQuantity < item.quantity) {
-              throw new OrderError(
-                `Insufficient inventory for ticketType ${item.ticketTypeId}: ` +
-                  `requested ${item.quantity}, available ${tt.totalQuantity}`,
-                OrderErrorCode.INSUFFICIENT_INVENTORY,
-              );
-            }
-            return tt;
-          }),
-      ),
+      items.map(async (item) => {
+        if (!Number.isInteger(item.quantity) || item.quantity < 1) {
+          throw new BadRequestException(
+            `Invalid quantity ${item.quantity} for ticketType ${item.ticketTypeId}`,
+          );
+        }
+
+        const ticketType = await this.ticketTypeService.findOne(item.ticketTypeId);
+        if (!ticketType) {
+          throw new NotFoundException(`TicketType ${item.ticketTypeId} not found`);
+        }
+
+        if (ticketType.soldQuantity + item.quantity > ticketType.totalQuantity) {
+          throw new BadRequestException(
+            `Insufficient inventory for ticketType ${item.ticketTypeId}: requested ${item.quantity}, available ${ticketType.totalQuantity - ticketType.soldQuantity}`,
+          );
+        }
+
+        return ticketType;
+      }),
     );
 
-    const expiryMinutes =
-      this.config.get<OrderConfig>('order')?.expiryMinutes ?? 15;
-    const expiresAt = new Date(Date.now() + expiryMinutes * 60 * 1_000);
-    const stellarMemo = this.generateMemo();
+    const orderId = randomUUID();
+    const stellarMemo = orderId.slice(0, 8);
+    const expiryMinutes = this.config.get<OrderConfig>('order')?.expiryMinutes ?? 15;
+    const expiresAt = new Date(Date.now() + expiryMinutes * 60_000);
 
-    // Compute totals from snapshotted prices.
-    let totalAmountXLM = 0;
     let totalAmountUSD = 0;
+    let totalAmountXLM = 0;
 
-    const orderItems: Partial<OrderItem>[] = items.map((item, idx) => {
-      const tt = ticketTypes[idx];
-      const subtotalXLM = tt.price * item.quantity;
-      const subtotalUSD = tt.price * item.quantity;
-      totalAmountXLM += subtotalXLM;
-      totalAmountUSD += subtotalUSD;
+    const orderItems = items.map((item, idx) => {
+      const ticketType = ticketTypes[idx];
+      const unitPrice = Number(ticketType.price);
+      const subtotal = unitPrice * item.quantity;
+      totalAmountUSD += subtotal;
+      totalAmountXLM += subtotal;
 
       return {
         ticketTypeId: item.ticketTypeId,
         quantity: item.quantity,
-        unitPriceXLM: tt.price,
-        subtotalXLM,
+        unitPriceUSD: unitPrice,
+        subtotalUSD: subtotal,
       };
     });
 
-    // Run everything inside a transaction so a failed reservation rolls back
-    // the order row automatically.
     const order = await this.dataSource.transaction(async (manager) => {
       const savedOrder = await manager.save(
         manager.create(Order, {
-          userId,
+          id: orderId,
+          userId: user.id,
           eventId,
           status: OrderStatus.PENDING,
-          totalAmountXLM,
           totalAmountUSD,
+          totalAmountXLM,
           stellarMemo,
+          stellarTxHash: null,
+          refundTxHash: null,
           expiresAt,
           paidAt: null,
-          stellarTxHash: null,
-          metadata: null,
         }),
       );
 
-      const itemEntities = orderItems.map((item) =>
-        manager.create(OrderItem, { ...item, orderId: savedOrder.id }),
+      const itemsToSave = orderItems.map((item) =>
+        manager.create(OrderItem, {
+          ...item,
+          orderId: savedOrder.id,
+        }),
       );
-      savedOrder.items = await manager.save(itemEntities);
 
-      // Soft-reserve inventory. If any reservation fails the transaction
-      // rolls back and the order is never persisted.
+      savedOrder.items = await manager.save(itemsToSave);
+
       for (const item of items) {
         await this.ticketTypeService.reserveTickets(
           item.ticketTypeId,
           item.quantity,
+          manager.queryRunner,
         );
       }
 
@@ -156,21 +126,16 @@ export class OrdersService {
     });
 
     this.logger.log(
-      `Order ${order.id} created for user ${userId} — ` +
-        `${items.length} item(s), ${totalAmountXLM} XLM, memo=${stellarMemo}`,
+      `Order ${order.id} created for user ${user.id} — ${items.length} item(s), ${totalAmountXLM} XLM, memo=${stellarMemo}`,
     );
 
-    return { order, stellarMemo };
+    return {
+      order,
+      stellarMemo,
+      amountXLM: totalAmountXLM,
+    };
   }
 
-  /**
-   * Find an order by ID.
-   *
-   * @param orderId - ID of the order to find
-   * @param user - Authenticated user (required for permission check)
-   * @throws NotFoundException if the order doesn't exist
-   * @throws ForbiddenException if the user is not the owner or an ADMIN
-   */
   async findById(orderId: string, user: User): Promise<Order> {
     const order = await this.orderRepo.findOne({
       where: { id: orderId },
@@ -181,11 +146,8 @@ export class OrdersService {
       throw new NotFoundException(`Order ${orderId} not found`);
     }
 
-    // Permission Check: Owner or ADMIN
     if (order.userId !== user.id && user.role !== UserRole.ADMIN) {
-      throw new ForbiddenException(
-        'You do not have permission to view this order',
-      );
+      throw new ForbiddenException('You do not have permission to view this order');
     }
 
     return order;
@@ -194,53 +156,31 @@ export class OrdersService {
   async findByUser(userId: string): Promise<Order[]> {
     return this.orderRepo.find({
       where: { userId },
-      relations: ['items'],
+      relations: ['items', 'items.ticketType'],
       order: { createdAt: 'DESC' },
     });
   }
 
-  /**
-   * Fetch all tickets associated with a specific order.
-   *
-   * @param orderId - ID of the order
-   * @param user - Authenticated user (required for permission check)
-   * @returns List of ticket summaries
-   */
   async getOrderTickets(orderId: string, user: User) {
-    // 1. Authorization check: ensure order exists and user has permission
     await this.findById(orderId, user);
 
-    // 2. Fetch all tickets for this order
     const tickets = await this.ticketRepo.find({
       where: { orderReference: orderId },
       relations: ['ticketType', 'event'],
       order: { createdAt: 'ASC' },
     });
 
-    // 3. Map to the requested summary format
-    return tickets.map((t) => ({
-      id: t.id,
-      qrCodeImage: t.qrCode, // Placeholder for actual image generation
-      attendeeName: t.attendeeName,
-      attendeeEmail: t.attendeeEmail,
-      status: t.status,
-      ticketTypeName: t.ticketType?.name,
-      eventTitle: t.event?.title,
-      eventDate: t.event?.eventDate,
+    return tickets.map((ticket) => ({
+      id: ticket.id,
+      attendeeName: ticket['attendeeName'],
+      attendeeEmail: ticket['attendeeEmail'],
+      status: ticket.status,
+      ticketTypeName: ticket.ticketType?.name,
+      eventTitle: ticket.event?.title,
+      eventDate: ticket.event?.eventDate,
     }));
   }
 
-  /**
-   * Cancel a PENDING order and release its reserved inventory.
-   *
-   * Only the order owner or an ADMIN can perform this action.
-   *
-   * @param id - Order ID to cancel
-   * @param user - Authenticated user performing the action
-   * @throws NotFoundException if the order doesn't exist
-   * @throws ForbiddenException if user is not authorized
-   * @throws BadRequestException if order status is not PENDING
-   */
   async cancel(id: string, user: User): Promise<Order> {
     const order = await this.orderRepo.findOne({
       where: { id },
@@ -251,26 +191,15 @@ export class OrdersService {
       throw new NotFoundException(`Order ${id} not found`);
     }
 
-    // Permission Check: Owner or ADMIN
     if (order.userId !== user.id && user.role !== UserRole.ADMIN) {
-      throw new ForbiddenException(
-        'You do not have permission to cancel this order',
-      );
+      throw new ForbiddenException('You do not have permission to cancel this order');
     }
 
-    // Status Check: Must be PENDING
     if (order.status !== OrderStatus.PENDING) {
-      throw new BadRequestException(
-        `Order ${id} cannot be cancelled — status is ${order.status}`,
-      );
+      throw new BadRequestException(`Order ${id} cannot be cancelled — status is ${order.status}`);
     }
 
-    // Release inventory and update status in a single transaction
     await this.dataSource.transaction(async (manager) => {
-      // 1. Mark as CANCELLED
-      await manager.update(Order, id, { status: OrderStatus.CANCELLED });
-
-      // 2. Release tickets back to inventory
       for (const item of order.items) {
         await this.ticketTypeService.releaseTickets(
           item.ticketTypeId,
@@ -278,49 +207,15 @@ export class OrdersService {
           manager.queryRunner,
         );
       }
+
+      await manager.update(Order, id, {
+        status: OrderStatus.CANCELLED,
+      });
     });
 
-    this.logger.log(
-      `Order ${id} cancelled by user ${user.id} (${user.role}) — inventory released`,
-    );
+    this.logger.log(`Order ${id} cancelled by user ${user.id} (${user.role}) — inventory released`);
 
     order.status = OrderStatus.CANCELLED;
     return order;
-  }
-
-  /**
-   * Cancel a PENDING order that has not yet expired (LEGACY).
-   * @deprecated Use cancel(id, user) for manual cancellations with inventory release.
-   */
-  async cancelOrder(orderId: string): Promise<Order> {
-    const order = await this.findById(orderId);
-
-    if (order.status !== OrderStatus.PENDING) {
-      throw new OrderError(
-        `Order ${orderId} cannot be cancelled — status is ${order.status}`,
-        OrderErrorCode.ORDER_NOT_CANCELLABLE,
-      );
-    }
-
-    if (order.isExpired()) {
-      throw new OrderError(
-        `Order ${orderId} has already expired`,
-        OrderErrorCode.ORDER_NOT_CANCELLABLE,
-      );
-    }
-
-    await this.orderRepo.update(orderId, { status: OrderStatus.CANCELLED });
-    order.status = OrderStatus.CANCELLED;
-
-    this.logger.log(`Order ${orderId} manually cancelled`);
-    return order;
-  }
-
-  /**
-   * Generate a Stellar-compatible memo (≤ 28 chars, URL-safe).
-   * Format: VTX-<10 random hex chars>  e.g. "VTX-3f9a2b1c4d"
-   */
-  private generateMemo(): string {
-    return `VTX-${randomBytes(5).toString('hex')}`;
   }
 }

--- a/src/ticket-types/ticket-types.service.ts
+++ b/src/ticket-types/ticket-types.service.ts
@@ -35,7 +35,7 @@ export class TicketTypesService {
     }));
   }
 
-  async findOne(id: string): Promise<TicketType> {
+  async findOne(id: string): Promise<TicketType | null> {
     return this.ticketTypeRepository.findOne({
       where: { id },
       relations: ["event"],
@@ -83,7 +83,7 @@ export class TicketTypesService {
     const ticketType = await repository
       .createQueryBuilder("ticketType")
       .where("ticketType.id = :id", { id: ticketTypeId })
-      .setLock({ mode: "pessimistic_write" })
+      .setLock({ mode: 'pessimistic_write' })
       .getOne();
 
     if (!ticketType) {
@@ -130,7 +130,7 @@ export class TicketTypesService {
     const ticketType = await repository
       .createQueryBuilder("ticketType")
       .where("ticketType.id = :id", { id: ticketTypeId })
-      .setLock({ mode: "pessimistic_write" })
+      .setLock({ mode: 'pessimistic_write' })
       .getOne();
 
     if (!ticketType) {

--- a/src/ticket-types/ticket-types.service.ts
+++ b/src/ticket-types/ticket-types.service.ts
@@ -36,10 +36,16 @@ export class TicketTypesService {
   }
 
   async findOne(id: string): Promise<TicketType | null> {
-    return this.ticketTypeRepository.findOne({
+    const ticketType = await this.ticketTypeRepository.findOne({
       where: { id },
-      relations: ["event"],
+      relations: ['event'],
     });
+
+    if (!ticketType) {
+      throw new BadRequestException(`Ticket type with ID ${id} not found`);
+    }
+
+    return ticketType;
   }
 
   async create(ticketTypeData: Partial<TicketType>): Promise<TicketType> {

--- a/src/ticket-types/ticket-types.service.ts
+++ b/src/ticket-types/ticket-types.service.ts
@@ -35,7 +35,7 @@ export class TicketTypesService {
     }));
   }
 
-  async findOne(id: string): Promise<TicketType | null> {
+  async findOne(id: string): Promise<TicketType> {
     const ticketType = await this.ticketTypeRepository.findOne({
       where: { id },
       relations: ['event'],
@@ -89,7 +89,7 @@ export class TicketTypesService {
     const ticketType = await repository
       .createQueryBuilder("ticketType")
       .where("ticketType.id = :id", { id: ticketTypeId })
-      .setLock({ mode: 'pessimistic_write' as const })
+      .setLock('pessimistic_write')
       .getOne();
 
     if (!ticketType) {
@@ -136,7 +136,7 @@ export class TicketTypesService {
     const ticketType = await repository
       .createQueryBuilder("ticketType")
       .where("ticketType.id = :id", { id: ticketTypeId })
-      .setLock({ mode: 'pessimistic_write' as const })
+      .setLock('pessimistic_write')
       .getOne();
 
     if (!ticketType) {

--- a/src/ticket-types/ticket-types.service.ts
+++ b/src/ticket-types/ticket-types.service.ts
@@ -89,7 +89,7 @@ export class TicketTypesService {
     const ticketType = await repository
       .createQueryBuilder("ticketType")
       .where("ticketType.id = :id", { id: ticketTypeId })
-      .setLock({ mode: 'pessimistic_write' })
+      .setLock({ mode: 'pessimistic_write' as const })
       .getOne();
 
     if (!ticketType) {
@@ -136,7 +136,7 @@ export class TicketTypesService {
     const ticketType = await repository
       .createQueryBuilder("ticketType")
       .where("ticketType.id = :id", { id: ticketTypeId })
-      .setLock({ mode: 'pessimistic_write' })
+      .setLock({ mode: 'pessimistic_write' as const })
       .getOne();
 
     if (!ticketType) {

--- a/src/tickets/entities/ticket.entity.ts
+++ b/src/tickets/entities/ticket.entity.ts
@@ -1,0 +1,51 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Event } from '../../events/entities/event.entity';
+import { TicketType } from '../../ticket-types/entities/ticket-type.entity';
+import { Order } from '../../orders/entities/order.entity';
+
+@Entity('tickets')
+export class Ticket {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @Column('uuid')
+  eventId: string;
+
+  @ManyToOne(() => Event)
+  @JoinColumn({ name: 'eventId' })
+  event: Event;
+
+  @Column('uuid')
+  ticketTypeId: string;
+
+  @ManyToOne(() => TicketType)
+  @JoinColumn({ name: 'ticketTypeId' })
+  ticketType: TicketType;
+
+  @Column('uuid', { nullable: true })
+  orderReference: string;
+
+  @ManyToOne(() => Order, (order) => order.tickets, { nullable: true })
+  @JoinColumn({ name: 'orderReference' })
+  order: Order;
+
+  @Column({ default: 'ACTIVE' })
+  status: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/tickets/tickets.controller.ts
+++ b/src/tickets/tickets.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Get, Query, UseGuards } from '@nestjs/common';
+import { TicketsService } from './tickets.service';
+import { JwtAuthGuard } from 'src/common/guards/jwt-auth.guard';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { User } from 'src/users/entities/user.entity';
+
+@UseGuards(JwtAuthGuard)
+@Controller('tickets')
+export class TicketsController {
+  constructor(private readonly ticketsService: TicketsService) {}
+
+  @Get('my')
+  async findMyTickets(
+    @CurrentUser() user: User,
+    @Query('status') status?: string,
+    @Query('page') page = '1',
+    @Query('pageSize') pageSize = '20',
+  ) {
+    const parsedPage = Number(page) || 1;
+    const parsedPageSize = Number(pageSize) || 20;
+
+    return this.ticketsService.findByUser(user.id, {
+      status,
+      page: parsedPage,
+      pageSize: parsedPageSize,
+    });
+  }
+}

--- a/src/tickets/tickets.module.ts
+++ b/src/tickets/tickets.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TicketsService } from './tickets.service';
+import { TicketsController } from './tickets.controller';
+import { Ticket } from './entities/ticket.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Ticket])],
+  providers: [TicketsService],
+  controllers: [TicketsController],
+  exports: [TicketsService],
+})
+export class TicketsModule {}

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Ticket } from './entities/ticket.entity';
+
+export interface TicketQuery {
+  page?: number;
+  pageSize?: number;
+  status?: string;
+}
+
+@Injectable()
+export class TicketsService {
+  constructor(
+    @InjectRepository(Ticket)
+    private readonly ticketRepository: Repository<Ticket>,
+  ) {}
+
+  async findByUser(userId: string, query: TicketQuery) {
+    const page = Math.max(1, query.page ?? 1);
+    const pageSize = Math.min(100, Math.max(1, query.pageSize ?? 20));
+
+    const qb = this.ticketRepository
+      .createQueryBuilder('ticket')
+      .leftJoinAndSelect('ticket.event', 'event')
+      .leftJoinAndSelect('ticket.ticketType', 'ticketType')
+      .where('ticket.userId = :userId', { userId });
+
+    if (query.status) {
+      qb.andWhere('ticket.status = :status', { status: query.status });
+    }
+
+    const [tickets, total] = await qb
+      .orderBy('ticket.createdAt', 'DESC')
+      .skip((page - 1) * pageSize)
+      .take(pageSize)
+      .getManyAndCount();
+
+    const data = tickets.map((ticket) => ({
+      id: ticket.id,
+      status: ticket.status,
+      eventTitle: ticket.event?.title,
+      eventDate: ticket.event?.eventDate,
+      ticketTypeName: ticket.ticketType?.name,
+      createdAt: ticket.createdAt,
+      updatedAt: ticket.updatedAt,
+    }));
+
+    return {
+      data,
+      page,
+      pageSize,
+      total,
+    };
+  }
+}


### PR DESCRIPTION
## Implementation Summary

- Added full order/ticket domain support
- Created new `Order` and `OrderItem` entities
- Added `OrderStatus` enum
- Added `CreateOrderDto` and order creation flow
- Implemented order creation with inventory reservation and Stellar payment memo
- Added GET `/orders/:id` with owner/admin access control
- Added GET `/orders/my` for current user orders
- Added GET `/tickets/my` for user ticket history
- Added ticket query pagination and optional status filtering
- Added new `tickets` module and `OrdersModule` registration
- Added migration for `orders`, `order_items`, and `tickets` tables

Closes #581 
Closes #589 
Closes #587
Closes #586