### PR TITLE
Implemented the verification logs and conversionnd

### DIFF
--- a/src/orders/entities/orders.entity.ts
+++ b/src/orders/entities/orders.entity.ts
@@ -1,0 +1,63 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  OneToMany,
+  CreateDateColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { OrderStatus } from '../enums/order-status.enum';
+import { OrderItem } from './order-item.entity';
+import { Ticket } from 'src/tickets/entities/ticket.entity';
+
+@Entity('orders')
+export class Order {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column('uuid')
+  userId: string;
+
+  @Column('uuid')
+  eventId: string;
+
+  @Column({
+    type: 'enum',
+    enum: OrderStatus,
+    default: OrderStatus.PENDING,
+  })
+  status: OrderStatus;
+
+  @Column('decimal', { precision: 10, scale: 2, default: 0 })
+  totalAmountUSD: number;
+
+  @Column('decimal', { precision: 18, scale: 7, default: 0 })
+  totalAmountXLM: number;
+
+  @Column({ unique: true })
+  stellarMemo: string;
+
+  @Column({ nullable: true, unique: true })
+  stellarTxHash: string | null;
+
+  @Column({ nullable: true, unique: true })
+  refundTxHash: string | null;
+
+  @Column({ type: 'timestamp' })
+  expiresAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  paidAt: Date | null;
+
+  @OneToMany(() => OrderItem, (item) => item.order, { cascade: true })
+  items: OrderItem[];
+
+  @OneToMany(() => Ticket, (ticket) => ticket.order)
+  tickets: Ticket[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/orders/enums/orders-status.enum.ts
+++ b/src/orders/enums/orders-status.enum.ts
@@ -1,0 +1,7 @@
+export enum OrdersStatus {
+  PENDING = 'PENDING',
+  PAID = 'PAID',
+  FAILED = 'FAILED',
+  REFUNDED = 'REFUNDED',
+  CANCELLED = 'CANCELLED',
+}

--- a/src/tickets/tickets.service.ts
+++ b/src/tickets/tickets.service.ts
@@ -53,4 +53,11 @@ export class TicketsService {
       total,
     };
   }
+
+  public async findOne(id: string) {
+    return this.ticketRepository.findOne({
+      where: { id },
+      relations: ['event', 'ticketType', 'order'],
+    });
+  }
 }


### PR DESCRIPTION
 Implemented the GET /verification/logs/:eventId — paginated scan audit log

Description
Let organizers review every scan attempt for an event, useful for dispute resolution.

What to do
Add getLogs(eventId, query) to VerificationService — paginated query on VerificationLog, ordered by verifiedAt desc
Add GET /verification/logs/:eventId to VerificationController — protected by JwtAuthGuard + ORGANIZER | ADMIN
Files touched
src/verification/verification.service.ts
src/verification/verification.controller.ts#598 verification: implement GET /verification/logs/:eventId — paginated scan audit log

Description
Let organizers review every scan attempt for an event, useful for dispute resolution.

What to do
Add getLogs(eventId, query) to VerificationService — paginated query on VerificationLog, ordered by verifiedAt desc
Add GET /verification/logs/:eventId to VerificationController — protected by JwtAuthGuard + ORGANIZER | ADMIN
Files touched
src/verification/verification.service.ts
src/verification/verification.controller.ts
closes #598



 Implemented the XLM/USD price conversion with 60-second cache

Description
Convert USD ticket prices to XLM at the current market rate so buyers know exactly how much to send.

What to do
Register CacheModule globally in AppModule (install @nestjs/cache-manager)
Create src/stellar/price.service.ts with getXLMUSDRate() (fetches from CoinGecko free API, caches 60 seconds) and convertUSDToXLM(usd) (returns string, rounded up to 7 decimal places)
If price feed unavailable, throw ServiceUnavailableException
Inject PriceService into OrdersService.create to populate order.totalAmountXLM
Files touched
src/stellar/price.service.ts (new)
src/stellar/stellar.module.ts
src/orders/orders.service.ts
src/app.module.ts601 stellar: implement XLM/USD price conversion with 60-second cache
Repo Avatar
[Lead-Studios/veritix-backend](https://github.com/Lead-Studios/veritix-backend)
Description
Convert USD ticket prices to XLM at the current market rate so buyers know exactly how much to send.

What to do
Register CacheModule globally in AppModule (install @nestjs/cache-manager)
Create src/stellar/price.service.ts with getXLMUSDRate() (fetches from CoinGecko free API, caches 60 seconds) and convertUSDToXLM(usd) (returns string, rounded up to 7 decimal places)
If price feed unavailable, throw ServiceUnavailableException
Inject PriceService into OrdersService.create to populate order.totalAmountXLM
Files touched
src/stellar/price.service.ts (new)
src/stellar/stellar.module.ts
src/orders/orders.service.ts
src/app.module.ts
closes #601 