### PR TITLE
test: add e2e tests for event lifecycle, purchase flow, verification flow, and admin flows

### DIFF
--- a/test/admin-flows.e2e-spec.ts
+++ b/test/admin-flows.e2e-spec.ts
@@ -1,0 +1,62 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Admin Flows (e2e)', () => {
+  let app: INestApplication;
+  let adminToken: string;
+  const targetUserId = 'test-user-id';
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/admin/auth/login')
+      .send({ email: 'superadmin@test.com', password: 'AdminPass123!' });
+    adminToken = loginRes.body?.access_token ?? '';
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should suspend a user', async () => {
+    const res = await request(app.getHttpServer())
+      .patch(`/admin/users/${targetUserId}/suspend`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ reason: 'Suspicious activity during e2e test' })
+      .expect(200);
+
+    expect(res.body).toHaveProperty('status', 'suspended');
+  });
+
+  it('should change a user role', async () => {
+    const res = await request(app.getHttpServer())
+      .patch(`/admin/users/${targetUserId}/role`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ role: 'organizer' })
+      .expect(200);
+
+    expect(res.body).toHaveProperty('role', 'organizer');
+  });
+
+  it('should retrieve an audit log entry for the admin actions', async () => {
+    const res = await request(app.getHttpServer())
+      .get('/admin/audit-log')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .query({ userId: targetUserId })
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body[0]).toHaveProperty('action');
+    expect(res.body[0]).toHaveProperty('performedBy');
+  });
+});

--- a/test/event-lifecycle.e2e-spec.ts
+++ b/test/event-lifecycle.e2e-spec.ts
@@ -1,0 +1,72 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Event Lifecycle (e2e)', () => {
+  let app: INestApplication;
+  let authToken: string;
+  let createdEventId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    // Obtain an auth token for subsequent requests
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'admin@test.com', password: 'Password123!' });
+    authToken = loginRes.body?.access_token ?? '';
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should create a new event', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/events')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        title: 'E2E Test Event',
+        description: 'Created during e2e lifecycle test',
+        date: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
+        location: 'Lagos',
+        ticketPrice: 5000,
+        totalTickets: 100,
+      })
+      .expect(201);
+
+    expect(res.body).toHaveProperty('id');
+    createdEventId = res.body.id;
+  });
+
+  it('should publish the created event', async () => {
+    await request(app.getHttpServer())
+      .patch(`/events/${createdEventId}/publish`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .expect(200);
+  });
+
+  it('should update the published event', async () => {
+    const res = await request(app.getHttpServer())
+      .patch(`/events/${createdEventId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ description: 'Updated description during e2e test' })
+      .expect(200);
+
+    expect(res.body.description).toBe('Updated description during e2e test');
+  });
+
+  it('should delete the event', async () => {
+    await request(app.getHttpServer())
+      .delete(`/events/${createdEventId}`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .expect(200);
+  });
+});

--- a/test/purchase-flow.e2e-spec.ts
+++ b/test/purchase-flow.e2e-spec.ts
@@ -1,0 +1,68 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Full Purchase Flow (e2e)', () => {
+  let app: INestApplication;
+  let authToken: string;
+  let orderId: string;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'user@test.com', password: 'Password123!' });
+    authToken = loginRes.body?.access_token ?? '';
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should place an order for a ticket', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/orders')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        eventId: 'test-event-id',
+        quantity: 1,
+      })
+      .expect(201);
+
+    expect(res.body).toHaveProperty('id');
+    expect(res.body).toHaveProperty('status');
+    orderId = res.body.id;
+  });
+
+  it('should simulate a successful payment for the order', async () => {
+    const res = await request(app.getHttpServer())
+      .post(`/orders/${orderId}/payment`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({
+        provider: 'paystack',
+        reference: `test-ref-${Date.now()}`,
+      })
+      .expect(200);
+
+    expect(res.body).toHaveProperty('status');
+  });
+
+  it('should confirm that tickets were issued after payment', async () => {
+    const res = await request(app.getHttpServer())
+      .get(`/orders/${orderId}/tickets`)
+      .set('Authorization', `Bearer ${authToken}`)
+      .expect(200);
+
+    expect(Array.isArray(res.body)).toBe(true);
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body[0]).toHaveProperty('ticketCode');
+  });
+});

--- a/test/verification-flow.e2e-spec.ts
+++ b/test/verification-flow.e2e-spec.ts
@@ -1,0 +1,60 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+
+describe('Full Verification Flow (e2e)', () => {
+  let app: INestApplication;
+  let authToken: string;
+  const ticketCode = 'TEST-TICKET-001';
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true }));
+    await app.init();
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({ email: 'organizer@test.com', password: 'Password123!' });
+    authToken = loginRes.body?.access_token ?? '';
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('should successfully scan a valid ticket', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/tickets/verify')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ticketCode })
+      .expect(200);
+
+    expect(res.body).toHaveProperty('valid', true);
+    expect(res.body).toHaveProperty('message');
+  });
+
+  it('should reject a double-scan of the same ticket', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/tickets/verify')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ticketCode })
+      .expect(409);
+
+    expect(res.body.message).toMatch(/already (used|scanned)/i);
+  });
+
+  it('should reject an early scan before the event window', async () => {
+    const res = await request(app.getHttpServer())
+      .post('/tickets/verify')
+      .set('Authorization', `Bearer ${authToken}`)
+      .send({ ticketCode: 'FUTURE-EVENT-TICKET-001' })
+      .expect(400);
+
+    expect(res.body.message).toMatch(/early|not yet|before/i);
+  });
+});


### PR DESCRIPTION
## Summary

- **Event Lifecycle** (`test/event-lifecycle.e2e-spec.ts`): end-to-end test covering the full event lifecycle — create, publish, update, and delete — authenticated as an organizer.
- **Full Purchase Flow** (`test/purchase-flow.e2e-spec.ts`): end-to-end test covering order placement, payment simulation via provider reference, and confirmation that tickets are issued after a successful payment.
- **Full Verification Flow** (`test/verification-flow.e2e-spec.ts`): end-to-end test covering a valid ticket scan, rejection of a double-scan on the same ticket (409), and rejection of an early scan before the event window (400).
- **Admin Flows** (`test/admin-flows.e2e-spec.ts`): end-to-end test covering admin user suspension, role change, and retrieval of the resulting audit log entries.

closes #630
closes #631
closes #632
closes #633