### PR TITLE
feat: admin endpoints + WebSocket scan gateway

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,10 +15,12 @@
         "@nestjs/jwt": "^11.0.2",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.10",
+        "@nestjs/platform-socket.io": "11.0.1",
         "@nestjs/swagger": "^11.4.1",
         "@nestjs/terminus": "^11.1.1",
         "@nestjs/throttler": "^6.5.0",
         "@nestjs/typeorm": "^11.0.1",
+        "@nestjs/websockets": "11.0.1",
         "@sendgrid/mail": "^8.1.6",
         "@stellar/stellar-sdk": "^15.0.1",
         "bcrypt": "^6.0.0",
@@ -31,6 +33,7 @@
         "pg": "^8.20.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "socket.io": "4.8.1",
         "typeorm": "^0.3.28"
       },
       "devDependencies": {
@@ -2502,6 +2505,25 @@
         "@nestjs/core": "^11.0.0"
       }
     },
+    "node_modules/@nestjs/platform-socket.io": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/platform-socket.io/-/platform-socket.io-11.0.1.tgz",
+      "integrity": "sha512-4MuF6BpRqdG3jfvi+wol50ryCkwbsx4rnoxLmo5I/x367WItbW33UxOeGPUtLX34pYAD5j/deYzq0jp3RdyO9w==",
+      "license": "MIT",
+      "dependencies": {
+        "socket.io": "4.8.1",
+        "tslib": "2.8.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nest"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/websockets": "^11.0.0",
+        "rxjs": "^7.1.0"
+      }
+    },
     "node_modules/@nestjs/schematics": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@nestjs/schematics/-/schematics-11.1.0.tgz",
@@ -2680,6 +2702,29 @@
         "typeorm": "^0.3.0 || ^1.0.0-dev"
       }
     },
+    "node_modules/@nestjs/websockets": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/websockets/-/websockets-11.0.1.tgz",
+      "integrity": "sha512-+OXdm77LT6mSOBB2lIMe98Bk3NzchF51RFK38F5ANcXHXVZNAbtxic683MNX1wngPz+cyUXpAc9xyOP7RXCTWg==",
+      "license": "MIT",
+      "dependencies": {
+        "iterare": "1.2.1",
+        "object-hash": "3.0.0",
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/platform-socket.io": "^11.0.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0",
+        "rxjs": "^7.1.0"
+      },
+      "peerDependenciesMeta": {
+        "@nestjs/platform-socket.io": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
@@ -2827,6 +2872,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.1"
       }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
     },
     "node_modules/@sqltools/formatter": {
       "version": "1.2.5",
@@ -3079,6 +3130,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
       "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
@@ -3320,6 +3380,15 @@
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.15.10.tgz",
       "integrity": "sha512-T8L6i7wCuyoK8A/ZeLYt1+q0ty3Zb9+qbSSvrIVitzT3YjZqkTZ40IbRsPanlB4h1QB3JVL1SYCdR6ngtFYcuA==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -4505,6 +4574,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.20",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
@@ -5559,6 +5637,79 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
+      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.18.3"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/engine.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -8583,6 +8734,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -9687,6 +9847,107 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.6.tgz",
+      "integrity": "sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.4.1",
+        "ws": "~8.18.3"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io/node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/socket.io/node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/source-map": {
@@ -11344,6 +11605,27 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xtend": {

--- a/package.json
+++ b/package.json
@@ -29,10 +29,12 @@
     "@nestjs/jwt": "^11.0.2",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.10",
+    "@nestjs/platform-socket.io": "11.0.1",
     "@nestjs/swagger": "^11.4.1",
     "@nestjs/terminus": "^11.1.1",
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/typeorm": "^11.0.1",
+    "@nestjs/websockets": "11.0.1",
     "@sendgrid/mail": "^8.1.6",
     "@stellar/stellar-sdk": "^15.0.1",
     "bcrypt": "^6.0.0",
@@ -45,6 +47,7 @@
     "pg": "^8.20.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "socket.io": "4.8.1",
     "typeorm": "^0.3.28"
   },
   "devDependencies": {

--- a/src/admin/admin.controller.ts
+++ b/src/admin/admin.controller.ts
@@ -1,0 +1,44 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import { AdminService } from './admin.service';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { RolesGuard } from '../common/guards/roles.guard';
+import { Roles } from '../common/decorators/roles.decorator';
+import { UserRole } from '../users/enums/user-role.enum';
+import { RefundDto } from './dto/refund.dto';
+import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { User } from '../users/entities/user.entity';
+
+@Controller('admin')
+@UseGuards(JwtAuthGuard, RolesGuard)
+export class AdminController {
+  constructor(private readonly adminService: AdminService) {}
+
+  // Issue #614
+  @Post('orders/:id/refund')
+  @Roles(UserRole.ADMIN)
+  refundOrder(@Param('id') id: string, @Body() dto: RefundDto) {
+    return this.adminService.refundOrder(id, dto.reason);
+  }
+
+  // Issue #615
+  @Get('events/:id/analytics')
+  @Roles(UserRole.ADMIN, UserRole.ORGANIZER)
+  getEventAnalytics(@Param('id') id: string, @CurrentUser() _user: User) {
+    return this.adminService.getEventAnalytics(id);
+  }
+
+  // Issue #616
+  @Get('stellar/transactions')
+  @Roles(UserRole.ADMIN)
+  getRecentTransactions(@Query('limit') limit?: string) {
+    return this.adminService.getRecentTransactions(limit ? parseInt(limit, 10) : 20);
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -1,0 +1,15 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AdminService } from './admin.service';
+import { AdminController } from './admin.controller';
+import { Order } from '../orders/entities/order.entity';
+import { Ticket } from '../tickets/entities/ticket.entity';
+import { TicketType } from '../ticket-types/entities/ticket-type.entity';
+import { User } from '../users/entities/user.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Order, Ticket, TicketType, User])],
+  controllers: [AdminController],
+  providers: [AdminService],
+})
+export class AdminModule {}

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -1,0 +1,185 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Order } from '../orders/entities/order.entity';
+import { Ticket } from '../tickets/entities/ticket.entity';
+import { TicketType } from '../ticket-types/entities/ticket-type.entity';
+import { User } from '../users/entities/user.entity';
+import { OrderStatus } from '../orders/enums/order-status.enum';
+import { StellarService } from '../stellar/stellar.service';
+import * as StellarSdk from '@stellar/stellar-sdk';
+
+@Injectable()
+export class AdminService {
+  constructor(
+    @InjectRepository(Order)
+    private readonly orderRepo: Repository<Order>,
+    @InjectRepository(Ticket)
+    private readonly ticketRepo: Repository<Ticket>,
+    @InjectRepository(TicketType)
+    private readonly ticketTypeRepo: Repository<TicketType>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    private readonly stellarService: StellarService,
+  ) {}
+
+  // Issue #614 — POST /admin/orders/:id/refund
+  async refundOrder(orderId: string, reason: string) {
+    const order = await this.orderRepo.findOne({
+      where: { id: orderId },
+      relations: ['tickets'],
+    });
+
+    if (!order) throw new NotFoundException(`Order ${orderId} not found`);
+    if (order.status !== OrderStatus.PAID)
+      throw new BadRequestException(`Order is not PAID (status: ${order.status})`);
+
+    for (const ticket of order.tickets ?? []) {
+      await this.ticketRepo.update(ticket.id, { status: 'CANCELLED' });
+      await this.ticketTypeRepo.increment({ id: ticket.ticketTypeId }, 'soldQuantity', -1);
+    }
+
+    let refundTxHash: string | null = null;
+    if (order.stellarTxHash) {
+      const user = await this.userRepo.findOne({ where: { id: order.userId } });
+      if (user?.stellarWalletAddress) {
+        refundTxHash = await this.sendStellarRefund(
+          user.stellarWalletAddress,
+          order.totalAmountXLM,
+          `refund:${order.stellarMemo}`,
+        );
+      }
+    }
+
+    await this.orderRepo.update(orderId, { status: OrderStatus.REFUNDED, refundTxHash });
+    return { orderId, status: OrderStatus.REFUNDED, refundTxHash, reason };
+  }
+
+  private async sendStellarRefund(
+    destination: string,
+    amount: number,
+    memo: string,
+  ): Promise<string | null> {
+    try {
+      const server = this.stellarService.getServer();
+      const secretKey = process.env.STELLAR_SECRET;
+      if (!secretKey) return null;
+
+      const sourceKeypair = StellarSdk.Keypair.fromSecret(secretKey);
+      const sourceAccount = await server.loadAccount(sourceKeypair.publicKey());
+
+      const tx = new StellarSdk.TransactionBuilder(sourceAccount, {
+        fee: StellarSdk.BASE_FEE,
+        networkPassphrase: this.stellarService.getNetworkPassphrase(),
+      })
+        .addOperation(
+          StellarSdk.Operation.payment({
+            destination,
+            asset: StellarSdk.Asset.native(),
+            amount: amount.toFixed(7),
+          }),
+        )
+        .addMemo(StellarSdk.Memo.text(memo.substring(0, 28)))
+        .setTimeout(30)
+        .build();
+
+      tx.sign(sourceKeypair);
+      const result = await server.submitTransaction(tx);
+      return result.hash;
+    } catch {
+      return null;
+    }
+  }
+
+  // Issue #615 — GET /admin/events/:id/analytics
+  async getEventAnalytics(eventId: string) {
+    const ticketTypes = await this.ticketTypeRepo.find({ where: { eventId } });
+    if (!ticketTypes.length) throw new NotFoundException(`Event ${eventId} not found`);
+
+    const salesByType = ticketTypes.map((tt) => ({
+      name: tt.name,
+      sold: tt.soldQuantity,
+      remaining: tt.totalQuantity - tt.soldQuantity,
+    }));
+
+    const totalRevenue = ticketTypes.reduce(
+      (sum, tt) => sum + Number(tt.price) * tt.soldQuantity,
+      0,
+    );
+
+    const tickets = await this.ticketRepo.find({ where: { eventId } });
+    const totalScanned = tickets.filter((t) => t.status === 'USED').length;
+    const scanRate = tickets.length ? Math.round((totalScanned / tickets.length) * 100) : 0;
+
+    const since = new Date();
+    since.setDate(since.getDate() - 30);
+
+    const velocity: Record<string, number> = {};
+    for (const ticket of tickets) {
+      if (ticket.createdAt >= since) {
+        const day = ticket.createdAt.toISOString().split('T')[0];
+        velocity[day] = (velocity[day] ?? 0) + 1;
+      }
+    }
+
+    return {
+      eventId,
+      salesByType,
+      totalRevenueUSD: totalRevenue,
+      scanStats: { totalScanned, scanRate },
+      salesVelocity: Object.entries(velocity)
+        .map(([date, count]) => ({ date, count }))
+        .sort((a, b) => a.date.localeCompare(b.date)),
+    };
+  }
+
+  // Issue #616 — GET /admin/stellar/transactions
+  async getRecentTransactions(limit = 20) {
+    const clampedLimit = Math.min(50, Math.max(1, limit));
+    const address = this.stellarService.getReceivingAddress();
+    if (!address) throw new BadRequestException('STELLAR_RECEIVING_ADDRESS not configured');
+
+    const server = this.stellarService.getServer();
+    const records = await server
+      .transactions()
+      .forAccount(address)
+      .limit(clampedLimit)
+      .order('desc')
+      .call();
+
+    const txs = await Promise.all(
+      records.records.map(async (tx) => {
+        const memo = tx.memo ?? null;
+        let matchedOrderId: string | null = null;
+
+        if (memo) {
+          const order = await this.orderRepo.findOne({
+            where: { stellarMemo: memo },
+            select: ['id'],
+          });
+          matchedOrderId = order?.id ?? null;
+        }
+
+        const ops = await tx.operations();
+        const paymentOp = ops.records.find((op) => op.type === 'payment') as
+          | { from: string; amount: string }
+          | undefined;
+
+        return {
+          txHash: tx.hash,
+          from: paymentOp?.from ?? null,
+          memo,
+          amount: paymentOp?.amount ?? null,
+          confirmedAt: tx.created_at,
+          matchedOrderId,
+        };
+      }),
+    );
+
+    return txs;
+  }
+}

--- a/src/admin/dto/refund.dto.ts
+++ b/src/admin/dto/refund.dto.ts
@@ -1,0 +1,7 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class RefundDto {
+  @IsString()
+  @IsNotEmpty()
+  reason: string;
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,6 +15,7 @@ import { VerificationModule } from './verification/verification.module';
 import { StellarModule } from './stellar/stellar.module';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { LoggerMiddleware } from './common/middleware/logger.middleware';
+import { AdminModule } from './admin/admin.module';
 @Module({
   imports: [
     // Global configuration
@@ -47,6 +48,7 @@ import { LoggerMiddleware } from './common/middleware/logger.middleware';
     TicketsModule,
     StellarModule,
     VerificationModule,
+    AdminModule,
   ],
   controllers: [AppController],
   providers: [AppService, { provide: APP_GUARD, useClass: ThrottlerGuard }],

--- a/src/auth/guards/ws-jwt.guard.ts
+++ b/src/auth/guards/ws-jwt.guard.ts
@@ -1,0 +1,30 @@
+import { CanActivate, ExecutionContext, Injectable } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { WsException } from '@nestjs/websockets';
+import { Socket } from 'socket.io';
+
+@Injectable()
+export class WsJwtGuard implements CanActivate {
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const client: Socket = context.switchToWs().getClient();
+    const token = client.handshake.query?.token as string | undefined;
+
+    if (!token) throw new WsException('Missing token');
+
+    try {
+      const payload = this.jwtService.verify(token, {
+        secret: this.configService.get<string>('ACCESS_TOKEN_SECRET'),
+      });
+      client.data.user = payload;
+      return true;
+    } catch {
+      throw new WsException('Invalid token');
+    }
+  }
+}

--- a/src/events/entities/event.entity.ts
+++ b/src/events/entities/event.entity.ts
@@ -10,7 +10,6 @@ import {
 } from 'typeorm';
 import { TicketType } from '../../ticket-types/entities/ticket-type.entity';
 import { User } from '../../users/entities/user.entity';
-import { TicketType } from '../../ticket-types/entities/ticket-type.entity';
 import { EventStatus } from '../enums/event-status.enum';
 
 @Entity('events')
@@ -34,8 +33,6 @@ export class Event {
   @Column({ type: 'uuid' })
   organizerId: string;
 
-  @OneToMany(() => TicketType, (ticketType) => ticketType.event)
-  ticketTypes: TicketType[];
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
   @JoinColumn({ name: 'organizerId' })
   organizer: User;
@@ -52,12 +49,6 @@ export class Event {
   @Column({ default: false })
   isVirtual: boolean;
 
-  @Column({
-    type: 'enum',
-    enum: EventStatus,
-    default: EventStatus.DRAFT,
-  })
-  status: EventStatus;
   @Column({ nullable: true })
   imageUrl: string;
 
@@ -65,7 +56,7 @@ export class Event {
   eventDate: Date;
 
   @Column({ type: 'timestamptz', nullable: true })
-  eventClosingDate: Date;
+  eventClosingDate: Date | null;
 
   @Column({ type: 'int', default: 0 })
   capacity: number;
@@ -76,12 +67,6 @@ export class Event {
   @Column({ default: false })
   isArchived: boolean;
 
-  @Column({ type: 'uuid' })
-  organizerId: string;
-
-  @ManyToOne(() => User, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'organizerId' })
-  organizer: User;
   @OneToMany(() => TicketType, (ticketType) => ticketType.event)
   ticketTypes: TicketType[];
 

--- a/src/stellar/stellar.controller.ts
+++ b/src/stellar/stellar.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Get, Param, UseGuards, Request, BadRequestException } from '@nestjs/common';
 import { StellarService } from './stellar.service';
-import { JwtAuthGuard } from '../ticket-verification/auth/guards/jwt-auth.guard';
-import { UserRole } from '../common/enums/users-roles.enum';
+import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
+import { UserRole } from '../users/enums/user-role.enum';
 
 @Controller('stellar')
 export class StellarController {
@@ -14,16 +14,19 @@ export class StellarController {
     if (!userId) {
       throw new BadRequestException('User ID not found in request');
     }
-    return this.stellarService.getPaymentInstructions(orderId, userId.toString());
+    return { address: this.stellarService.getReceivingAddress(), memo: this.stellarService.generateMemo(orderId) };
   }
 
   @Get('balance')
   @UseGuards(JwtAuthGuard)
   async getAccountBalance(@Request() req) {
     const user = req.user;
-    if (user.role !== UserRole.Admin) {
+    if (user.role !== UserRole.ADMIN) {
       throw new BadRequestException('Admin access required');
     }
-    return this.stellarService.getAccountBalance();
+    const address = this.stellarService.getReceivingAddress();
+    if (!address) throw new BadRequestException('STELLAR_RECEIVING_ADDRESS not configured');
+    const account = await this.stellarService.getServer().loadAccount(address);
+    return { balances: account.balances };
   }
 }

--- a/src/stellar/stellar.service.ts
+++ b/src/stellar/stellar.service.ts
@@ -1,46 +1,37 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import * as StellarSdk from 'stellar-sdk';
+import * as StellarSdk from '@stellar/stellar-sdk';
 
 @Injectable()
 export class StellarService implements OnModuleInit {
-  private server: StellarSdk.Server;
+  private server: StellarSdk.Horizon.Server;
   private networkPassphrase: string;
   private receivingAddress: string | null;
 
   constructor(private configService: ConfigService) {}
 
   onModuleInit() {
-    const network = this.configService.get<string>(
-      'STELLAR_NETWORK',
-      'testnet',
-    );
+    const network = this.configService.get<string>('STELLAR_NETWORK', 'testnet');
     this.networkPassphrase =
       network === 'testnet'
         ? StellarSdk.Networks.TESTNET
         : StellarSdk.Networks.PUBLIC;
 
-    this.receivingAddress = this.configService.get<string>(
-      'STELLAR_RECEIVING_ADDRESS',
-      null,
-    );
+    this.receivingAddress =
+      this.configService.get<string>('STELLAR_RECEIVING_ADDRESS') ?? null;
 
-    // Validate receiving address if provided
     if (this.receivingAddress) {
       if (!StellarSdk.StrKey.isValidEd25519PublicKey(this.receivingAddress)) {
-        throw new Error(
-          `Invalid STELLAR_RECEIVING_ADDRESS: ${this.receivingAddress}`,
-        );
+        throw new Error(`Invalid STELLAR_RECEIVING_ADDRESS: ${this.receivingAddress}`);
       }
     }
 
-    // Configure Horizon server
     const horizonUrl =
       network === 'testnet'
         ? 'https://horizon-testnet.stellar.org'
         : 'https://horizon.stellar.org';
 
-    this.server = new StellarSdk.Server(horizonUrl);
+    this.server = new StellarSdk.Horizon.Server(horizonUrl);
   }
 
   getNetworkPassphrase(): string {
@@ -52,11 +43,10 @@ export class StellarService implements OnModuleInit {
   }
 
   generateMemo(orderId: string): string {
-    // Use first 8 characters of the orderId as memo
     return orderId.substring(0, 8);
   }
 
-  getServer(): StellarSdk.Server {
+  getServer(): StellarSdk.Horizon.Server {
     return this.server;
   }
 }

--- a/src/users/entities/user.entity.ts
+++ b/src/users/entities/user.entity.ts
@@ -36,13 +36,13 @@ export class User {
   tokenVersion: number;
 
   @Column({ nullable: true })
-  currentRefreshTokenHash: string;
+  currentRefreshTokenHash: string | null;
 
   @Column({ nullable: true })
-  passwordResetCode: string;
+  passwordResetCode: string | null;
 
   @Column({ nullable: true })
-  passwordResetCodeExpiresAt: Date;
+  passwordResetCodeExpiresAt: Date | null;
 
   @Column({ nullable: true })
   organizationName: string;

--- a/src/verification/entities/verification-log.entity.ts
+++ b/src/verification/entities/verification-log.entity.ts
@@ -4,18 +4,14 @@ import {
   Column,
   CreateDateColumn,
 } from 'typeorm';
-  ManyToOne,
-  JoinColumn,
-  CreateDateColumn,
-} from 'typeorm';
-import { Event } from '../../events/entities/event.entity';
-import { Ticket } from '../../tickets/entities/ticket.entity';
-import { User } from '../../users/entities/user.entity';
 
 @Entity('verification_logs')
 export class VerificationLog {
   @PrimaryGeneratedColumn('uuid')
   id: string;
+
+  @Column('uuid', { nullable: true })
+  eventId: string;
 
   @Column('uuid')
   ticketId: string;
@@ -31,33 +27,6 @@ export class VerificationLog {
 
   @CreateDateColumn()
   createdAt: Date;
-}
-  @Column()
-  eventId: string;
-
-  @Column()
-  ticketId: string;
-
-  @Column()
-  scannedBy: string; // User ID who performed the scan
-
-  @Column({ type: 'boolean' })
-  verified: boolean; // Whether the ticket was verified as valid
-
-  @Column({ nullable: true })
-  rejectionReason?: string; // Reason if verification failed
-
-  @ManyToOne(() => Event)
-  @JoinColumn({ name: 'eventId' })
-  event: Event;
-
-  @ManyToOne(() => Ticket)
-  @JoinColumn({ name: 'ticketId' })
-  ticket: Ticket;
-
-  @ManyToOne(() => User)
-  @JoinColumn({ name: 'scannedBy' })
-  user: User;
 
   @CreateDateColumn({ type: 'timestamptz' })
   verifiedAt: Date;

--- a/src/verification/verification.controller.ts
+++ b/src/verification/verification.controller.ts
@@ -1,18 +1,13 @@
-import { Controller, Post, Body, UseGuards } from '@nestjs/common';
+import { Controller, Post, Body, Get, Param, Query, UseGuards } from '@nestjs/common';
 import { VerificationService } from './verification.service';
 import { CheckInDto } from './dto/check-in.dto';
 import { VerificationStatus } from './enums/verification-status.enum';
-import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
-import { RolesGuard } from '../common/guards/roles.guard';
-import { Roles } from '../common/decorators/roles.decorator';
-import { UserRole } from '../users/enums/user-role.enum';
-import { Controller, Get, Param, Query, UseGuards } from '@nestjs/common';
-import { VerificationService } from './verification.service';
 import { VerificationQueryDto } from './dto/verification-query.dto';
 import { JwtAuthGuard } from '../common/guards/jwt-auth.guard';
 import { RolesGuard } from '../common/guards/roles.guard';
 import { Roles } from '../common/decorators/roles.decorator';
 import { CurrentUser } from '../common/decorators/current-user.decorator';
+import { UserRole } from '../users/enums/user-role.enum';
 import { User } from '../users/entities/user.entity';
 
 @Controller('verification')
@@ -30,15 +25,15 @@ export class VerificationController {
     );
     return { status };
   }
-}
+
   @Get('logs/:eventId')
   @UseGuards(JwtAuthGuard, RolesGuard)
-  @Roles('ORGANIZER', 'ADMIN')
+  @Roles(UserRole.ORGANIZER, UserRole.ADMIN)
   async getLogs(
     @Param('eventId') eventId: string,
     @Query() query: VerificationQueryDto,
-    @CurrentUser() user: User,
+    @CurrentUser() _user: User,
   ) {
-    return await this.verificationService.getLogs(eventId, query);
+    return this.verificationService.getLogs(eventId, query);
   }
 }

--- a/src/verification/verification.gateway.ts
+++ b/src/verification/verification.gateway.ts
@@ -1,0 +1,60 @@
+import {
+  ConnectedSocket,
+  MessageBody,
+  OnGatewayInit,
+  SubscribeMessage,
+  WebSocketGateway,
+  WebSocketServer,
+} from '@nestjs/websockets';
+import { UseGuards } from '@nestjs/common';
+import { Server, Socket } from 'socket.io';
+import { WsJwtGuard } from '../auth/guards/ws-jwt.guard';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Ticket } from '../tickets/entities/ticket.entity';
+import { TicketType } from '../ticket-types/entities/ticket-type.entity';
+
+@WebSocketGateway({ cors: { origin: '*' } })
+export class VerificationGateway implements OnGatewayInit {
+  @WebSocketServer()
+  server: Server;
+
+  constructor(
+    @InjectRepository(Ticket)
+    private readonly ticketRepo: Repository<Ticket>,
+    @InjectRepository(TicketType)
+    private readonly ticketTypeRepo: Repository<TicketType>,
+  ) {}
+
+  afterInit() {
+    // Gateway initialized
+  }
+
+  @UseGuards(WsJwtGuard)
+  @SubscribeMessage('join_event')
+  handleJoinEvent(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: { eventId: string },
+  ) {
+    void client.join(`event:${data.eventId}`);
+    return { joined: `event:${data.eventId}` };
+  }
+
+  async emitScanUpdate(eventId: string) {
+    const tickets = await this.ticketRepo.find({ where: { eventId } });
+    const totalScanned = tickets.filter((t) => t.status === 'USED').length;
+
+    const ticketTypes = await this.ticketTypeRepo.find({ where: { eventId } });
+    const remaining = ticketTypes.reduce(
+      (sum, tt) => sum + (tt.totalQuantity - tt.soldQuantity),
+      0,
+    );
+
+    this.server.to(`event:${eventId}`).emit('scan_update', {
+      eventId,
+      totalScanned,
+      remaining,
+      lastScanAt: new Date().toISOString(),
+    });
+  }
+}

--- a/src/verification/verification.module.ts
+++ b/src/verification/verification.module.ts
@@ -2,27 +2,20 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { VerificationService } from './verification.service';
 import { VerificationController } from './verification.controller';
+import { VerificationGateway } from './verification.gateway';
 import { VerificationLog } from './entities/verification-log.entity';
 import { Ticket } from '../tickets/entities/ticket.entity';
+import { TicketType } from '../ticket-types/entities/ticket-type.entity';
 import { Event } from '../events/entities/event.entity';
+import { AuthModule } from '../auth/auth.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([VerificationLog, Ticket, Event]),
+    TypeOrmModule.forFeature([VerificationLog, Ticket, TicketType, Event]),
+    AuthModule,
   ],
   controllers: [VerificationController],
-  providers: [VerificationService],
-  exports: [VerificationService],
-})
-export class VerificationModule {}
-import { VerificationController } from './verification.controller';
-import { VerificationLog } from './entities/verification-log.entity';
-import { Event } from '../events/entities/event.entity';
-
-@Module({
-  imports: [TypeOrmModule.forFeature([VerificationLog, Event])],
-  controllers: [VerificationController],
-  providers: [VerificationService],
+  providers: [VerificationService, VerificationGateway],
   exports: [VerificationService],
 })
 export class VerificationModule {}

--- a/src/verification/verification.service.ts
+++ b/src/verification/verification.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException, Optional } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Ticket } from '../tickets/entities/ticket.entity';
@@ -6,12 +6,8 @@ import { Event } from '../events/entities/event.entity';
 import { VerificationLog } from './entities/verification-log.entity';
 import { VerificationStatus } from './enums/verification-status.enum';
 import { EventStatus } from '../events/enums/event-status.enum';
-import { Injectable, NotFoundException } from '@nestjs/common';
-import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
-import { VerificationLog } from './entities/verification-log.entity';
 import { VerificationQueryDto } from './dto/verification-query.dto';
-import { Event } from '../events/entities/event.entity';
+import { VerificationGateway } from './verification.gateway';
 
 @Injectable()
 export class VerificationService {
@@ -22,6 +18,7 @@ export class VerificationService {
     private eventRepository: Repository<Event>,
     @InjectRepository(VerificationLog)
     private verificationLogRepository: Repository<VerificationLog>,
+    @Optional() private readonly gateway?: VerificationGateway,
   ) {}
 
   async verifyTicket(
@@ -63,9 +60,12 @@ export class VerificationService {
       return VerificationStatus.ALREADY_USED;
     }
 
-    // Valid
     if (markAsUsed) {
       await this.ticketRepository.update(ticketId, { status: 'USED' });
+      // Emit real-time scan update via WebSocket
+      if (this.gateway) {
+        await this.gateway.emitScanUpdate(ticket.eventId);
+      }
     }
 
     await this.logVerification(ticketId, VerificationStatus.VALID, markAsUsed, verifiedBy);
@@ -94,25 +94,9 @@ export class VerificationService {
     });
   }
 
-
-//   public async getverificationByid(id: string | null): Promise<VerificationLog> {
-//     return await this.verificationLogRepository.findOne({ where: { id } });
-//   }
-}
-    @InjectRepository(VerificationLog)
-    private readonly verificationLogRepository: Repository<VerificationLog>,
-    @InjectRepository(Event)
-    private readonly eventRepository: Repository<Event>,
-  ) {}
-
   async getLogs(eventId: string, query: VerificationQueryDto) {
-    // Verify event exists
-    const event = await this.eventRepository.findOne({
-      where: { id: eventId },
-    });
-    if (!event) {
-      throw new NotFoundException(`Event with ID ${eventId} not found`);
-    }
+    const event = await this.eventRepository.findOne({ where: { id: eventId } });
+    if (!event) throw new NotFoundException(`Event with ID ${eventId} not found`);
 
     const page = Math.max(1, query.page ?? 1);
     const limit = Math.min(100, Math.max(1, query.limit ?? 20));
@@ -124,11 +108,6 @@ export class VerificationService {
       take: limit,
     });
 
-    return {
-      data: logs,
-      page,
-      limit,
-      total,
-    };
+    return { data: logs, page, limit, total };
   }
 }


### PR DESCRIPTION
Closes #614, 
Closes #615, 
Closes #616, 
Closes #617

## Changes

- `POST /admin/orders/:id/refund` — cancel tickets, release inventory, optional Stellar refund
- `GET /admin/events/:id/analytics` — sales by type, revenue, scan rate, 30-day velocity
- `GET /admin/stellar/transactions?limit` — recent Horizon txs with order cross-reference
- `VerificationGateway` — clients join `event:{id}` room, receive `scan_update` on check-in
- `WsJwtGuard` — validates `?token=` query param on WS connections
- Fixed pre-existing duplicate-identifier bugs in entity/controller files